### PR TITLE
Fixes #45.

### DIFF
--- a/assembly-public/pom.xml
+++ b/assembly-public/pom.xml
@@ -68,7 +68,7 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>jquery-js</artifactId>
       <type>zip</type>
       <scope>provided</scope>
@@ -155,7 +155,7 @@ limitations under the License.
                     <pathelement location="${com.graphicsfuzz:assembly-binaries:zip}"/>
                     <pathelement location="${com.graphicsfuzz:thrift:zip:python}"/>
                     <pathelement location="${com.graphicsfuzz:server-static-public:zip}"/>
-                    <pathelement location="${com.graphicsfuzz:jquery-js:zip}"/>
+                    <pathelement location="${com.graphicsfuzz.thirdparty:jquery-js:zip}"/>
                     <pathelement location="${com.graphicsfuzz:thrift:zip:js}"/>
                     <pathelement location="${git-file}"/>
                     <fileset dir="${project.basedir}/src/main/scripts"/>
@@ -168,7 +168,7 @@ limitations under the License.
                       <zipfileset src="${com.graphicsfuzz:assembly-binaries:zip}"/>
                       <zipfileset src="${com.graphicsfuzz:thrift:zip:python}" prefix="python/fuzzer_service"/>
                       <zipfileset src="${com.graphicsfuzz:server-static-public:zip}"/>
-                      <zipfileset src="${com.graphicsfuzz:jquery-js:zip}" prefix="server-static/jquery"/>
+                      <zipfileset src="${com.graphicsfuzz.thirdparty:jquery-js:zip}" prefix="server-static/jquery"/>
                       <zipfileset src="${com.graphicsfuzz:thrift:zip:js}" prefix="server-static/gen-js"/>
                       <zipfileset dir="${project.basedir}/src/main/scripts"/>
                       <zipfileset dir="${project.build.directory}/dependency" prefix="jar"/>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -50,14 +50,14 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>thrift-py</artifactId>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>thrift-js</artifactId>
       <type>zip</type>
       <scope>provided</scope>
@@ -107,14 +107,14 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>semantic-ui</artifactId>
       <type>zip</type>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>jquery-js</artifactId>
       <type>zip</type>
       <scope>provided</scope>
@@ -222,14 +222,14 @@ limitations under the License.
                   <sourcefiles>
                     <pathelement location="${com.graphicsfuzz:assembly-binaries:zip}"/>
                     <pathelement location="${com.graphicsfuzz:python:zip}"/>
-                    <pathelement location="${com.graphicsfuzz:thrift-py:zip}"/>
-                    <pathelement location="${com.graphicsfuzz:thrift-js:zip}"/>
-                    <pathelement location="${com.graphicsfuzz:jquery-js:zip}"/>
+                    <pathelement location="${com.graphicsfuzz.thirdparty:thrift-py:zip}"/>
+                    <pathelement location="${com.graphicsfuzz.thirdparty:thrift-js:zip}"/>
+                    <pathelement location="${com.graphicsfuzz.thirdparty:jquery-js:zip}"/>
                     <pathelement location="${com.graphicsfuzz:server-static-public:zip}"/>
                     <pathelement location="${com.graphicsfuzz:thrift:zip:python}"/>
                     <pathelement location="${com.graphicsfuzz:thrift:zip:js}"/>
                     <pathelement location="${com.graphicsfuzz:tester:zip:shaders}"/>
-                    <pathelement location="${com.graphicsfuzz:semantic-ui:zip}"/>
+                    <pathelement location="${com.graphicsfuzz.thirdparty:semantic-ui:zip}"/>
                     <pathelement location="${git-file}"/>
                     <fileset dir="${project.basedir}/src/main/scripts"/>
                     <fileset dir="${project.build.directory}/dependency"/>
@@ -241,14 +241,14 @@ limitations under the License.
                     <zip destfile="${assembly-zip}" compress="false">
                       <zipfileset src="${com.graphicsfuzz:assembly-binaries:zip}"/>
                       <zipfileset src="${com.graphicsfuzz:python:zip}" prefix="python"/>
