### PR TITLE
Do not assume all images are actually produced/retrieved

### DIFF
--- a/python/src/main/python/drivers/vkrun.py
+++ b/python/src/main/python/drivers/vkrun.py
@@ -201,7 +201,11 @@ def run_android(vert, frag, json, skip_render):
             # different, or missing
             for i in range(1, NUM_RENDER):
                 next_image = resdir + '/image_{}.png'.format(i)
-                if not filecmp.cmp(ref_image, next_image, shallow=False):
+                if not os.path.exists(next_image):
+                    status = 'UNEXPECTED_ERROR'
+                    with open(LOGFILE, 'a') as f:
+                        f.write('\n Not all images are produce? Missing image: {}\n'.format(i))
+                elif not filecmp.cmp(ref_image, next_image, shallow=False):
                     status = 'NONDET'
                     shutil.copy(ref_image, 'nondet0.png')
                     shutil.copy(next_image, 'nondet1.png')


### PR DESCRIPTION
I've seen weird situtations on the Shield where the adb pull did not retrieve all images, or maybe some images were not even being produced. This fix avoids to crash the worker, and have to restart it again by hand, in such a case.