### PR TITLE
Add minimal support for compute shaders

### DIFF
--- a/python/src/main/python/drivers/glsl-to-spv-worker.py
+++ b/python/src/main/python/drivers/glsl-to-spv-worker.py
@@ -268,6 +268,10 @@ def do_compute_job(args, comp_job):
             status = f.read().rstrip()
         if status == 'SUCCESS':
             res.status = tt.JobStatus.SUCCESS
+            assert(os.path.isfile('ssbo.json'))
+            with open('ssbo.json', 'r') as f:
+                res.computeOutputs = f.read()
+
         elif status == 'CRASH':
             res.status = tt.JobStatus.CRASH
         elif status == 'TIMEOUT':

--- a/python/src/main/python/drivers/vkrun.py
+++ b/python/src/main/python/drivers/vkrun.py
@@ -615,8 +615,10 @@ def ssbo_bin_to_json(ssbo_bin_file, ssbo_json_file):
         int_val = struct.unpack('<I', data[i:i + int_width])[0]
         ssbo.append(int_val)
 
+    ssbo_json_obj = { 'ssbo': ssbo }
+
     with open(ssbo_json_file, 'w') as f:
-        f.write(json.dumps(ssbo))
+        f.write(json.dumps(ssbo_json_obj))
 
 def run_compute(comp, comp_json):
     assert(os.path.isfile(comp))


### PR DESCRIPTION
These are minimal changes to get compute shader support via VkRunner.

It assumes SSBO and shader to operate on `int` type of 32 bits. It also assume the device in little endian (which is the case of virtually all device). The resulting SSBO values are provided in the '.info.json' file as:
` { [...], "outputs": { "ssbo": [1,2,3, ... ] } }`

There will be refactor once we have a better understanding of how we want to handle compute shaders, e.g. how to handle different types in SSBO, or resulting values.
