### PR TITLE
Rename "token" to "worker" or "workerName"

### DIFF
--- a/client-tests/src/test/java/com/graphicsfuzz/clienttests/CommonClientTest.java
+++ b/client-tests/src/test/java/com/graphicsfuzz/clienttests/CommonClientTest.java
@@ -39,7 +39,7 @@ import com.graphicsfuzz.shadersets.ShaderDispatchException;
 
 public abstract class CommonClientTest {
 
-  static final String TOKEN = "test_worker";
+  static final String WORKERNAME = "test_worker";
   static Process worker;
   static Thread server;
   static final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
@@ -124,7 +124,7 @@ public abstract class CommonClientTest {
     final File outputDir = temporaryFolder.newFolder();
     String[] args = {
         FilenameUtils.removeExtension(Paths.get(getTestShadersDirectory(), fragmentShader).toString()) + ".json",
-        "--token", TOKEN, "--server", "http://localhost:8080", "--output",
+        "--worker", WORKERNAME, "--server", "http://localhost:8080", "--output",
         outputDir.getAbsolutePath()};
     RunShaderFamily.mainHelper(
         args, null

--- a/client-tests/src/test/java/com/graphicsfuzz/clienttests/DesktopClientTest.java
+++ b/client-tests/src/test/java/com/graphicsfuzz/clienttests/DesktopClientTest.java
@@ -73,14 +73,14 @@ public class DesktopClientTest extends CommonClientTest {
     pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
     pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
 
-    FileUtils.writeStringToFile(new File(temporaryFolder.getRoot(), "token.txt"),
-        TOKEN, StandardCharsets.UTF_8);
+    FileUtils.writeStringToFile(new File(temporaryFolder.getRoot(), "worker-name.txt"),
+        WORKERNAME, StandardCharsets.UTF_8);
 
     worker = pb.start();
 
     int exceptionCount = 0;
     final int limit = 1000;
-    File workerDirectory = Paths.get(serverWorkDir.getAbsolutePath(), "processing", TOKEN)
+    File workerDirectory = Paths.get(serverWorkDir.getAbsolutePath(), "processing", WORKERNAME)
         .toFile();
     while (true) {
       Thread.sleep(10);
@@ -92,7 +92,7 @@ public class DesktopClientTest extends CommonClientTest {
       }
       exceptionCount++;
     }
-    System.out.println("Got token after " + exceptionCount + " tries");
+    System.out.println("Got worker name after " + exceptionCount + " tries");
   }
 
   @AfterClass
@@ -180,7 +180,7 @@ public class DesktopClientTest extends CommonClientTest {
     String[] args = {
         FilenameUtils.removeExtension(
             Paths.get(getTestShadersDirectory(), computeShader).toString()) + ".json",
-        "--token", TOKEN, "--server", "http://localhost:8080", "--output",
+        "--worker", WORKERNAME, "--server", "http://localhost:8080", "--output",
         outputDir.getAbsolutePath()
     };
 

--- a/client-tests/src/test/java/com/graphicsfuzz/clienttests/WebGlClientTest.java
+++ b/client-tests/src/test/java/com/graphicsfuzz/clienttests/WebGlClientTest.java
@@ -43,7 +43,7 @@ public class WebGlClientTest extends CommonClientTest {
     Thread.sleep(5000);
 
     final List<String> command = Arrays.asList(
-        "firefox", "-new-instance", "http://localhost:8080/static/runner.html?context=webgl2&token=" + TOKEN);
+        "firefox", "-new-instance", "http://localhost:8080/static/runner.html?context=webgl2&worker=" + WORKERNAME);
     final ProcessBuilder pb =
         new ProcessBuilder()
             .command(command)
@@ -56,7 +56,7 @@ public class WebGlClientTest extends CommonClientTest {
 
     int exceptionCount = 0;
     final int limit = 1000;
-    File workerDirectory = Paths.get(serverWorkDir.getAbsolutePath(), "processing", TOKEN)
+    File workerDirectory = Paths.get(serverWorkDir.getAbsolutePath(), "processing", WORKERNAME)
         .toFile();
     while (true) {
       Thread.sleep(10);
@@ -68,7 +68,7 @@ public class WebGlClientTest extends CommonClientTest {
       }
       exceptionCount++;
     }
-    System.out.println("Got token after " + exceptionCount + " tries");
+    System.out.println("Got worker name after " + exceptionCount + " tries");
   }
 
   @AfterClass

--- a/common/src/main/java/com/graphicsfuzz/shadersets/RemoteShaderDispatcher.java
+++ b/common/src/main/java/com/graphicsfuzz/shadersets/RemoteShaderDispatcher.java
@@ -39,7 +39,7 @@ public class RemoteShaderDispatcher implements IShaderDispatcher {
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteShaderDispatcher.class);
 
   private final String url;
-  private final String token;
+  private final String worker;
   private final FuzzerServiceManager.Iface fuzzerServiceManager;
 
   private final AtomicLong jobCounter;
@@ -49,27 +49,27 @@ public class RemoteShaderDispatcher implements IShaderDispatcher {
 
   public RemoteShaderDispatcher(
       String url,
-      String token,
+      String worker,
       Iface fuzzerServiceManager,
       AtomicLong jobCounter) {
-    this(url, token, fuzzerServiceManager, jobCounter, DEFAULT_RETRY_LIMIT);
+    this(url, worker, fuzzerServiceManager, jobCounter, DEFAULT_RETRY_LIMIT);
   }
 
   public RemoteShaderDispatcher(
       String url,
-      String token,
+      String worker,
       Iface fuzzerServiceManager,
       AtomicLong jobCounter,
       int retryLimit) {
     this.url = url;
-    this.token = token;
+    this.worker = worker;
     this.fuzzerServiceManager = fuzzerServiceManager;
     this.jobCounter = jobCounter;
     this.retryLimit = retryLimit;
   }
 
-  public RemoteShaderDispatcher(String url, String token) {
-    this(url, token, null, new AtomicLong(), DEFAULT_RETRY_LIMIT);
+  public RemoteShaderDispatcher(String url, String worker) {
+    this(url, worker, null, new AtomicLong(), DEFAULT_RETRY_LIMIT);
   }
 
   @Override
@@ -107,7 +107,7 @@ public class RemoteShaderDispatcher implements IShaderDispatcher {
         .setJobId(jobCounter.incrementAndGet())
         .setImageJob(imageJob);
 
-    return fuzzerServiceManagerProxy.submitJob(job, token, retryLimit)
+    return fuzzerServiceManagerProxy.submitJob(job, worker, retryLimit)
         .getImageJob()
         .getResult();
   }

--- a/common/src/main/java/com/graphicsfuzz/shadersets/RunShaderFamily.java
+++ b/common/src/main/java/com/graphicsfuzz/shadersets/RunShaderFamily.java
@@ -67,8 +67,8 @@ public class RunShaderFamily {
             "URL of server to use for sending get image requests.")
         .type(String.class);
 
-    parser.addArgument("--token")
-        .help("The token of the client used for get image requests. Used with --server.")
+    parser.addArgument("--worker")
+        .help("The worker used for get image requests. Used with --server.")
         .type(String.class);
 
     parser.addArgument("--output")
@@ -86,18 +86,18 @@ public class RunShaderFamily {
     final boolean verbose = ns.get("verbose");
     final File shaderFamily = ns.get("shader_family");
     final String server = ns.get("server");
-    final String token = ns.get("token");
+    final String worker = ns.get("worker");
     final File outputDir = ns.get("output");
 
-    if (managerOverride != null && (server == null || token == null)) {
+    if (managerOverride != null && (server == null || worker == null)) {
       throw new ArgumentParserException(
-          "Must supply server (dummy string) and token when executing in server process.",
+          "Must supply server (dummy string) and worker name when executing in server process.",
           parser);
     }
 
     if (server != null) {
-      if (token == null) {
-        throw new ArgumentParserException("Must supply token with server.", parser);
+      if (worker == null) {
+        throw new ArgumentParserException("Must supply worker name with server.", parser);
       }
     }
 
@@ -108,7 +108,7 @@ public class RunShaderFamily {
             ? new LocalShaderDispatcher(false, fileOps, new File(outputDir, "temp"))
             : new RemoteShaderDispatcher(
                 server + "/manageAPI",
-                token,
+                worker,
                 managerOverride,
                 new AtomicLong());
 

--- a/fuzzerserver/src/main/java/com/graphicsfuzz/server/FileDownloadServlet.java
+++ b/fuzzerserver/src/main/java/com/graphicsfuzz/server/FileDownloadServlet.java
@@ -16,7 +16,7 @@
 
 package com.graphicsfuzz.server;
 
-import static com.graphicsfuzz.server.thrift.FuzzerServiceConstants.DOWNLOAD_FIELD_NAME_TOKEN;
+import static com.graphicsfuzz.server.thrift.FuzzerServiceConstants.DOWNLOAD_FIELD_NAME_WORKER;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,7 +43,7 @@ public class FileDownloadServlet extends HttpServlet {
     /**
      * @return The file to write to.
      */
-    File processDownload(String pathInfo, String token) throws DownloadException;
+    File processDownload(String pathInfo, String worker) throws DownloadException;
   }
 
   private final DownloadProcessor downloadProcessor;
@@ -69,9 +69,9 @@ public class FileDownloadServlet extends HttpServlet {
     }
     pathInfo = pathInfo.substring(1);
     File file = null;
-    String token = request.getParameter(DOWNLOAD_FIELD_NAME_TOKEN);
+    String worker = request.getParameter(DOWNLOAD_FIELD_NAME_WORKER);
     try {
-      file = downloadProcessor.processDownload(pathInfo, token);
+      file = downloadProcessor.processDownload(pathInfo, worker);
     } catch (DownloadException exception) {
       throw new ServletException(exception);
     }

--- a/fuzzerserver/src/main/java/com/graphicsfuzz/server/SessionMap.java
+++ b/fuzzerserver/src/main/java/com/graphicsfuzz/server/SessionMap.java
@@ -54,11 +54,11 @@ public final class SessionMap {
     }
 
     public Session(
-        String token,
+        String worker,
         String platformInfo,
         ExecutorService executorService) {
       this.platformInfo = platformInfo;
-      workQueue = new WorkQueue(executorService, "WorkQueue(" + token + ")");
+      workQueue = new WorkQueue(executorService, "WorkQueue(" + worker + ")");
     }
   }
 
@@ -70,16 +70,16 @@ public final class SessionMap {
 
   private final ConcurrentMap<String, Session> sessions = new ConcurrentHashMap<>();
 
-  public Set<String> getTokenSet() {
+  public Set<String> getWorkerSet() {
     return Collections.unmodifiableSet(sessions.keySet());
   }
 
-  public boolean containsToken(String token) {
-    return sessions.containsKey(token);
+  public boolean containsWorker(String worker) {
+    return sessions.containsKey(worker);
   }
 
-  public boolean isLive(String token) {
-    Session session = this.sessions.get(token);
+  public boolean isLive(String worker) {
+    Session session = this.sessions.get(worker);
     if (session == null) {
       return false;
     }
@@ -87,27 +87,27 @@ public final class SessionMap {
   }
 
   /**
-   * @return true if token was absent and so has been put into the map.
+   * @return true if worker was absent and so has been put into the map.
    */
-  public boolean putIfAbsent(String token, Session session) {
-    return sessions.putIfAbsent(token, session) == null;
+  public boolean putIfAbsent(String worker, Session session) {
+    return sessions.putIfAbsent(worker, session) == null;
   }
 
-  public void replace(String token, Session oldSession, Session session) {
-    sessions.replace(token, oldSession, session);
+  public void replace(String worker, Session oldSession, Session session) {
+    sessions.replace(worker, oldSession, session);
   }
 
-  public void remove(String token) {
-    sessions.remove(token);
+  public void remove(String worker) {
+    sessions.remove(worker);
   }
 
-  public WorkQueue getWorkQueue(String token) {
-    return sessions.get(token).workQueue;
+  public WorkQueue getWorkQueue(String worker) {
+    return sessions.get(worker).workQueue;
   }
 
-  public <T, E extends Throwable> T lockSessionAndExecute(String token,
+  public <T, E extends Throwable> T lockSessionAndExecute(String worker,
       SessionWorkerEx<T, E> sessionWorker) throws E {
-    Session session = sessions.get(token);
+    Session session = sessions.get(worker);
     synchronized (session.mutex) {
       return sessionWorker.go(session);
     }

--- a/fuzzerserver/src/main/java/com/graphicsfuzz/server/WorkQueue.java
+++ b/fuzzerserver/src/main/java/com/graphicsfuzz/server/WorkQueue.java
@@ -83,13 +83,13 @@ public class WorkQueue {
         // runnables may add work.
         // Should not use "return" below:
         try {
-          MDC.put("token", name + ":" + runnable.toString());
+          MDC.put("worker", name + ":" + runnable.toString());
           LOGGER.info("Dequeued work item. Running it now.");
           runnable.run();
         } catch (Throwable ex) {
           LOGGER.error("Throwable", ex);
         } finally {
-          MDC.remove("token");
+          MDC.remove("worker");
         }
       }
     }
@@ -148,12 +148,12 @@ public class WorkQueue {
         CommandRunnable cr = (CommandRunnable) item;
         res.add(
             new CommandInfo()
-              .setName(cr.getName())
+              .setWorkerName(cr.getName())
               .setCommand(cr.getCommand())
               .setLogFile(cr.getLogFile())
         );
       } else {
-        res.add(new CommandInfo().setName(item.toString()));
+        res.add(new CommandInfo().setWorkerName(item.toString()));
       }
     }
     return res;

--- a/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/GenerateAndRunShaders.java
+++ b/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/GenerateAndRunShaders.java
@@ -60,8 +60,8 @@ public class GenerateAndRunShaders {
           .help("URL of server.")
           .type(String.class);
 
-    parser.addArgument("token")
-          .help("Token for worker.")
+    parser.addArgument("worker")
+          .help("Worker name.")
           .type(String.class);
 
     parser.addArgument("glsl_version")
@@ -134,7 +134,7 @@ public class GenerateAndRunShaders {
         queue,
         outputDir,
         ns.get("server"),
-        ns.get("token"),
+        ns.get("worker"),
         shadingLanguageVersion,
         crashStringsToIgnore,
         ns.get("only_variants"),

--- a/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/ShaderConsumer.java
+++ b/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/ShaderConsumer.java
@@ -43,7 +43,7 @@ public class ShaderConsumer implements Runnable {
   private final File outputDir;
   private final File tempDir;
   private final String server;
-  private final String token;
+  private final String worker;
   private final ShadingLanguageVersion shadingLanguageVersion;
   private final Set<String> crashStringsToIgnore;
   private final boolean onlyVariants;
@@ -54,7 +54,7 @@ public class ShaderConsumer implements Runnable {
       BlockingQueue<Pair<ShaderJob, ShaderJob>> queue,
       File outputDir,
       String server,
-      String token,
+      String worker,
       ShadingLanguageVersion shadingLanguageVersion,
       Set<String> crashStringsToIgnore,
       boolean onlyVariants,
@@ -64,7 +64,7 @@ public class ShaderConsumer implements Runnable {
     this.outputDir = outputDir;
     this.tempDir = new File(outputDir, "temp");
     this.server = server;
-    this.token = token;
+    this.worker = worker;
     this.shadingLanguageVersion = shadingLanguageVersion;
     this.crashStringsToIgnore = crashStringsToIgnore;
     this.onlyVariants = onlyVariants;
@@ -75,7 +75,7 @@ public class ShaderConsumer implements Runnable {
   public void run() {
 
     final IShaderDispatcher imageGenerator =
-        new RemoteShaderDispatcher(server + "/manageAPI", token);
+        new RemoteShaderDispatcher(server + "/manageAPI", worker);
 
     final File invalidDirectory = new File(outputDir, "INVALID");
 

--- a/generate-and-run-shaders/src/test/java/com/graphicsfuzz/generator/GenerateAndRunShadersTest.java
+++ b/generate-and-run-shaders/src/test/java/com/graphicsfuzz/generator/GenerateAndRunShadersTest.java
@@ -44,7 +44,7 @@ public class GenerateAndRunShadersTest {
                 donors.getAbsolutePath(),
                 outputDir,
                 "dummy_server",
-                "dummy_token",
+                "dummy_worker",
                 "100"
             }
       );
@@ -70,7 +70,7 @@ public class GenerateAndRunShadersTest {
                 donors.getAbsolutePath(),
                 outputDir,
                 "dummy_server",
-                "dummy_token",
+                "dummy_worker",
                 "100"
             }
       );
@@ -95,7 +95,7 @@ public class GenerateAndRunShadersTest {
                 donors.getAbsolutePath(),
                 outputDir,
                 "dummy_server",
-                "dummy_token",
+                "dummy_worker",
                 "100"
             }
       );

--- a/gles-worker/core/src/com/graphicsfuzz/glesworker/JobGetter.java
+++ b/gles-worker/core/src/com/graphicsfuzz/glesworker/JobGetter.java
@@ -26,7 +26,7 @@ import com.graphicsfuzz.repackaged.org.apache.thrift.protocol.TProtocol;
 import com.graphicsfuzz.repackaged.org.apache.thrift.transport.THttpClient;
 import com.graphicsfuzz.repackaged.org.apache.thrift.transport.TTransport;
 import com.graphicsfuzz.server.thrift.FuzzerService;
-import com.graphicsfuzz.server.thrift.GetTokenResult;
+import com.graphicsfuzz.server.thrift.GetWorkerNameResult;
 import com.graphicsfuzz.server.thrift.Job;
 
 public class JobGetter implements Disposable {
@@ -36,7 +36,7 @@ public class JobGetter implements Disposable {
   private CloseableHttpClient httpClient;
   private TTransport transport;
   public FuzzerService.Iface fuzzerServiceProxy;
-  public String token;
+  public String worker;
 
   // The latest job that has been gotten.
   private Job latestJob;
@@ -59,25 +59,25 @@ public class JobGetter implements Disposable {
     Gdx.app.log("JobGetter", "JobGetter created");
   }
 
-  public boolean setToken(String token, String platformInfo) throws TException {
+  public boolean setWorkerName(String worker, String platformInfo) throws TException {
 
-    GetTokenResult getTokenResult = fuzzerServiceProxy.getToken(
+    GetWorkerNameResult getWorkerNameResult = fuzzerServiceProxy.getWorkerName(
         platformInfo,
-        token);
+        worker);
 
-    if (getTokenResult.isSetToken()) {
-      this.token = getTokenResult.getToken();
-      Gdx.app.log("JobGetter", "Token set: " + this.token);
+    if (getWorkerNameResult.isSetWorkerName()) {
+      this.worker = getWorkerNameResult.getWorkerName();
+      Gdx.app.log("JobGetter", "Worker name set: " + this.worker);
       return true;
     } else {
-      Gdx.app.log("JobGetter", "Failed to set token");
+      Gdx.app.log("JobGetter", "Failed to set worker name");
       return false;
     }
   }
 
   public Job getJob() throws TException {
 
-    Job job = fuzzerServiceProxy.getJob(token);
+    Job job = fuzzerServiceProxy.getJob(worker);
 
     Gdx.app.log("JobGetter", "Got a job.");
 
@@ -121,7 +121,7 @@ public class JobGetter implements Disposable {
 
       Gdx.app.log("JobGetter", "Sending jobDone.");
 
-      fuzzerServiceProxy.jobDone(token, job);
+      fuzzerServiceProxy.jobDone(worker, job);
 
       // We have sent a reply, so nullify latestJob.
       latestJob = null;

--- a/gles-worker/core/src/com/graphicsfuzz/glesworker/Main.java
+++ b/gles-worker/core/src/com/graphicsfuzz/glesworker/Main.java
@@ -312,28 +312,28 @@ public class Main extends ApplicationAdapter {
     // Here we've established connection with the server, so its URL is good, let's save it
     serverFile.writeString(url, false);
 
-    // Recover token
-    FileHandle tokenFile = Gdx.files.local("token.txt");
+    // Recover worker name
+    FileHandle workerNameFile = Gdx.files.local("worker-name.txt");
 
-    if (jobGetter.token == null) {
-      if (tokenFile.exists()) {
-        jobGetter.token = tokenFile.readString();
+    if (jobGetter.worker == null) {
+      if (workerNameFile.exists()) {
+        jobGetter.worker = workerNameFile.readString();
       } else {
         if (Gdx.app.getType() == ApplicationType.Desktop) {
-          Gdx.app.log("Main", "Please set a token by creating token.txt with one line of text.");
+          Gdx.app.log("Main", "Please set a worker name by creating worker-name.txt with one line of text.");
           setBackoffWaitTicks();
         } else if (!showingTextInput) {
-          String defaultToken = "";
+          String defaultWorker = "";
           if (platformInfoJson.has("clientplatform") &&
               platformInfoJson.get("clientplatform").getAsString().equalsIgnoreCase("android") &&
               platformInfoJson.has("model")) {
-            defaultToken = platformInfoJson.get("model").getAsString().trim().replace(" ", "-");
+            defaultWorker = platformInfoJson.get("model").getAsString().trim().replace(" ", "-");
           }
           showingTextInput = true;
           Gdx.input.getTextInput(new TextInputListener() {
             @Override
             public void input(String text) {
-              jobGetter.token = text;
+              jobGetter.worker = text;
               showingTextInput = false;
             }
 
@@ -341,7 +341,7 @@ public class Main extends ApplicationAdapter {
             public void canceled() {
               showingTextInput = false;
             }
-          }, "Absent or invalid token, provide new token:", defaultToken, "");
+          }, "Absent or invalid worker name, provide new name:", defaultWorker, "");
         }
 
         // Return: the text listener will be invoked on the next frame.
@@ -351,22 +351,22 @@ public class Main extends ApplicationAdapter {
 
     String platformInfo = platformInfoJson.toString();
 
-    boolean tokenOK = false;
+    boolean workerNameOK = false;
     try {
-      tokenOK = jobGetter.setToken(jobGetter.token, platformInfo);
+      workerNameOK = jobGetter.setWorkerName(jobGetter.worker, platformInfo);
     } catch (TException e) {
-      Gdx.app.log("Main", "Exception when trying to get token: " + e.getMessage());
-      tokenOK = false;
+      Gdx.app.log("Main", "Exception when trying to get worker name: " + e.getMessage());
+      workerNameOK = false;
     }
 
-    if (tokenOK) {
-      Gdx.app.log("Main", "Set token: " + jobGetter.token);
-      tokenFile.writeString(jobGetter.token, false);
+    if (workerNameOK) {
+      Gdx.app.log("Main", "Set worker name: " + jobGetter.worker);
+      workerNameFile.writeString(jobGetter.worker, false);
       return true;
     } else {
-      Gdx.app.log("Main", "Token was refused, or server is unreachable.");
-      // Reset token
-      jobGetter.token = null;
+      Gdx.app.log("Main", "Worker name was refused, or server is unreachable.");
+      // Reset worker name
+      jobGetter.worker = null;
       return false;
     }
   }
@@ -468,7 +468,7 @@ public class Main extends ApplicationAdapter {
       // we do not use jobgetter.replyJob() as if we are here due to a crash, there is no previous
       // job stored in latestJob, so replyJob() will think the answer has already been sent.
       // FIXME: we should simplify all this.
-      jobGetter.fuzzerServiceProxy.jobDone(jobGetter.token, toreply);
+      jobGetter.fuzzerServiceProxy.jobDone(jobGetter.worker, toreply);
 
       persistentData.reset();
       return;
@@ -689,7 +689,7 @@ public class Main extends ApplicationAdapter {
         DisplayContent.append("datetime: "
               + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
               + "\n\n");
-        DisplayContent.append("token: " + (jobGetter != null ? jobGetter.token : "") + "\n");
+        DisplayContent.append("worker: " + (jobGetter != null ? jobGetter.worker : "") + "\n");
 
         DisplayContent.append("server: " + url + "\n");
         DisplayContent.append("state: " + state.toString() + "\n");

--- a/graphicsfuzz/src/main/scripts/server-static/backend.js
+++ b/graphicsfuzz/src/main/scripts/server-static/backend.js
@@ -23,7 +23,7 @@ var triangleRightVertexPositionBuffer = null;
 var transport = null;
 var protocol = null;
 var client = null;
-var token = null;
+var worker = null;
 
 var msWait = 10;
 
@@ -85,7 +85,7 @@ function doRun() {
             protocol = new Thrift.TJSONProtocol(transport);
             client = new oglfuzzerserver.FuzzerServiceClient(protocol);
 
-            token = new oglfuzzerserver.Token();
+            worker = new oglfuzzerserver.WorkerName();
             var platformInfo = getPlatformInfo();
 
             if (typeof(Storage) === "undefined") {
@@ -94,18 +94,18 @@ function doRun() {
             }
 
             var queryParams = $.jurlp(window.location.href).query();
-            token.value = queryParams.token != undefined ? queryParams.token : localStorage.getItem("token");
-            console.log("Trying token '" + token.value + "'.");
-            token = client.getToken(platformInfo, token);
-            localStorage.setItem("token", token.value);
-            console.log("Token from server '" + token.value + "'.");
+            worker.value = queryParams.worker != undefined ? queryParams.worker : localStorage.getItem("worker");
+            console.log("Trying worker name'" + worker.value + "'.");
+            worker = client.getWorkerName(platformInfo, worker);
+            localStorage.setItem("worker", worker.value);
+            console.log("Worker name from server '" + worker.value + "'.");
 
-            document.getElementById("current_token").value = "Current token: " + token.value;
+            document.getElementById("current_worker").value = "Current worker: " + worker.value;
 
             isRunning = true;
         }
 
-        var job = client.getJob(token);
+        var job = client.getJob(worker);
         console.log("Got a job.");
 
         if (job.noJob != null) {
@@ -118,7 +118,7 @@ function doRun() {
 
         if(job.skipJob != null) {
             console.log("Got a skip job.");
-            client.jobDone(token, job);
+            client.jobDone(worker, job);
             return;
         }
 
@@ -148,7 +148,7 @@ function doRun() {
                 imageJob.result.errorMessage = result.error + "\n" + result.log;
             }
 
-            client.jobDone(token, job);
+            client.jobDone(worker, job);
         }
 	} catch (exception) {
 		console.log("Exception occurred: " + exception);
@@ -169,8 +169,8 @@ function stopRun() {
 	isRunning = false;
 }
 
-function resetToken() {
-	localStorage.removeItem("token");
+function resetWorker() {
+	localStorage.removeItem("worker");
 }
 
 /* OpenGL functions ------------------------------------------------------*/
@@ -453,10 +453,10 @@ function getImage() {
 	return canvas.toDataURL("image/png");
 }
 
-function downloadFile(token, url) {
+function downloadFile(worker, url) {
 	var file;
 	$.ajax({
-		url: url + "?token=" + token.value,
+		url: url + "?worker=" + worker.value,
 		async: false,
 		dataType: "text",
         mimeType: "textPlain"
@@ -470,9 +470,9 @@ function downloadFile(token, url) {
 	return file;
 }
 
-function uploadFile(token, url, shaderSet, file, destinationFilename) {
+function uploadFile(worker, url, shaderSet, file, destinationFilename) {
 	var packet = new FormData();
-	packet.append("token", token.value);
+	packet.append("worker", worker.value);
 	packet.append("id", shaderSet.shaderSetId);
 	packet.append("file", dataURItoBlob(file), destinationFilename);
 	$.ajax({
@@ -497,12 +497,12 @@ function getUnmaskedInfo(gl) {
 		vendor: '',
 		renderer: ''
 	};
-	
+
 	var dbgRenderInfo = gl.getExtension("WEBGL_debug_renderer_info");
 	if (dbgRenderInfo != null) {
 		unMaskedInfo.vendor   = gl.getParameter(dbgRenderInfo.UNMASKED_VENDOR_WEBGL);
 		unMaskedInfo.renderer = gl.getParameter(dbgRenderInfo.UNMASKED_RENDERER_WEBGL);
 	}
-	
+
 	return unMaskedInfo;
 }

--- a/graphicsfuzz/src/main/scripts/server-static/index.html
+++ b/graphicsfuzz/src/main/scripts/server-static/index.html
@@ -37,13 +37,13 @@ limitations under the License.
 			<div class="cell">
 				<canvas id="opengl-canvas" style="border: none;" width="640" height="480"></canvas>
 			</div>
-			
+
 			<div class="cell">
 				<div id="button_div">
 					<ul>
 						<li><button title="Connects to a given server and starts executing available jobs" onclick="doRun()">Connect & Run</button></li>
 						<li><button title="Disconnects from the current server" onclick="stopRun()">Disconnect</button></li>
-						<li><button title="Resets the current token to 'null'" onclick="resetToken()">Reset token</button></li>
+						<li><button title="Resets the current worker name to 'null'" onclick="resetWorkerName()">Reset worker name</button></li>
 					</ul>
 
 					<ul>
@@ -59,10 +59,10 @@ limitations under the License.
 				<div style="clear:both;"></div>
 			</div>
 		</div>
-		
+
 		<div class="row">
 			<div class="cell shader_location_input">
-				<input type="text" id="current_token" placeholder="Current token:" readonly/><br/>
+				<input type="text" id="current_worker" placeholder="Current worker name:" readonly/><br/>
 				<input type="text" id="rendered_shader" placeholder="Rendered shader:" readonly/><br/>
 				<input type="text" id="location" placeholder="Location of shader(s)"/><br/>
 				<textarea id="shader_source" placeholder="Source of fragment shader"></textarea>

--- a/python/src/main/python/drivers/run_browser.py
+++ b/python/src/main/python/drivers/run_browser.py
@@ -31,9 +31,9 @@ parser.add_argument("--browserPath", type=str, action="store",
 parser.add_argument("--url", type=str, action="store",
                     default=r"http://localhost:8080/static/runner.html",
                     help="URL of server managing experiments.")
-parser.add_argument("--token", type=str, action="store",
+parser.add_argument("--worker", type=str, action="store",
                     default="",
-                    help="Name of token to be used by server.")
+                    help="Worker to be used by server.")
 parser.add_argument("browserArgs", action="store", nargs="*",
                     default = ["--enable-logging=stderr --enable-logging --v=1 --disable-gpu-process-crash-limit"],
                     help="Arguments to be passed to the browser")
@@ -65,8 +65,8 @@ def signal_handler(sig, frame):
 def run():
     global browser_proc
     full_url = args.url
-    if args.token != "":
-        full_url += "?token=" + args.token
+    if args.worker != "":
+        full_url += "?worker=" + args.worker
     cmd = [args.browserPath] + [full_url] + args.browserArgs
     print("Running command:\n\t" + " ".join(cmd) + "\n")
     browser_proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE);

--- a/python/src/main/python/drivers/run_browser_android.py
+++ b/python/src/main/python/drivers/run_browser_android.py
@@ -32,11 +32,11 @@ def start_logcat():
     logcat_subprocess = subprocess.Popen(logcat_subprocess_arg, stdout=subprocess.PIPE, universal_newlines=True)
     return logcat_subprocess.stdout
 
-def start_worker(server, token, newtab=False):
+def start_worker(server, worker, newtab=False):
     # Note the escaped ampersand in the command
     worker_cmd = "adb shell am start -n org.mozilla.firefox/org.mozilla.gecko.LauncherActivity"
     if newtab:
-        worker_cmd += " -a android.intent.action.VIEW -d 'http://" + server + "/static/runner.html?context=webgl2\&token=" + token + "'"
+        worker_cmd += " -a android.intent.action.VIEW -d 'http://" + server + "/static/runner.html?context=webgl2\&worker=" + worker + "'"
     # shlex.split() doesn't keep the escape around the URL ... ? resort
     # to shell=True
     subprocess.run(worker_cmd, shell=True)
@@ -51,17 +51,17 @@ parser.add_argument(
     help='Server URL, e.g. localhost:8080')
 
 parser.add_argument(
-    'token',
-    help='Worker token to identify to the server')
+    'worker',
+    help='Worker name to identify to the server')
 
 args = parser.parse_args()
 
 logcat = start_logcat()
-start_worker(args.server, args.token, newtab=True)
+start_worker(args.server, args.worker, newtab=True)
 
 while True:
     line = logcat.readline()
     if (" Process org.mozilla.firefox " in line) and (" has died" in line):
         print("Detected a crash: " + line, end='')
         print('Restart worker...')
-        start_worker(args.server, args.token)
+        start_worker(args.server, args.worker)

--- a/python/src/main/python/drivers/vkrun.py
+++ b/python/src/main/python/drivers/vkrun.py
@@ -78,6 +78,9 @@ def run_linux(vert, frag, json, skip_render):
     with open(LOGFILE, 'a') as f:
         f.write('\nSTATUS ' + status + '\n')
 
+    with open('STATUS', 'w') as f:
+        f.write(status)
+
 def dump_info_linux():
     cmd = 'vkworker --info'
     status = 'SUCCESS'
@@ -202,6 +205,9 @@ def run_android(vert, frag, json, skip_render):
 
     with open(LOGFILE, 'a') as f:
         f.write('\nSTATUS ' + status + '\n')
+
+    with open('STATUS', 'w') as f:
+        f.write(status)
 
     if status != 'SUCCESS':
         # Something went wrong, make sure to stop the app in any case

--- a/python/src/main/python/drivers/worker_vk.py
+++ b/python/src/main/python/drivers/worker_vk.py
@@ -215,11 +215,11 @@ def get_service(server, args, worker_info_json_string):
         workerRes = service.getWorkerName(platforminfo, tryWorker)
         assert type(workerRes) != None
 
-        if workerRes.worker == None:
+        if workerRes.workerName == None:
             print('Worker error: ' + tt.WorkerNameError._VALUES_TO_NAMES[workerRes.error])
             exit(1)
 
-        worker = workerRes.worker
+        worker = workerRes.workerName
 
         print("Got worker: " + worker)
         assert(worker == args.worker)

--- a/python/src/main/python/drivers/worker_vk.py
+++ b/python/src/main/python/drivers/worker_vk.py
@@ -207,30 +207,30 @@ def get_service(server, args, worker_info_json_string):
         service = FuzzerService.Client(protocol)
         transport.open()
 
-        # Get token
+        # Get worker name
         platforminfo = worker_info_json_string
 
-        tryToken = args.token
-        print("Call getToken()")
-        tokenRes = service.getToken(platforminfo, tryToken)
-        assert type(tokenRes) != None
+        tryWorker = args.worker
+        print("Call getWorkername()")
+        workerRes = service.getWorkerName(platforminfo, tryWorker)
+        assert type(workerRes) != None
 
-        if tokenRes.token == None:
-            print('Token error: ' + tt.TokenError._VALUES_TO_NAMES[tokenRes.error])
+        if workerRes.worker == None:
+            print('Worker error: ' + tt.WorkerNameError._VALUES_TO_NAMES[workerRes.error])
             exit(1)
 
-        token = tokenRes.token
+        worker = workerRes.worker
 
-        print("Got token: " + token)
-        assert(token == args.token)
+        print("Got worker: " + worker)
+        assert(worker == args.worker)
 
-        if not os.path.exists(args.token):
-            os.makedirs(args.token)
+        if not os.path.exists(args.worker):
+            os.makedirs(args.worker)
 
         # Set working dir
-        os.chdir(args.token)
+        os.chdir(args.worker)
 
-        return service, token
+        return service, worker
 
     except (TApplicationException, ConnectionRefusedError, ConnectionResetError) as exception:
         return None, None
@@ -256,8 +256,8 @@ def isDeviceAvailable(serial):
 parser = argparse.ArgumentParser()
 
 parser.add_argument(
-    'token',
-    help='Worker token to identify to the server')
+    'worker',
+    help='Worker name to identify to the server')
 
 parser.add_argument(
     '--adbID',
@@ -279,7 +279,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-print('token: ' + args.token)
+print('Worker: ' + args.worker)
 
 server = args.server + '/request'
 print('server: ' + server)
@@ -318,7 +318,7 @@ while True:
         exit(1)
 
     if not(service):
-        service, token = get_service(server, args, worker_info_json_string)
+        service, worker = get_service(server, args, worker_info_json_string)
 
         if not(service):
             print("Cannot connect to server, retry in a second...")
@@ -326,21 +326,21 @@ while True:
             continue
 
     try:
-        job = service.getJob(token)
+        job = service.getJob(worker)
 
         if job.noJob != None:
             print("No job")
 
         elif job.skipJob != None:
             print("Skip job")
-            service.jobDone(token, job)
+            service.jobDone(worker, job)
 
         else:
             assert(job.imageJob != None)
             print("#### Image job: " + job.imageJob.name)
             job.imageJob.result = doImageJob(args, job.imageJob)
             print("Send back, results status: {}".format(job.imageJob.result.status))
-            service.jobDone(token, job)
+            service.jobDone(worker, job)
 
     except (TApplicationException, ConnectionError) as exception:
         print("Connection to server lost. Re-initialising client.")

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
@@ -159,8 +159,8 @@ public class GlslReduce {
           .help("Server URL to which image jobs are sent.")
           .type(String.class);
 
-    parser.addArgument("--token")
-          .help("Client token to which image jobs are sent. Used with --server.")
+    parser.addArgument("--worker")
+          .help("Name of worker to which image jobs are sent. Used with --server.")
           .type(String.class);
 
     parser.addArgument("--output")
@@ -266,23 +266,23 @@ public class GlslReduce {
       final boolean stopOnError = ns.get("stop_on_error");
 
       final String server = ns.get("server");
-      final String token = ns.get("token");
+      final String worker = ns.get("worker");
 
       final boolean usingSwiftshader = ns.get("swiftshader");
 
       final boolean continuePreviousReduction = ns.get("continue_previous_reduction");
 
-      if (managerOverride != null && (server == null || token == null)) {
+      if (managerOverride != null && (server == null || worker == null)) {
         throw new ArgumentParserException(
-              "Must supply server (dummy string) and token when executing in server process.",
+              "Must supply server (dummy string) and worker when executing in server process.",
               parser);
       }
 
-      if (server != null && token == null) {
-        throw new ArgumentParserException("If --server is used then --token is required", parser);
+      if (server != null && worker == null) {
+        throw new ArgumentParserException("If --server is used then --worker is required", parser);
       }
-      if (server == null && token != null) {
-        LOGGER.warn("Warning: --token ignored, as it is used without --server");
+      if (server == null && worker != null) {
+        LOGGER.warn("Warning: --worker ignored, as it is used without --server");
       }
       if (server != null && usingSwiftshader) {
         LOGGER.warn("Warning: --swiftshader ignored, as --server is being used");
@@ -296,8 +296,8 @@ public class GlslReduce {
         if (server != null) {
           throwExceptionForCustomReduction("server");
         }
-        if (token != null) {
-          throwExceptionForCustomReduction("token");
+        if (worker != null) {
+          throwExceptionForCustomReduction("worker");
         }
         if (errorString != null) {
           throwExceptionForCustomReduction("error_string");
@@ -350,7 +350,7 @@ public class GlslReduce {
                       new File(workDir, "temp"))
                   : new RemoteShaderDispatcher(
                       server + "/manageAPI",
-                      token,
+                      worker,
                       managerOverride,
                       new AtomicLong(),
                       retryLimit);

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/tool/GlslReduceTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/tool/GlslReduceTest.java
@@ -37,7 +37,7 @@ public class GlslReduceTest {
   @Test
   public void noServerAllowedInCustomReduction() throws Exception {
     try {
-      GlslReduce.mainHelper(new String[]{"--server", "some_server", "--token", "some_token",
+      GlslReduce.mainHelper(new String[]{"--server", "some_server", "--worker", "some_worker",
               makeShaderJobAndReturnJsonFilename(), "CUSTOM", "--output",
               temporaryFolder.getRoot().getAbsolutePath()}
           , null);
@@ -48,14 +48,14 @@ public class GlslReduceTest {
   }
 
   @Test
-  public void noTokenAllowedInCustomReduction() throws Exception {
+  public void noWorkerNameAllowedInCustomReduction() throws Exception {
     try {
-      GlslReduce.mainHelper(new String[]{"--token", "some_token",
+      GlslReduce.mainHelper(new String[]{"--worker", "some_worker",
           makeShaderJobAndReturnJsonFilename(), "CUSTOM", "--output",
           temporaryFolder.getRoot().getAbsolutePath()}, null);
       assertTrue(false);
     } catch (RuntimeException exception) {
-      checkOptionNotAllowed(exception, "token");
+      checkOptionNotAllowed(exception, "worker");
     }
   }
 

--- a/server-public/src/main/java/com/graphicsfuzz/serverpublic/FuzzerServer.java
+++ b/server-public/src/main/java/com/graphicsfuzz/serverpublic/FuzzerServer.java
@@ -89,7 +89,7 @@ public final class FuzzerServer {
     context.addServlet(
           new ServletHolder(
                 new FileDownloadServlet(
-                    (pathInfo, token) -> Paths.get(staticDir, pathInfo).toFile(), staticDir)),
+                    (pathInfo, worker) -> Paths.get(staticDir, pathInfo).toFile(), staticDir)),
           "/static/*");
 
     HandlerList handlerList = new HandlerList();

--- a/server-static-public/src/main/files/server-static/runner.html
+++ b/server-static-public/src/main/files/server-static/runner.html
@@ -41,7 +41,7 @@ limitations under the License.
 
   <div class="row">
     <div class="cell shader_location_input">
-      <input type="text" class="runner_input" id="current_token0" placeholder="Current token:" readonly/><br/>
+      <input type="text" class="runner_input" id="current_worker0" placeholder="Current worker name:" readonly/><br/>
       <input type="text" class="runner_input" id="rendered_shader0" placeholder="Rendered shader:" readonly/><br/>
       <input type="text" class="runner_input" id="version" value="WebGL Context: " readonly/><br/>
       <textarea id="console0" class="console" placeholder="Console" readonly></textarea>

--- a/server-static-public/src/main/files/server-static/runner.js
+++ b/server-static-public/src/main/files/server-static/runner.js
@@ -118,7 +118,7 @@ function initClient(i) {
     workers[i] = localStorage.getItem("worker" + i);
   }
   myLog("Trying worker '" + workers[i] + "'.", i);
-  var getWorkerNameResult = clients[i].getWorkerName(platformInfo, workerNames[i]);
+  var getWorkerNameResult = clients[i].getWorkerName(platformInfo, workers[i]);
   if (!getWorkerNameResult.workerName) {
     throw "Worker name rejected: " + reverseWorkerNameError[getWorkerNameResult.error];
   }

--- a/server-static-public/src/main/files/server-static/runner.js
+++ b/server-static-public/src/main/files/server-static/runner.js
@@ -20,7 +20,7 @@ var transport = null;
 var protocol = null;
 var platformInfo = null;
 var clients = [];
-var tokens = [];
+var workers = [];
 var completedJobs = [];
 var gls = [];
 
@@ -28,12 +28,12 @@ var msWaitDefault = 10;
 var msWaitMax = 5000;
 var msWait = msWaitDefault;
 
-var reverseTokenError = {};
+var reverseWorkerNameError = {};
 
 var webgl_context;
 
-for (var key in graphicsfuzzserver.TokenError) {
-  reverseTokenError[graphicsfuzzserver.TokenError[key]] = key;
+for (var key in graphicsfuzzserver.WorkerNameError) {
+  reverseWorkerNameError[graphicsfuzzserver.WorkerNameError[key]] = key;
 }
 
 //Get time since [time] in microseconds (time should be obtained with window.performance.now() to match precision)
@@ -106,35 +106,35 @@ function initClient(i) {
     throw "Attempted to initialise client " + i + " when only " + clients.length + " exist.";
   }
   clients.push(new graphicsfuzzserver.FuzzerServiceClient(protocol));
-  tokens.push("");
+  workers.push("");
   completedJobs.push(0);
 
-  //Check URL for tokens
-  tokens[i] = getArg("token" + i);
-  if (i == 0 && tokens[i] == undefined) {
-    tokens[i] = getArg("token");
+  //Check URL for workers
+  workers[i] = getArg("worker" + i);
+  if (i == 0 && workers[i] == undefined) {
+    workers[i] = getArg("worker");
   }
-  if (tokens[i] == undefined) {
-    tokens[i] = localStorage.getItem("token" + i);
+  if (workers[i] == undefined) {
+    workers[i] = localStorage.getItem("worker" + i);
   }
-  myLog("Trying token '" + tokens[i] + "'.", i);
-  var getTokenResult = clients[i].getToken(platformInfo, tokens[i]);
-  if (!getTokenResult.token) {
-    throw "token rejected: " + reverseTokenError[getTokenResult.error];
+  myLog("Trying worker '" + workers[i] + "'.", i);
+  var getWorkerNameResult = clients[i].getWorkerName(platformInfo, workerNames[i]);
+  if (!getWorkerNameResult.workerName) {
+    throw "Worker name rejected: " + reverseWorkerNameError[getWorkerNameResult.error];
   }
-  tokens[i] = getTokenResult.token;
+  workers[i] = getWorkerNameResult.workerName;
 
-  localStorage.setItem("token" + i, tokens[i]);
-  myLog("Token from server '" + tokens[i] + "'.", i);
+  localStorage.setItem("worker" + i, workers[i]);
+  myLog("Worker from server '" + workers[i] + "'.", i);
 
-  document.getElementById("current_token" + i).value = "Current token: " + tokens[i];
+  document.getElementById("current_worker" + i).value = "Current worker: " + workers[i];
 }
 
 //Get job and execute shader if necessary
 function getAndHandleJob(i) {
 
   //Get job
-  var job = clients[i].getJob(tokens[i]);
+  var job = clients[i].getJob(workers[i]);
   myLog("Got a job.", i);
 
   //No job
@@ -272,12 +272,12 @@ function finishJob(i, job) {
   console.log("Job Done " + completedJobs[i] + " ");
 
   //Return result
-  clients[i].jobDone(tokens[i], job);
+  clients[i].jobDone(workers[i], job);
 
   if (!contextOK) {
     location.reload();
   }
-  
+
 }
 
 //Log text in str to console i
@@ -301,12 +301,12 @@ function startSafe(n) {
     for(x in e) {
       str += x + ":" + e[x] + "\n";
     }
-    var tokenRejected = (typeof e === "string" && e.startsWith("token rejected"));
-    if(tokenRejected) {
-      str = "TOKEN WAS REJECTED\n" + e;
+    var workerRejected = (typeof e === "string" && e.startsWith("Worker name rejected"));
+    if(workerRejected) {
+      str = "WORKER NAME WAS REJECTED\n" + e;
     }
     myLog(str, currI);
-    if(tokenRejected) {
+    if(workerRejected) {
       setTimeout(doRefresh, 10000);
     } else {
       setTimeout(doRefresh, 2000);
@@ -534,7 +534,7 @@ function loadClient(i, numClients) {
     document.getElementById("containing-element").removeAttribute("id");
     var elem = [];
     elem.push(document.getElementById("opengl-canvas{i}"));
-    elem.push(document.getElementById("current_token{i}"));
+    elem.push(document.getElementById("current_worker{i}"));
     elem.push(document.getElementById("rendered_shader{i}"));
     elem.push(document.getElementById("console{i}"));
     for (var j = 0; j < elem.length; j++) {

--- a/server-static-public/src/main/files/server-static/runner_multi_template.html
+++ b/server-static-public/src/main/files/server-static/runner_multi_template.html
@@ -1,7 +1,7 @@
 <td style="padding: 0;"><canvas id="opengl-canvas{i}" class="opengl-canvas"width="256" height="256"></canvas></td>
 <td style="padding: 0;">
   <div class="cell shader_location_input" style="height: 480px; width: 640px; display: flex; flex-direction: column;">
-    <input type="text" id="current_token{i}" class="multi_input" placeholder="Current token:" readonly/><br/>
+    <input type="text" id="current_worker{i}" class="multi_input" placeholder="Current worker name:" readonly/><br/>
     <input type="text" id="rendered_shader{i}" class="multi_input" placeholder="Rendered shader:" readonly/><br/>
     <textarea id="console{i}" placeholder="Console" class="multi_input" style="flex-grow: 1" readonly></textarea>
   </div>

--- a/server/src/main/java/com/graphicsfuzz/server/FuzzerServer.java
+++ b/server/src/main/java/com/graphicsfuzz/server/FuzzerServer.java
@@ -98,7 +98,7 @@ public final class FuzzerServer {
     context.addServlet(
         new ServletHolder(
             new FileDownloadServlet(
-                (pathInfo, token) -> Paths.get(staticDir, pathInfo).toFile(), staticDir)),
+                (pathInfo, workerName) -> Paths.get(staticDir, pathInfo).toFile(), staticDir)),
         "/static/*");
 
     HandlerList handlerList = new HandlerList();

--- a/server/src/main/java/com/graphicsfuzz/server/webui/ReductionFilesHelper.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/ReductionFilesHelper.java
@@ -24,18 +24,18 @@ import java.util.Optional;
 
 public class ReductionFilesHelper {
 
-  static File getReductionDir(String token, String shaderSet, String variant) {
-    return new File(WebUiConstants.WORKER_DIR + "/" + token + "/" + shaderSet
+  static File getReductionDir(String worker, String shaderSet, String variant) {
+    return new File(WebUiConstants.WORKER_DIR + "/" + worker + "/" + shaderSet
         + "/reductions/" + variant);
   }
 
   static Optional<File> getLatestReductionImage(
-      String token,
+      String worker,
       String shaderset,
       String shader,
       ShaderJobFileOperations fileOps) throws IOException {
 
-    final File reductionDir = getReductionDir(token, shaderset, shader);
+    final File reductionDir = getReductionDir(worker, shaderset, shader);
     final Optional<Integer> latestSuccessfulReductionStep =
           ReductionProgressHelper.getLatestReductionStepSuccess(
               reductionDir,

--- a/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
@@ -277,7 +277,7 @@ public class WebUi extends HttpServlet {
     List<WorkerInfo> workers = fuzzerServiceManagerProxy.getServerState().getWorkers();
     workers.sort((workerInfo, t1) -> {
       Comparator<String> comparator = Comparator.naturalOrder();
-      return comparator.compare(workerInfo.getToken(), t1.getToken());
+      return comparator.compare(workerInfo.getWorkerName(), t1.getWorkerName());
     });
     if (!includeInactive) {
       workers.removeIf(w -> !(w.live));
@@ -324,11 +324,12 @@ public class WebUi extends HttpServlet {
         "Run WebGL viewer</a>\n",
         "<a class='ui button' href='/static/webgl_viewer.html?context=webgl2'>",
         "Run WebGL2 viewer</a>\n",
-        "<div class='ui button' onclick=\"promptForInfo('Enter a token (or leave blank for a",
-        "generated token): ', '/static/runner.html?token=', '', '/static/runner.html', true);\">",
+        "<div class='ui button' onclick=\"promptForInfo('Enter a worker name",
+        "(or leave blank for a generated name): ',",
+        "'/static/runner.html?worker=', '', '/static/runner.html', true);\">",
         "Launch WebGL worker</div>\n",
-        "<div class='ui button' onclick=\"promptForInfo('Enter a token (or leave blank for a",
-        "generated token): ', '/static/runner.html?context=webgl2&token=', '',",
+        "<div class='ui button' onclick=\"promptForInfo('Enter a worker name (or leave blank for a",
+        "generated name): ', '/static/runner.html?context=webgl2&worker=', '',",
         "'/static/runner.htmlcontext=webgl2', true);\">",
         "Launch WebGL2 worker</div>\n",
         "</p>\n",
@@ -339,14 +340,14 @@ public class WebUi extends HttpServlet {
         "<div class='ui segment'>\n",
         "<h3>Connected workers</h3>\n",
         "<div class='ui selection animated celled list'>\n");
-    List<String> tokens = new ArrayList<>();
+    List<String> workers = new ArrayList<>();
     for (WorkerInfo worker : getLiveWorkers(false)) {
-      htmlAppendLn("<a class='item' href='/webui/worker/", worker.getToken(), "'>",
+      htmlAppendLn("<a class='item' href='/webui/worker/", worker.getWorkerName(), "'>",
           "<i class='large middle aligned mobile icon'></i><div class='content'>",
-          "<div class='header'>", worker.getToken(), "</div>",
+          "<div class='header'>", worker.getWorkerName(), "</div>",
           "#queued jobs: ",
           Integer.toString(worker.getCommandQueueSize()), "</div></a>");
-      tokens.add(worker.getToken());
+      workers.add(worker.getWorkerName());
     }
     htmlAppendLn("</div></div>");
 
@@ -357,10 +358,10 @@ public class WebUi extends HttpServlet {
         "<button class='ui black basic button' onclick='toggleDiv(this)'",
         " data-hide='disconnected-workers'>Show/Hide</button>\n",
         "<div class='disconnected-workers invisible ui selection animated celled list'>");
-    List<File> workers = getAllWorkers(request, response);
+    List<File> workerFiles = getAllWorkers(request, response);
     if (workers != null) {
-      for (File worker : workers) {
-        if (!tokens.contains(worker.getName())) {
+      for (File worker : workerFiles) {
+        if (!workers.contains(worker.getName())) {
           htmlAppendLn("<a class='item' href='/webui/worker/", worker.getName(), "'>",
               worker.getName(), "</a>");
         }
@@ -444,7 +445,7 @@ public class WebUi extends HttpServlet {
         "<p><form method='post' id='clearForm'>\n",
         "<input type='hidden' id='' name='queueType' value='worker'/>\n",
         "<input type='hidden' id='' name='type' value='clear'/>\n",
-        "<input type='hidden' id='' name='token' value='", workerName, "'/>\n",
+        "<input type='hidden' id='' name='worker' value='", workerName, "'/>\n",
         "<div class='ui button' onclick=\"clearForm.submit();\">Clear Queue</div>\n",
         "</form></p>\n",
         "</div>");
@@ -488,7 +489,7 @@ public class WebUi extends HttpServlet {
     boolean atLeastOne = false;
 
     for (WorkerInfo worker : getLiveWorkers(true)) {
-      if (worker.getToken().equals(workerName)) {
+      if (worker.getWorkerName().equals(workerName)) {
         List<CommandInfo> commands = worker.getCommandQueue();
         if (commands.size() > 0) {
           atLeastOne = true;
@@ -496,7 +497,7 @@ public class WebUi extends HttpServlet {
               " data-hide='job-queue'>Show/Hide</button>\n",
               "<div class='job-queue ui celled list'>");
           for (CommandInfo ci : commands) {
-            htmlAppendLn("<div class='item'><div class='header'>", ci.name, "</div></div>");
+            htmlAppendLn("<div class='item'><div class='header'>", ci.workerName, "</div></div>");
           }
           htmlAppendLn("</div>");
           break;
@@ -656,9 +657,9 @@ public class WebUi extends HttpServlet {
             "<div class='ui checkbox'>",
             "<input tabindex='0' class='hidden' type='checkbox' name='workercheck'",
             " data-num='", Integer.toString(dataNum), "' onclick='applyCheckbox(event);'",
-            " value='", workerInfo.getToken(), "'>",
+            " value='", workerInfo.getWorkerName(), "'>",
             "<label data-num='", Integer.toString(dataNum), "' onclick='applyCheckbox(event);'>",
-            workerInfo.getToken(), "</label>",
+            workerInfo.getWorkerName(), "</label>",
             "</div></div>");
         dataNum += 1;
       }
@@ -798,11 +799,11 @@ public class WebUi extends HttpServlet {
       err404(request, response, "Path to result " + request.getPathInfo() + " invalid!");
       return;
     }
-    final String token = path[3];
+    final String worker = path[3];
     final String shaderFamily = path[4];
     final String variant = path[5];
     final String variantDir =
-        WebUiConstants.WORKER_DIR + "/" + token + "/" + shaderFamily + "/";
+        WebUiConstants.WORKER_DIR + "/" + worker + "/" + shaderFamily + "/";
     final String variantFullPathNoExtension = variantDir + variant;
 
     File infoFile = new File(variantDir, variant + ".info.json");
@@ -819,7 +820,7 @@ public class WebUi extends HttpServlet {
     htmlAppendLn("<div class='ui segment'><h3>Single result</h3>",
         "<p>Shader <b><a href='/webui/shader/", shaderPath, "'>",
         variant, "</a></b> of <b>", shaderFamily, "</b>",
-        " run on <b>", token, "</b><br>",
+        " run on <b>", worker, "</b><br>",
         "status: <b>", status, "</b></p>");
 
     htmlAppendLn("<form method='post' id='deleteForm'>\n",
@@ -888,20 +889,20 @@ public class WebUi extends HttpServlet {
     htmlAppendLn("<div class='ui segment'>\n",
         "<h3>Reduction results</h3>");
 
-    final ReductionStatus referenceReductionStatus = getReductionStatus(token, shaderFamily,
+    final ReductionStatus referenceReductionStatus = getReductionStatus(worker, shaderFamily,
         "reference");
     File referenceShader = new File(WebUiConstants.SHADERSET_DIR + "/"
         + shaderFamily, "reference.frag");
     if (referenceReductionStatus == ReductionStatus.FINISHED) {
       referenceShader = new File(
-          ReductionFilesHelper.getReductionDir(token, shaderFamily, "reference"),
+          ReductionFilesHelper.getReductionDir(worker, shaderFamily, "reference"),
           "reference_reduced_final.frag"
       );
     }
 
 
     String reductionHtml = "";
-    final ReductionStatus reductionStatus = getReductionStatus(token, shaderFamily, variant);
+    final ReductionStatus reductionStatus = getReductionStatus(worker, shaderFamily, variant);
 
     htmlAppendLn("<p>Reduction status: <b>", reductionStatus.toString(), "</b></p>");
 
@@ -943,14 +944,14 @@ public class WebUi extends HttpServlet {
         htmlAppendLn("<p>Reduction failed with an exception:</p>",
             "<textarea readonly rows='25' cols='160'>\n",
             getFileContents(ReductionProgressHelper.getReductionExceptionFile(
-                ReductionFilesHelper.getReductionDir(token, shaderFamily, variant), variant)),
+                ReductionFilesHelper.getReductionDir(worker, shaderFamily, variant), variant)),
             "</textarea>");
         break;
 
       case ONGOING:
         final Optional<Integer> reductionStep = ReductionProgressHelper
               .getLatestReductionStepAny(ReductionFilesHelper
-                    .getReductionDir(token, shaderFamily, variant),
+                    .getReductionDir(worker, shaderFamily, variant),
                   "variant", fileOps);
         htmlAppendLn(
             "<p>Reduction not finished for this result: ",
@@ -979,7 +980,7 @@ public class WebUi extends HttpServlet {
 
     // Show reduction log, if it exists, regardless of current reduction status
     final File logFile =
-        new File(ReductionFilesHelper.getReductionDir(token, shaderFamily, variant),
+        new File(ReductionFilesHelper.getReductionDir(worker, shaderFamily, variant),
           "command.log");
     if (logFile.exists()) {
       htmlAppendLn("<p>Contents of reduction log file:</p>",
@@ -1036,8 +1037,8 @@ public class WebUi extends HttpServlet {
     }
   }
 
-  private ReductionStatus getReductionStatus(String token, String shaderSet, String shader) {
-    final File reductionDir = ReductionFilesHelper.getReductionDir(token, shaderSet, shader);
+  private ReductionStatus getReductionStatus(String worker, String shaderSet, String shader) {
+    final File reductionDir = ReductionFilesHelper.getReductionDir(worker, shaderSet, shader);
     if (! reductionDir.exists()) {
       return ReductionStatus.NOREDUCTION;
     }
@@ -1104,9 +1105,9 @@ public class WebUi extends HttpServlet {
           "<div class='ui checkbox'>",
           "<input tabindex='0' class='hidden' type='checkbox' name='workercheck'",
           " data-num='", Integer.toString(dataNum), "' onclick='applyCheckbox(event);'",
-          " value='", workerInfo.getToken(), "'>",
+          " value='", workerInfo.getWorkerName(), "'>",
           "<label data-num='", Integer.toString(dataNum), "' onclick='applyCheckbox(event);'>",
-          workerInfo.getToken(), "</label>",
+          workerInfo.getWorkerName(), "</label>",
           "</div></div>");
       dataNum += 1;
     }
@@ -1145,7 +1146,7 @@ public class WebUi extends HttpServlet {
           commands.add("run_shader_family");
           commands.add("--server");
           commands.add("http://localhost:8080/manageAPI");
-          commands.add("--token");
+          commands.add("--worker");
           commands.add(worker);
           commands.add("--output");
           commands.add("processing/" + worker + "/" + shaderset);
@@ -1323,9 +1324,9 @@ public class WebUi extends HttpServlet {
       args.add("--reference");
       args.add(request.getParameter("reference_image"));
     }
-    args.add("--token");
-    final String token = request.getParameter("token");
-    args.add(token);
+    args.add("--worker");
+    final String worker = request.getParameter("worker");
+    args.add(worker);
     args.add("--server");
     args.add("http://localhost:8080/manageAPI");
     final String threshold = request.getParameter("threshold");
@@ -1374,12 +1375,12 @@ public class WebUi extends HttpServlet {
     String message;
     try {
       fuzzerServiceManagerProxy.queueCommand(
-          args.get(0) + ":" + shaderJobFilePath, args, token, output + "/command.log");
+          args.get(0) + ":" + shaderJobFilePath, args, worker, output + "/command.log");
       message = "Reduction started successfully!";
     } catch (TException exception) {
       message = "Reduction failed (is worker live?):\\n" + exception.getMessage();
     }
-    reduceReference(shaderJobFilePath, token);
+    reduceReference(shaderJobFilePath, worker);
 
     html.setLength(0);
     htmlAppendLn("<script>\n",
@@ -1417,7 +1418,7 @@ public class WebUi extends HttpServlet {
     args.add(reductionDir.getPath());
     args.add("--reference");
     args.add(referenceResult.getPath());
-    args.add("--token");
+    args.add("--worker");
     args.add(worker);
     args.add("--server");
     args.add("http://localhost:8080/manageAPI");
@@ -1438,16 +1439,16 @@ public class WebUi extends HttpServlet {
     response.setContentType("text/html");
 
     String queueType = request.getParameter("queueType");
-    String token = request.getParameter("token");
+    String worker = request.getParameter("worker");
     String msg;
 
     if (queueType.equals("worker")) {
       //Attempt to clear worker job queue
       try {
-        fuzzerServiceManagerProxy.clearClientJobQueue(token);
-        msg = "Queue for worker " + token + " cleared!";
+        fuzzerServiceManagerProxy.clearClientJobQueue(worker);
+        msg = "Queue for worker " + worker + " cleared!";
       } catch (TException exception) {
-        msg = "Worker " + token + " has no queued commands!";
+        msg = "Worker " + worker + " has no queued commands!";
       }
     } else {
       err404(request, response, "Unexpected queue type!");
@@ -1463,7 +1464,7 @@ public class WebUi extends HttpServlet {
     response.getWriter().println(html);
   }
 
-  //Renames a worker (token) (renames dir in the filesystem) and redirects to new worker page
+  //Renames a worker (worker) (renames dir in the filesystem) and redirects to new worker page
   private void renameWorker(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     response.setContentType("text/html");
@@ -1484,7 +1485,7 @@ public class WebUi extends HttpServlet {
     boolean workerLive = false;
     try {
       for (WorkerInfo workerInfo : getLiveWorkers(true)) {
-        if (workerInfo.getToken().equals(worker)) {
+        if (workerInfo.getWorkerName().equals(worker)) {
           workerLive = true;
           break;
         }
@@ -1552,7 +1553,7 @@ public class WebUi extends HttpServlet {
       commands.add("http://localhost:8080");
       StringBuilder msg = new StringBuilder();
       for (String worker : workers) {
-        commands.add("--token");
+        commands.add("--worker");
         commands.add(worker);
         commands.add("--output");
         commands.add("processing/" + worker + "/" + shaderset + "/");
@@ -1861,7 +1862,7 @@ public class WebUi extends HttpServlet {
   private void htmlReductionForm(
       String shaderJobFilePath,
       String output,
-      String token,
+      String worker,
       String referenceResultPath,
       String variantShaderJobResultFileNoExtension,
       String resultStatus) {
@@ -1874,7 +1875,7 @@ public class WebUi extends HttpServlet {
         "<input type='hidden' name='type' value='reduce'>",
         "<input type='hidden' name='shader_path' value='", shaderJobFilePath, "'>",
         "<input type='hidden' name='output' value='", output, "'>",
-        "<input type='hidden' name='token' value='", token, "'>",
+        "<input type='hidden' name='worker' value='", worker, "'>",
         "<table><tr>",
         "<td class='row_middle'><h3 class='no_margin'>Required Arguments</h3></td>",
         "<td class='row_middle'><h3 class='no_margin'>Optional Arguments</h3></td>",

--- a/shadersets-util/src/main/java/com/graphicsfuzz/shadersets/RunShaderFamily.java
+++ b/shadersets-util/src/main/java/com/graphicsfuzz/shadersets/RunShaderFamily.java
@@ -82,8 +82,8 @@ public class RunShaderFamily {
             "URL of server to use for sending get image requests.")
         .type(String.class);
 
-    parser.addArgument("--token")
-        .help("The token of the client used for get image requests. Used with --server.")
+    parser.addArgument("--worker")
+        .help("The name of the worker used for get image requests. Used with --server.")
         .type(String.class);
 
     parser.addArgument("--output")
@@ -95,24 +95,23 @@ public class RunShaderFamily {
         .help("Shader family directory, or prefix of single shader job")
         .type(String.class);
 
-
     Namespace ns = parser.parseArgs(args);
 
     final boolean verbose = ns.get("verbose");
     final String shaderFamily = ns.get("shader_family");
     final String server = ns.get("server");
-    final String token = ns.get("token");
+    final String worker = ns.get("worker");
     final File outputDir = ns.get("output");
 
-    if (managerOverride != null && (server == null || token == null)) {
+    if (managerOverride != null && (server == null || worker == null)) {
       throw new ArgumentParserException(
-          "Must supply server (dummy string) and token when executing in server process.",
+          "Must supply server (dummy string) and worker name when executing in server process.",
           parser);
     }
 
     if (server != null) {
-      if (token == null) {
-        throw new ArgumentParserException("Must supply token with server.", parser);
+      if (worker == null) {
+        throw new ArgumentParserException("With --server, must supply --worker name.", parser);
       }
     }
 
@@ -121,7 +120,7 @@ public class RunShaderFamily {
             ? new LocalShaderDispatcher(false)
             : new RemoteShaderDispatcher(
                 server + "/manageAPI",
-                token,
+                worker,
                 managerOverride,
                 new AtomicLong());
 

--- a/thrift/src/main/thrift/FuzzerService.thrift
+++ b/thrift/src/main/thrift/FuzzerService.thrift
@@ -33,10 +33,10 @@ const string IDENTIFIER_ANDROID = "android";
 const string IDENTIFIER_IOS = "ios";
 
 const string UPLOAD_FIELD_NAME_FILE = "file";
-const string UPLOAD_FIELD_NAME_TOKEN = "token";
+const string UPLOAD_FIELD_NAME_WORKER = "worker";
 const string UPLOAD_FIELD_NAME_ID = "id"; // the shader set id
 
-const string DOWNLOAD_FIELD_NAME_TOKEN = UPLOAD_FIELD_NAME_TOKEN;
+const string DOWNLOAD_FIELD_NAME_WORKER = UPLOAD_FIELD_NAME_WORKER;
 
 // get_image exit codes.
 const i32 COMPILE_ERROR_EXIT_CODE = 101;
@@ -67,21 +67,21 @@ enum ImageComparisonMetric {
     PSNR
 }
 
-enum TokenError {
+enum WorkerNameError {
   SERVER_ERROR = 0,
   INVALID_PLATFORM_INFO,
-  INVALID_PROVIDED_TOKEN,
+  INVALID_PROVIDED_WORKER,
   PLATFORM_INFO_CHANGED,
 }
 
 struct CommandInfo {
-  1 : optional string name,
+  1 : optional string workerName,
   2 : optional list<string> command,
   3 : optional string logFile,
 }
 
 struct WorkerInfo {
-  1 : optional string token,
+  1 : optional string workerName,
   2 : optional list<CommandInfo> commandQueue,
   3 : optional list<string> jobQueue,
   4 : optional bool live,
@@ -92,9 +92,9 @@ struct ServerInfo {
   2 : optional list<WorkerInfo> workers
 }
 
-struct GetTokenResult {
-  1 : optional string token,
-  2 : optional TokenError error,
+struct GetWorkerNameResult {
+  1 : optional string workerName,
+  2 : optional WorkerNameError error,
 }
 
 enum JobStatus {
@@ -213,8 +213,8 @@ struct CommandResult {
   3 : optional i32 exitCode,
 }
 
-exception TokenNotFoundException {
-  1 : optional string token
+exception WorkerNameNotFoundException {
+  1 : optional string workerName
 }
 
 
@@ -223,11 +223,11 @@ exception TokenNotFoundException {
 **/
 service FuzzerService {
 
-  GetTokenResult getToken(1 : string platformInfo, 2 : string token),
+  GetWorkerNameResult getWorkerName(1 : string platformInfo, 2 : string workerName),
 
-  Job getJob(1 : string token) throws (1 : TokenNotFoundException ex),
+  Job getJob(1 : string workerName) throws (1 : WorkerNameNotFoundException ex),
 
-  void jobDone(1 : string token, 2 : Job job) throws (1 : TokenNotFoundException ex),
+  void jobDone(1 : string workerName, 2 : Job job) throws (1 : WorkerNameNotFoundException ex),
 }
 
 /**
@@ -254,7 +254,7 @@ service FuzzerServiceManager {
   /**
   * Submit a job (i.e. ImageJob) to a worker job queue.
   **/
-  Job submitJob(1 : Job job, 2 : string forClient, 3 : i32 retryLimit) throws (1 : TokenNotFoundException ex),
+  Job submitJob(1 : Job job, 2 : string forClient, 3 : i32 retryLimit) throws (1 : WorkerNameNotFoundException ex),
 
   /**
   * Clears a worker job queue.
@@ -269,7 +269,7 @@ service FuzzerServiceManager {
     1 : string name,
     // E.g. run_shader_family shaderfamilies/bbb --output processing/greylaptop/bbb_exp/
     2 : list<string> command,
-    // This should generally be set to the token.
+    // This should generally be set to the worker name
     3 : string queueName,
     // Optional: path to log file. E.g. processing/aaa/bbb_ccc_inv/command.log
     4 : string logFile),


### PR DESCRIPTION
Name more regularly what is a worker identifier, which used to be called a 'token'.
Token is replaced by 'worker' in most places, and by 'workerName' in the context where 'worker' could refer to a more general worker abstraction.