-                      <zipfileset src="${com.graphicsfuzz:thrift-py:zip}" prefix="python/thrift"/>
-                      <zipfileset src="${com.graphicsfuzz:thrift-js:zip}" prefix="server-static/thrift"/>
-                      <zipfileset src="${com.graphicsfuzz:jquery-js:zip}" prefix="server-static/jquery"/>
+                      <zipfileset src="${com.graphicsfuzz.thirdparty:thrift-py:zip}" prefix="python/thrift"/>
+                      <zipfileset src="${com.graphicsfuzz.thirdparty:thrift-js:zip}" prefix="server-static/thrift"/>
+                      <zipfileset src="${com.graphicsfuzz.thirdparty:jquery-js:zip}" prefix="server-static/jquery"/>
                       <zipfileset src="${com.graphicsfuzz:server-static-public:zip}"/>
                       <zipfileset src="${com.graphicsfuzz:thrift:zip:python}" prefix="python/fuzzer_service"/>
                       <zipfileset src="${com.graphicsfuzz:thrift:zip:js}" prefix="server-static/gen-js"/>
                       <zipfileset src="${com.graphicsfuzz:tester:zip:shaders}" prefix="test-shaders"/>
-                      <zipfileset src="${com.graphicsfuzz:semantic-ui:zip}" prefix="server-static/semantic"/>
+                      <zipfileset src="${com.graphicsfuzz.thirdparty:semantic-ui:zip}" prefix="server-static/semantic"/>
                       <zipfileset dir="${project.basedir}/src/main/scripts"/>
                       <zipfileset dir="${project.build.directory}/dependency" prefix="jar"/>
                       <zipfileset dir="${project.build.directory}/sources" prefix="sources"/>

--- a/build/travis/licenses.py
+++ b/build/travis/licenses.py
@@ -393,7 +393,7 @@ def get_maven_dependencies_populated():
             'license_file': '',
             'skipped': '',
         },
