### PR TITLE
Improve logging macros

### DIFF
--- a/vulkan-worker/src/common/vkcheck.cc
+++ b/vulkan-worker/src/common/vkcheck.cc
@@ -17,8 +17,8 @@
 #include <assert.h>
 #include <string.h>
 
-const char *getVkResultString (VkResult res) {
-  switch (res) {
+const char *getVkResultString (VkResult result) {
+  switch (result) {
     case VK_SUCCESS: return "VK_SUCCESS";
     case VK_NOT_READY: return "VK_NOT_READY";
     case VK_TIMEOUT: return "VK_TIMEOUT";
@@ -66,15 +66,16 @@ static inline const char *stripFilePath(const char *file) {
 
 void __VK_CHECK_LOG_CALL(const char *file, int line, const char *expr) {
   file = stripFilePath(file);
-  log("%s:%d CALL %s", file, line, expr);
+  log("%s:%d CALL   %s", file, line, expr);
 }
 
-void __VK_CHECK_LOG_RETURN(const char *file, int line, const char *expr, VkResult result) {
+void __VK_CHECK_LOG_RETURN(const char *file, int line, VkResult result) {
   file = stripFilePath(file);
-  log("%s:%d RETURN %s: %s", file, line, expr, getVkResultString(result));
+  log("%s:%d RETURN %s", file, line, getVkResultString(result));
+  assert(result == VK_SUCCESS);
 }
 
-void __VK_CHECK_LOG_VOID_RETURN(const char *file, int line, const char *expr) {
+void __VK_CHECK_LOG_VOID_RETURN(const char *file, int line) {
   file = stripFilePath(file);
-  log("%s:%d RETURN %s: void", file, line, expr);
+  log("%s:%d RETURN void", file, line);
 }

--- a/vulkan-worker/src/common/vkcheck.cc
+++ b/vulkan-worker/src/common/vkcheck.cc
@@ -54,18 +54,27 @@ const char *getVkResultString (VkResult res) {
   }
 }
 
-void __VK_CHECK(bool do_check, VkResult res, const char *expr, const char *file, int line) {
-
-  // Strip the file full path to only the file name
+// Strip the file full path to only the file name
+static inline const char *stripFilePath(const char *file) {
   const char *p = strrchr(file, '/');
-  if (p != NULL) {
-    file = p + 1;
+  if (p != nullptr) {
+    p++;
+    return p;
   }
+  return file;
+}
 
-  if (do_check) {
-    log("%s:%d %s: %s", file, line, expr, getVkResultString(res));
-    assert(res == VK_SUCCESS);
-  } else {
-    log("%s:%d %s", file, line, expr);
-  }
+void __VK_CHECK_LOG_CALL(const char *file, int line, const char *expr) {
+  file = stripFilePath(file);
+  log("%s:%d CALL %s", file, line, expr);
+}
+
+void __VK_CHECK_LOG_RETURN(const char *file, int line, const char *expr, VkResult result) {
+  file = stripFilePath(file);
+  log("%s:%d RETURN %s: %s", file, line, expr, getVkResultString(result));
+}
+
+void __VK_CHECK_LOG_VOID_RETURN(const char *file, int line, const char *expr) {
+  file = stripFilePath(file);
+  log("%s:%d RETURN %s: void", file, line, expr);
 }

--- a/vulkan-worker/src/common/vkcheck.h
+++ b/vulkan-worker/src/common/vkcheck.h
@@ -17,19 +17,21 @@
 
 #include <vulkan/vulkan.h>
 
+const char *getVkResultString (VkResult result);
+
 void __VK_CHECK_LOG_CALL(const char *file, int line, const char *expr);
-void __VK_CHECK_LOG_RETURN(const char *file, int line, const char *expr, VkResult result);
-void __VK_CHECK_LOG_VOID_RETURN(const char *file, int line, const char *expr);
+void __VK_CHECK_LOG_RETURN(const char *file, int line, VkResult result);
+void __VK_CHECK_LOG_VOID_RETURN(const char *file, int line);
 
 #define VKCHECK(expr) do { \
   __VK_CHECK_LOG_CALL(__FILE__, __LINE__, #expr); \
-  __VK_CHECK_LOG_RETURN(__FILE__, __LINE__, #expr, (expr)); \
+  __VK_CHECK_LOG_RETURN(__FILE__, __LINE__, (expr));  \
   } while (false)
 
 #define VKLOG(expr) do { \
   __VK_CHECK_LOG_CALL(__FILE__, __LINE__, #expr); \
   (expr); \
-  __VK_CHECK_LOG_VOID_RETURN(__FILE__, __LINE__, #expr); \
+  __VK_CHECK_LOG_VOID_RETURN(__FILE__, __LINE__); \
   } while (false)
 
 #endif

--- a/vulkan-worker/src/common/vkcheck.h
+++ b/vulkan-worker/src/common/vkcheck.h
@@ -17,10 +17,19 @@
 
 #include <vulkan/vulkan.h>
 
-void __VK_CHECK(bool do_check, VkResult res, const char *expr, const char *file, int line);
+void __VK_CHECK_LOG_CALL(const char *file, int line, const char *expr);
+void __VK_CHECK_LOG_RETURN(const char *file, int line, const char *expr, VkResult result);
+void __VK_CHECK_LOG_VOID_RETURN(const char *file, int line, const char *expr);
 
-#define VKCHECK(expr) __VK_CHECK(true, (expr), #expr, __FILE__, __LINE__)
+#define VKCHECK(expr) do { \
+  __VK_CHECK_LOG_CALL(__FILE__, __LINE__, #expr); \
+  __VK_CHECK_LOG_RETURN(__FILE__, __LINE__, #expr, (expr)); \
+  } while (false)
 
-#define VKLOG(expr) do{ (expr); __VK_CHECK(false, VK_SUCCESS, #expr, __FILE__, __LINE__); }while(false)
+#define VKLOG(expr) do { \
+  __VK_CHECK_LOG_CALL(__FILE__, __LINE__, #expr); \
+  (expr); \
+  __VK_CHECK_LOG_VOID_RETURN(__FILE__, __LINE__, #expr); \
+  } while (false)
 
 #endif

--- a/vulkan-worker/src/common/vulkan_worker.cc
+++ b/vulkan-worker/src/common/vulkan_worker.cc
@@ -1103,10 +1103,10 @@ void VulkanWorker::SubmitCommandBuffer() {
 
   VkResult result = VK_TIMEOUT;
   do {
-    log("Wait for fence");
+    // Do not use VKCHECK as VK_TIMEOUT is a valid result
     result = vkWaitForFences(device_, 1, &fence_, VK_TRUE, fence_timeout_nanoseconds_);
+    log("vkWaitForFences(): %s", getVkResultString(result));
   } while (result == VK_TIMEOUT);
-  log("Fence Result: %d", result);
   assert(result == VK_SUCCESS);
 }
 
@@ -1276,7 +1276,9 @@ void VulkanWorker::PrepareExport() {
 
   VkResult result = VK_TIMEOUT;
   do {
+    // Do not use VKCHECK as VK_TIMEOUT is a valid result
     result = vkWaitForFences(device_, 1, &fence_, VK_TRUE, fence_timeout_nanoseconds_);
+    log("vkWaitForFences(): %s", getVkResultString(result));
   } while (result == VK_TIMEOUT);
   assert(result == VK_SUCCESS);
 }


### PR DESCRIPTION
Log function calls before and after actually calling them. This clarify which function call actually triggers a crash.