### PR TITLE
Refactor reducer

### DIFF
--- a/common-util/src/main/java/com/graphicsfuzz/common/util/FileHelper.java
+++ b/common-util/src/main/java/com/graphicsfuzz/common/util/FileHelper.java
@@ -16,33 +16,14 @@
 
 package com.graphicsfuzz.common.util;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
 import org.apache.commons.io.FilenameUtils;
 
 public class FileHelper {
 
-  public static File fileWithAppendedString(File file, String extra) {
-    String ext = FilenameUtils.getExtension(file.toString());
-    String basename = FilenameUtils.removeExtension(file.toString());
-    return new File(basename + extra + "." + ext);
-  }
-
-  public static String firstLine(File file) throws IOException {
-    try (BufferedReader r = new BufferedReader(new FileReader(file));) {
-      return r.readLine();
-    }
-  }
-
   public static File replaceExtension(File file, String ext) {
     return new File(FilenameUtils.removeExtension(file.toString()) + ext);
-  }
-
-  public static File replaceDir(File file, File dir) {
-    return new File(dir, file.getName());
   }
 
   public static void checkExists(File file) throws FileNotFoundException {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/IReductionState.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/IReductionState.java
@@ -23,8 +23,6 @@ import java.io.FileNotFoundException;
 
 public interface IReductionState {
 
-  UniformsInfo computeRemainingUniforms(File uniformsJson) throws FileNotFoundException;
-
   boolean hasFragmentShader();
 
   boolean hasVertexShader();
@@ -32,5 +30,7 @@ public interface IReductionState {
   TranslationUnit getFragmentShader();
 
   TranslationUnit getVertexShader();
+
+  UniformsInfo getUniformsInfo();
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/IReductionStateFileWriter.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/IReductionStateFileWriter.java
@@ -20,7 +20,7 @@ import java.io.FileNotFoundException;
 
 public interface IReductionStateFileWriter {
 
-  void writeFileFromState(IReductionState state, String outputFilesPrefix)
+  void writeFilesFromState(IReductionState state, String outputFilesPrefix)
       throws FileNotFoundException;
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/filejudge/ImageShaderFileJudge.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/filejudge/ImageShaderFileJudge.java
@@ -27,6 +27,7 @@ import com.graphicsfuzz.shadersets.ShaderDispatchException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
@@ -36,26 +37,26 @@ public class ImageShaderFileJudge implements IFileJudge {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ImageShaderFileJudge.class);
 
-  private File referenceShaderFile;
-  private File referenceShaderImage;
+  private static final String REFERENCE_IMAGE_NAME = "reference_image.png";
+
   private File workDir;
   private IImageFileComparator fileComparator;
   private IShaderDispatcher imageGenerator;
   private final boolean throwExceptionOnValidationError;
 
   public ImageShaderFileJudge(
-        File referenceShaderFile,
-        File referenceShaderImage,
         File workDir,
         IImageFileComparator fileComparator,
         IShaderDispatcher imageGenerator,
         boolean throwExceptionOnValidationError) {
-    this.referenceShaderFile = referenceShaderFile;
-    this.referenceShaderImage = referenceShaderImage;
     this.workDir = workDir;
     this.fileComparator = fileComparator;
     this.imageGenerator = imageGenerator;
     this.throwExceptionOnValidationError = throwExceptionOnValidationError;
+  }
+
+  public static File getReferenceImageInWorkDir(File workDir) {
+    return Paths.get(workDir.toString(), REFERENCE_IMAGE_NAME).toFile();
   }
 
   @Override
@@ -88,7 +89,7 @@ public class ImageShaderFileJudge implements IFileJudge {
                 outputText,
                 JobStatus.SAME_AS_REFERENCE.toString() + "\n",
                 StandardCharsets.UTF_8);
-          outputImage = referenceShaderImage;
+          outputImage = getReferenceImageInWorkDir(workDir);
           break;
         default:
           LOGGER.info("Failed to run get_image on shader. Not interesting.");
@@ -100,7 +101,7 @@ public class ImageShaderFileJudge implements IFileJudge {
       // Success or same as ref:
 
       // 3.
-      if (!fileComparator.areFilesInteresting(referenceShaderImage, outputImage)) {
+      if (!fileComparator.areFilesInteresting(getReferenceImageInWorkDir(workDir), outputImage)) {
         LOGGER.info("Shader image was not deemed interesting by file comparator. Not interesting.");
         return false;
       }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/GlslReductionState.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/GlslReductionState.java
@@ -31,22 +31,16 @@ import java.util.stream.Collectors;
 
 public class GlslReductionState implements IReductionState {
 
-  private final Optional<TranslationUnit> fragmentShader;
   private final Optional<TranslationUnit> vertexShader;
+  private final Optional<TranslationUnit> fragmentShader;
+  private final UniformsInfo uniformsInfo;
 
-  public GlslReductionState(Optional<TranslationUnit> fragmentShader,
-      Optional<TranslationUnit> vertexShader) {
-    this.fragmentShader = fragmentShader;
+  public GlslReductionState(Optional<TranslationUnit> vertexShader,
+                            Optional<TranslationUnit> fragmentShader,
+                            UniformsInfo uniformsInfo) {
     this.vertexShader = vertexShader;
-  }
-
-  public GlslReductionState(Optional<TranslationUnit> fragmentShader) {
-    this(fragmentShader, Optional.empty());
-  }
-
-  @Override
-  public boolean hasFragmentShader() {
-    return fragmentShader.isPresent();
+    this.fragmentShader = fragmentShader;
+    this.uniformsInfo = uniformsInfo;
   }
 
   @Override
@@ -55,9 +49,8 @@ public class GlslReductionState implements IReductionState {
   }
 
   @Override
-  public TranslationUnit getFragmentShader() {
-    assert hasFragmentShader();
-    return fragmentShader.get();
+  public boolean hasFragmentShader() {
+    return fragmentShader.isPresent();
   }
 
   @Override
@@ -67,21 +60,14 @@ public class GlslReductionState implements IReductionState {
   }
 
   @Override
-  public UniformsInfo computeRemainingUniforms(File uniformsJson) throws FileNotFoundException {
-    assert fragmentShader.isPresent();
-    final UniformsInfo result = new UniformsInfo(
-          new File(uniformsJson.getAbsolutePath()));
+  public TranslationUnit getFragmentShader() {
+    assert hasFragmentShader();
+    return fragmentShader.get();
+  }
 
-    Set<String> remainingUniforms = new HashSet<>();
-    remainingUniforms.addAll(getUniforms(fragmentShader));
-    remainingUniforms.addAll(getUniforms(vertexShader));
-
-    for (String name : result.getUniformNames().stream()
-        .filter(item -> !remainingUniforms.contains(item)).collect(
-        Collectors.toList())) {
-      result.removeUniform(name);
-    }
-    return result;
+  @Override
+  public UniformsInfo getUniformsInfo() {
+    return uniformsInfo;
   }
 
   private Set<String> getUniforms(Optional<TranslationUnit> maybeTu) {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/GlslReductionStateFileWriter.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/GlslReductionStateFileWriter.java
@@ -24,6 +24,7 @@ import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.reducer.IReductionState;
 import com.graphicsfuzz.reducer.IReductionStateFileWriter;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
 
 public class GlslReductionStateFileWriter implements IReductionStateFileWriter {
@@ -35,14 +36,16 @@ public class GlslReductionStateFileWriter implements IReductionStateFileWriter {
   }
 
   @Override
-  public void writeFileFromState(IReductionState state, String outputFilesPrefix)
+  public void writeFilesFromState(IReductionState state, String outputFilesPrefix)
         throws FileNotFoundException {
-    if (state.hasFragmentShader()) {
-      writeFile(state.getFragmentShader(), ShaderKind.FRAGMENT, outputFilesPrefix);
-    }
     if (state.hasVertexShader()) {
       writeFile(state.getVertexShader(), ShaderKind.VERTEX, outputFilesPrefix);
     }
+    if (state.hasFragmentShader()) {
+      writeFile(state.getFragmentShader(), ShaderKind.FRAGMENT, outputFilesPrefix);
+    }
+    Helper.emitUniformsInfo(state.getUniformsInfo(),
+        new PrintStream(new FileOutputStream(outputFilesPrefix + ".json")));
   }
 
   private void writeFile(TranslationUnit shader, ShaderKind shaderKind, String outputFilesPrefix)

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/SimplePlan.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/SimplePlan.java
@@ -251,7 +251,7 @@ public class SimplePlan implements IReductionPlan {
       default:
         throw new RuntimeException("Unsupported shader kind: " + shaderKind);
     }
-    return new GlslReductionState(fragmentShader, vertexShader);
+    return new GlslReductionState(vertexShader, fragmentShader, originalState.getUniformsInfo());
   }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunities.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
@@ -67,7 +68,12 @@ public class LiveOutputVariableWriteReductionOpportunities
 
   private static boolean isOutVariableBackup(DeclarationStmt declarationStmt) {
     return declarationStmt.getVariablesDeclaration().getDeclInfos()
-          .stream().anyMatch(vdi -> vdi.getName().startsWith(Constants.GLF_OUT_VAR_BACKUP_PREFIX));
+        .stream().map(VariableDeclInfo::getName)
+        .anyMatch(LiveOutputVariableWriteReductionOpportunities::isOutVariableBackup);
+  }
+
+  private static boolean isOutVariableBackup(String name) {
+    return name.startsWith(Constants.GLF_OUT_VAR_BACKUP_PREFIX);
   }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/ReducerBugPoint.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/ReducerBugPoint.java
@@ -22,6 +22,7 @@ import com.graphicsfuzz.common.util.Helper;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.UniformsInfo;
 import com.graphicsfuzz.reducer.IReductionStateFileWriter;
 import com.graphicsfuzz.reducer.ReductionDriver;
 import com.graphicsfuzz.reducer.glslreducers.GlslReductionState;
@@ -147,7 +148,9 @@ public class ReducerBugPoint {
       System.err.println("Trying iteration " + i);
 
       GlslReductionState initialState = new GlslReductionState(
-            Optional.of(interestingTranslationUnit));
+          Optional.empty(),
+          Optional.of(interestingTranslationUnit),
+          new UniformsInfo(interestingJson));
       IReductionStateFileWriter fileWriter = new GlslReductionStateFileWriter(
           shadingLanguageVersion);
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
@@ -76,7 +76,8 @@ public class ReductionDriverTest {
 
     TranslationUnit tu = ParseHelper.parse(tempFile, false);
 
-    GlslReductionState state = new GlslReductionState(Optional.of(tu));
+    GlslReductionState state = new GlslReductionState(Optional.empty(), Optional.of(tu),
+        new UniformsInfo(tempJsonFile));
 
     IFileJudge pessimist = new IFileJudge() {
 
@@ -102,42 +103,6 @@ public class ReductionDriverTest {
         new ReductionOpportunityContext(false, version, generator, null),
         false, state).doReduction(getPrefix(tempFile), 0, new GlslReductionStateFileWriter(version),
         pessimist, testFolder.getRoot(), -1);
-
-  }
-
-  @Test
-  public void checkUniformIsRemoved() throws Exception {
-
-    File tempFile = testFolder.newFile("temp.frag");
-    File tempJsonFile = testFolder.newFile("temp.json");
-
-    String program = "uniform vec3 unused; void main() { }";
-
-    BufferedWriter bw = new BufferedWriter(new FileWriter(tempFile));
-    bw.write(program);
-    bw.close();
-
-    BufferedWriter bwJson = new BufferedWriter(new FileWriter(tempJsonFile));
-    bwJson.write("{ \"unused\": { \"func\": \"glUniform3f\", \"args\": [ 1.0, 1.0, 1.0 ] } }");
-    bwJson.close();
-
-    ShadingLanguageVersion version = ShadingLanguageVersion.ESSL_100;
-    IRandom generator = new RandomWrapper(0);
-
-    TranslationUnit tu = ParseHelper.parse(tempFile, false);
-
-    GlslReductionState state = new GlslReductionState(Optional.of(tu));
-
-    IFileJudge optimist = (item -> true);
-
-    String finalFilePrefix = new ReductionDriver(new ReductionOpportunityContext(false, version, generator, null), false, state)
-        .doReduction(getPrefix(tempFile), 0, new GlslReductionStateFileWriter(version),
-        optimist, testFolder.getRoot(), -1);
-
-    UniformsInfo uniformsInfo = new UniformsInfo(
-        new File(finalFilePrefix + ".json"));
-
-    assertTrue(uniformsInfo.getUniformNames().isEmpty());
 
   }
 
@@ -241,7 +206,8 @@ public class ReductionDriverTest {
         ? Optional.of(Helper.parse(tempVertexShaderFile.get(), stripHeader))
         : Optional.empty();
 
-    GlslReductionState state = new GlslReductionState(Optional.of(tuFrag), tuVert);
+    GlslReductionState state = new GlslReductionState(tuVert,
+        Optional.of(tuFrag), new UniformsInfo(tempJsonFile));
 
     return new ReductionDriver(new ReductionOpportunityContext(reduceEverywhere, version, generator, new IdGenerator()), false, state)
         .doReduction(getPrefix(tempFragmentShaderFile), 0, new GlslReductionStateFileWriter(version),
@@ -272,7 +238,8 @@ public class ReductionDriverTest {
 
     final TranslationUnit tu = ParseHelper.parse(tempFile, false);
 
-    GlslReductionState state = new GlslReductionState(Optional.of(tu));
+    GlslReductionState state = new GlslReductionState(
+        Optional.empty(), Optional.of(tu), new UniformsInfo(tempJsonFile));
 
     IFileJudge referencesSinCosAnd3 = filesPrefix -> {
         try {

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunitiesTest.java
@@ -54,6 +54,16 @@ public class UnwrapReductionOpportunitiesTest {
   }
 
   @Test
+  public void testNestedEmptyBlocks() throws Exception {
+    final String program = "void main() { { { } } }";
+    final TranslationUnit tu = Helper.parse(program, false);
+    List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities.findOpportunities(tu,
+        new ReductionOpportunityContext(false,
+            ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0), null));
+    assertEquals(1, ops.size());
+  }
+
+  @Test
   public void misc() throws Exception {
     final String shader = "void main()\n"
           + "{\n"

--- a/server/src/main/java/com/graphicsfuzz/server/webui/ReductionFilesHelper.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/ReductionFilesHelper.java
@@ -16,7 +16,7 @@
 
 package com.graphicsfuzz.server.webui;
 
-import com.graphicsfuzz.common.util.ReductionStepHelper;
+import com.graphicsfuzz.common.util.ReductionProgressHelper;
 import java.io.File;
 import java.util.Optional;
 
@@ -30,7 +30,7 @@ public class ReductionFilesHelper {
   static Optional<File> getLatestReductionImage(String token, String shaderset, String shader) {
     final File reductionDir = getReductionDir(token, shaderset, shader);
     final Optional<Integer> latestSuccessfulReductionStep =
-          ReductionStepHelper.getLatestReductionStepSuccess(reductionDir, "variant");
+          ReductionProgressHelper.getLatestReductionStepSuccess(reductionDir, "variant");
     if (!latestSuccessfulReductionStep.isPresent()) {
       return Optional.empty();
     }
@@ -45,10 +45,6 @@ public class ReductionFilesHelper {
       return Optional.empty();
     }
     return Optional.of(latestImage);
-  }
-
-  static File getReductionExceptionFile(String shader, File reductionDir) {
-    return new File(reductionDir, shader + "_exception.txt");
   }
 
 }

--- a/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.graphicsfuzz.alphanumcomparator.AlphanumComparator;
 import com.graphicsfuzz.common.transformreduce.Constants;
-import com.graphicsfuzz.common.util.ReductionStepHelper;
+import com.graphicsfuzz.common.util.ReductionProgressHelper;
 import com.graphicsfuzz.reducer.ReductionKind;
 import com.graphicsfuzz.server.thrift.CommandInfo;
 import com.graphicsfuzz.server.thrift.CommandResult;
@@ -937,13 +937,13 @@ public class WebUi extends HttpServlet {
       case EXCEPTION:
         htmlAppendLn("<p>Reduction failed with an exception:</p>",
             "<textarea readonly rows='25' cols='80'>\n",
-            getFileContents(ReductionFilesHelper.getReductionExceptionFile(shader,
+            getFileContents(ReductionProgressHelper.getReductionExceptionFile(shader,
                 ReductionFilesHelper.getReductionDir(token, shaderset, shader))),
             "</textarea>");
         break;
 
       case ONGOING:
-        final Optional<Integer> reductionStep = ReductionStepHelper
+        final Optional<Integer> reductionStep = ReductionProgressHelper
               .getLatestReductionStepAny(ReductionFilesHelper
                     .getReductionDir(token, shaderset, shader), "variant");
         htmlAppendLn("<p>Reduction not finished for this result: ",
@@ -1043,7 +1043,7 @@ public class WebUi extends HttpServlet {
       return ReductionStatus.NOTINTERESTING;
     }
 
-    if (ReductionFilesHelper.getReductionExceptionFile(shader, reductionDir).exists()) {
+    if (ReductionProgressHelper.getReductionExceptionFile(shader, reductionDir).exists()) {
       return ReductionStatus.EXCEPTION;
     }
 

--- a/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
@@ -190,7 +190,10 @@ public class ReducerUnitTest {
     for (int i = 0; i < numIterations; i++) {
 
       GlslReductionState initialState = new GlslReductionState(
-            Optional.of(tu));
+          Optional.empty(),
+          Optional.of(tu),
+          new UniformsInfo(
+              new File(Helper.jsonFilenameForShader(shaderFile.getAbsolutePath()))));
       IReductionStateFileWriter fileWriter = new GlslReductionStateFileWriter(
           shadingLanguageVersion);
 
@@ -348,7 +351,10 @@ public class ReducerUnitTest {
     final ShadingLanguageVersion version = ShadingLanguageVersion.getGlslVersionFromShader(shaderFile);
     final IRandom generator = new RandomWrapper(0);
     final TranslationUnit tu = Helper.parse(shaderFile, true);
-    final GlslReductionState state = new GlslReductionState(Optional.of(tu));
+    final GlslReductionState state = new GlslReductionState(
+        Optional.empty(),
+        Optional.of(tu),
+        new UniformsInfo(new File(Helper.jsonFilenameForShader(shaderFile.getAbsolutePath()))));
     return new ReductionDriver(new ReductionOpportunityContext(false, version, generator, new IdGenerator()), false, state)
         .doReduction(FilenameUtils.removeExtension(shaderFile.getAbsolutePath()), 0,
           new GlslReductionStateFileWriter(version),
@@ -394,7 +400,7 @@ public class ReducerUnitTest {
     int numSteps = 20;
 
     Reduce.main(new String[] {
-          reference.getAbsolutePath(),
+          FilenameUtils.removeExtension(reference.getAbsolutePath()),
           "--swiftshader",
           "IDENTICAL",
           "--reduce_everywhere",
@@ -411,7 +417,7 @@ public class ReducerUnitTest {
     while (new File(output, Constants.REDUCTION_INCOMPLETE).exists()) {
       numSteps += 5;
       Reduce.main(new String[] {
-            reference.getAbsolutePath(),
+            FilenameUtils.removeExtension(reference.getAbsolutePath()),
             "--swiftshader",
             "IDENTICAL",
             "--reduce_everywhere",
@@ -479,7 +485,7 @@ public class ReducerUnitTest {
     assertEquals(0, referenceResult.res);
     final File output = temporaryFolder.newFolder();
     Reduce.main(new String[] {
-          reference.getAbsolutePath(),
+          FilenameUtils.removeExtension(reference.getAbsolutePath()),
           "--swiftshader",
           "IDENTICAL",
           "--reduce_everywhere",


### PR DESCRIPTION
The tool chain has traditionally been very fragment shader centric, as we used to deal exclusively with fragment shaders.  This refactoring makes the reducer less fragment shader centric by (a) having a reduction work on a *prefix* of the name of the shader or shaders being reduced (i.e., "foo" rather than "foo.frag"), and (b) having GlslReductionState encapsulate either/both of a vertex and fragment shader as well as uniforms info.

There is more to be done but this is a good first chunk to merge.