-        'com.graphicsfuzz:alphanum-comparator': {
+        'com.graphicsfuzz.thirdparty:alphanum-comparator': {
             'comment': '',
             'name': 'The Alphanum Algorithm',
             'url': 'http://www.davekoelle.com/alphanum.html',
@@ -449,7 +449,7 @@ def get_maven_dependencies_populated():
             'license_file': '',
             'skipped': 'internal project',
         },
-        'com.graphicsfuzz:gif-sequence-writer': {
+        'com.graphicsfuzz.thirdparty:gif-sequence-writer': {
             'comment': '',
             'name': 'Animated GIF Writer',
             'url': 'http://elliot.kroo.net/software/java/GifSequenceWriter/',
@@ -457,7 +457,7 @@ def get_maven_dependencies_populated():
             'license_file': 'third_party/gif-sequence-writer/LICENSE',
             'skipped': '',
         },
-        'com.graphicsfuzz:jquery-js': {
+        'com.graphicsfuzz.thirdparty:jquery-js': {
             'comment': '',
             'name': 'jQuery',
             'url': 'https://jquery.org/',
@@ -484,7 +484,7 @@ def get_maven_dependencies_populated():
             'license_file': '',
             'skipped': 'internal project',
         },
-        'com.graphicsfuzz:semantic-ui': {
+        'com.graphicsfuzz.thirdparty:semantic-ui': {
             'comment': '',
             'name': 'Semantic UI',
             'url': 'https://github.com/semantic-org/semantic-ui/',
@@ -532,7 +532,7 @@ def get_maven_dependencies_populated():
             'license_file': '',
             'skipped': 'internal project',
         },
-        'com.graphicsfuzz:thrift-js': {
+        'com.graphicsfuzz.thirdparty:thrift-js': {
             'comment': '',
             'name': 'Apache Thrift',
             'url': 'https://thrift.apache.org/',
@@ -540,7 +540,7 @@ def get_maven_dependencies_populated():
             'license_file': ['third_party/thrift-js/NOTICE', 'third_party/thrift-js/LICENSE'],
             'skipped': '',
         },
-        'com.graphicsfuzz:thrift-py': {
+        'com.graphicsfuzz.thirdparty:thrift-py': {
             'comment': '',
             'name': '',
             'url': '',
@@ -805,6 +805,10 @@ def read_maven_dependencies(
             line = line.strip()
             line = line.split(":")
             dependency = line[0] + ":" + line[1]
+            # Ignore com.graphicsfuzz: internal projects
+            # Note that third party internal projects start with com.graphicsfuzz.thirdparty:
+            if dependency.startswith("com.graphicsfuzz:"):
+                continue
             if dependency not in dependencies_dict:
                 dependencies_dict[dependency] = dict()
 
@@ -832,13 +836,13 @@ def go():
     dependencies_populated = get_maven_dependencies_populated()
     dependencies_populated.update(get_extras())
 
-    # Check for new maven dependencies for which we have not provided license information.
+    # Find maven dependencies for which we have not provided license information.
     for dep in maven_dependencies:
         if dep not in dependencies_populated:
-            print("Missing dependency " + dep)
+            print("Missing dependency license information " + dep)
             sys.exit(1)
 
-    # Write a THIRD_PARTY file.
+    # Write an OPEN_SOURCE_LICENSES.TXT file.
     with io.open("OPEN_SOURCE_LICENSES.TXT", "w", newline='\r\n') as fout:
 
         fout.write("\n")

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>alphanum-comparator</artifactId>
     </dependency>
     <dependency>
@@ -79,7 +79,7 @@ limitations under the License.
       <artifactId>server-thrift-gen</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>gif-sequence-writer</artifactId>
     </dependency>
 

--- a/parent-all/pom.xml
+++ b/parent-all/pom.xml
@@ -230,12 +230,12 @@ limitations under the License.
 
       <!-- third party open source projects -->
       <dependency>
-        <groupId>com.graphicsfuzz</groupId>
+        <groupId>com.graphicsfuzz.thirdparty</groupId>
         <artifactId>alphanum-comparator</artifactId>
         <version>1.0</version>
       </dependency>
       <dependency>
-        <groupId>com.graphicsfuzz</groupId>
+        <groupId>com.graphicsfuzz.thirdparty</groupId>
         <artifactId>gif-sequence-writer</artifactId>
         <version>1.0</version>
       </dependency>
@@ -436,28 +436,28 @@ limitations under the License.
       </dependency>
 
       <dependency>
-        <groupId>com.graphicsfuzz</groupId>
+        <groupId>com.graphicsfuzz.thirdparty</groupId>
         <artifactId>semantic-ui</artifactId>
         <version>2.0.7</version>
         <type>zip</type>
       </dependency>
 
       <dependency>
-        <groupId>com.graphicsfuzz</groupId>
+        <groupId>com.graphicsfuzz.thirdparty</groupId>
         <artifactId>thrift-py</artifactId>
         <version>1.0</version>
         <type>zip</type>
       </dependency>
 
       <dependency>
-        <groupId>com.graphicsfuzz</groupId>
+        <groupId>com.graphicsfuzz.thirdparty</groupId>
         <artifactId>thrift-js</artifactId>
         <version>1.0</version>
         <type>zip</type>
       </dependency>
 
       <dependency>
-        <groupId>com.graphicsfuzz</groupId>
+        <groupId>com.graphicsfuzz.thirdparty</groupId>
         <artifactId>jquery-js</artifactId>
         <version>1.0</version>
         <type>zip</type>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -127,7 +127,7 @@ limitations under the License.
       <artifactId>common</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.graphicsfuzz</groupId>
+      <groupId>com.graphicsfuzz.thirdparty</groupId>
       <artifactId>alphanum-comparator</artifactId>
     </dependency>
     <dependency>

--- a/third_party/alphanum-comparator/pom.xml
+++ b/third_party/alphanum-comparator/pom.xml
@@ -1,6 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.graphicsfuzz.thirdparty</groupId>
   <artifactId>alphanum-comparator</artifactId>
   <name>alphanum-comparator</name>
   <packaging>jar</packaging>

--- a/third_party/gif-sequence-writer/pom.xml
+++ b/third_party/gif-sequence-writer/pom.xml
@@ -1,6 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.graphicsfuzz.thirdparty</groupId>
   <artifactId>gif-sequence-writer</artifactId>
   <name>gif-sequence-writer</name>
   <packaging>jar</packaging>

--- a/third_party/jquery-js/pom.xml
+++ b/third_party/jquery-js/pom.xml
@@ -2,6 +2,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.graphicsfuzz.thirdparty</groupId>
   <artifactId>jquery-js</artifactId>
   <name>jquery-js</name>
   <packaging>pom</packaging>

--- a/third_party/semantic-ui/pom.xml
+++ b/third_party/semantic-ui/pom.xml
@@ -2,6 +2,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.graphicsfuzz.thirdparty</groupId>
   <artifactId>semantic-ui</artifactId>
   <name>semantic-ui</name>
   <packaging>pom</packaging>

--- a/third_party/thrift-js/pom.xml
+++ b/third_party/thrift-js/pom.xml
@@ -2,6 +2,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.graphicsfuzz.thirdparty</groupId>
   <artifactId>thrift-js</artifactId>
   <name>thrift-js</name>
   <packaging>pom</packaging>

--- a/third_party/thrift-py/pom.xml
+++ b/third_party/thrift-py/pom.xml
@@ -2,6 +2,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <groupId>com.graphicsfuzz.thirdparty</groupId>
   <artifactId>thrift-py</artifactId>
   <name>thrift-py</name>
   <packaging>pom</packaging>


### PR DESCRIPTION
Third party internal maven projects now use group com.graphicsfuzz.thirdparty. The group com.graphicsfuzz is now ignored by the licenses.py script so we don't need to provide license information for our own maven projects.