### PR TITLE
Fail when missing external storage permission

### DIFF
--- a/vulkan-worker/src/android/src/main/cpp/main.cc
+++ b/vulkan-worker/src/android/src/main/cpp/main.cc
@@ -134,7 +134,34 @@ void FreeGflagsArgs(int argc, char **argv) {
   free(argv);
 }
 
+bool CanReadWriteExternalStorage() {
+  static bool first_try = true;
+
+  if (!first_try) {
+    return true;
+  } else {
+    first_try = false;
+  }
+
+  const char* filename = "/sdcard/graphicsfuzz/test_permission";
+
+  FILE *f = fopen(filename, "w");
+
+  if (f == nullptr) {
+    return false;
+  } else {
+    fclose(f);
+    remove(filename);
+    return true;
+  }
+}
+
 void android_main(struct android_app* state) {
+
+  if (!CanReadWriteExternalStorage()) {
+    log("ERROR: cannot write in /sdcard/graphicsfuzz/, please double check App permission to access external storage");
+    std::terminate();
+  }
 
   // Reset all default values, as any change may survive the exiting of this
   // android_main() function and still be set when android_main() is called


### PR DESCRIPTION
It used to be a plain assertion failure, now we produce a better error message in the log.

Fix #124 . We could do a better job by using Java, but it would add a huge amount of code.
