### PR TITLE
Prepare command buffers only once for several renderings and exports

### DIFF
--- a/vulkan-worker/src/android/src/main/cpp/main.cc
+++ b/vulkan-worker/src/android/src/main/cpp/main.cc
@@ -50,7 +50,7 @@ void ProcessAppCmd (struct android_app *app, int32_t cmd) {
         assert(app_data->vertex_file != nullptr);
         assert(app_data->fragment_file != nullptr);
         assert(app_data->uniform_file != nullptr);
-        app_data->vulkan_worker->Render(app_data->vertex_file, app_data->fragment_file, app_data->uniform_file, FLAGS_skip_render);
+        app_data->vulkan_worker->RunTest(app_data->vertex_file, app_data->fragment_file, app_data->uniform_file, FLAGS_skip_render);
         ANativeActivity_finish(app->activity);
       }
       break;

--- a/vulkan-worker/src/common/vulkan_worker.cc
+++ b/vulkan-worker/src/common/vulkan_worker.cc
@@ -1453,6 +1453,7 @@ void VulkanWorker::LoadUniforms(const char *uniforms_string) {
 }
 
 void VulkanWorker::ExportPNG(const char *png_filename) {
+  log("EXPORTPNG START");
 
   VKCHECK(vkResetFences(device_, 1, &fence_));
 
@@ -1545,6 +1546,8 @@ void VulkanWorker::ExportPNG(const char *png_filename) {
   free(source_image_blob);
   free(rgba_blob);
   free(png);
+
+  log("EXPORTPNG END");
 }
 
 void VulkanWorker::PrepareTest(std::vector<uint32_t> &vertex_spv, std::vector<uint32_t> &fragment_spv, const char *uniforms_string) {

--- a/vulkan-worker/src/common/vulkan_worker.h
+++ b/vulkan-worker/src/common/vulkan_worker.h
@@ -68,6 +68,7 @@ class VulkanWorker {
   VkDevice device_;
   VkCommandPool command_pool_;
   VkCommandBuffer command_buffer_;
+  std::vector<VkCommandBuffer> export_command_buffers_;
   VkSurfaceKHR surface_;
   VkFormat format_;
   VkSwapchainKHR swapchain_;
@@ -159,7 +160,7 @@ class VulkanWorker {
   void PrepareExport();
   void CleanExport();
   void ExportPNG(const char *png_filename);
-  void UpdateImageLayout(VkImage image, VkImageLayout old_image_layout, VkImageLayout new_image_layout, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dest_stage_mask);
+  void UpdateImageLayout(VkCommandBuffer command_buffer, VkImage image, VkImageLayout old_image_layout, VkImageLayout new_image_layout, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dest_stage_mask);
   void DoRender(std::vector<uint32_t> &vertex_spv, std::vector<uint32_t> &fragment_spv, const char *uniforms_string, const char *png_filename, bool skip_render);
 
   uint32_t GetMemoryTypeIndex(uint32_t memory_requirements_type_bits, VkMemoryPropertyFlags required_properties);

--- a/vulkan-worker/src/common/vulkan_worker.h
+++ b/vulkan-worker/src/common/vulkan_worker.h
@@ -161,7 +161,9 @@ class VulkanWorker {
   void CleanExport();
   void ExportPNG(const char *png_filename);
   void UpdateImageLayout(VkCommandBuffer command_buffer, VkImage image, VkImageLayout old_image_layout, VkImageLayout new_image_layout, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dest_stage_mask);
-  void DoRender(std::vector<uint32_t> &vertex_spv, std::vector<uint32_t> &fragment_spv, const char *uniforms_string, const char *png_filename, bool skip_render);
+  void PrepareTest(std::vector<uint32_t> &vertex_spv, std::vector<uint32_t> &fragment_spv, const char *uniforms_string);
+  void CleanTest();
+  void DrawTest(const char *png_filename, bool skip_render);
 
   uint32_t GetMemoryTypeIndex(uint32_t memory_requirements_type_bits, VkMemoryPropertyFlags required_properties);
   char *GetFileContent(FILE *file);
@@ -171,7 +173,7 @@ class VulkanWorker {
   public:
   VulkanWorker(PlatformData *platform_data);
   ~VulkanWorker();
-  void Render(FILE *vertex_file, FILE *fragment_file, FILE *uniforms_file, bool skip_render);
+  void RunTest(FILE *vertex_file, FILE *fragment_file, FILE *uniforms_file, bool skip_render);
   static void DumpWorkerInfo(const char *worker_info_filename);
 };
 

--- a/vulkan-worker/src/linux/main.cc
+++ b/vulkan-worker/src/linux/main.cc
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
   platform_data.window = glfwCreateWindow(WIDTH, HEIGHT, "VulkanWorker", nullptr, nullptr);
 
   VulkanWorker* vulkan_worker = new VulkanWorker(&platform_data);
-  vulkan_worker->Render(vertex_file, fragment_file, uniform_file, FLAGS_skip_render);
+  vulkan_worker->RunTest(vertex_file, fragment_file, uniform_file, FLAGS_skip_render);
   delete vulkan_worker;
 
   fclose(vertex_file);


### PR DESCRIPTION
A few optimizations to avoid re-creating a graphics pipeline when rendering the same shaders several times in a row. Also, the command buffers for exporting the image are created once, and not every time we want to export an image.

This lead to a performance gain of 500ms, from 1700ms to 1200ms, on an typical example.
