### PR TITLE
Impose usage of Android serial number

### DIFF
--- a/python/src/main/python/drivers/worker_vk.py
+++ b/python/src/main/python/drivers/worker_vk.py
@@ -370,7 +370,11 @@ print('server: ' + server)
 
 # Set device ID
 if args.adbID:
-    os.environ["ANDROID_SERIAL"] = args.adbID
+    os.environ['ANDROID_SERIAL'] = args.adbID
+else:
+    if 'ANDROID_SERIAL' not in os.environ:
+        print('Please set ANDROID_SERIAL env variable, or use --adbID')
+        exit(1)
 
 # Prepare device
 adb('shell mkdir -p /sdcard/graphicsfuzz/')


### PR DESCRIPTION
When several devices are plugged in the same server, we can easily forget to set ANDROID_SERIAL, which results in a list of irrelevant crashes.