### PR TITLE
The parser now throws a specific exception for when a shader is not p…

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/tool/ReportShaderSize.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/tool/ReportShaderSize.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.common.tool;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.StatsVisitor;
@@ -27,7 +28,7 @@ public class ReportShaderSize {
 
 
   public static void main(String[] args) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
     if (args.length != 1) {
       System.err.println("Usage: ReportShaderSize <file>");
       System.exit(1);

--- a/ast/src/main/java/com/graphicsfuzz/common/util/GlslParserException.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/util/GlslParserException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.common.util;
+
+import com.graphicsfuzz.parser.GLSLParser;
+
+public class GlslParserException extends Exception {
+
+  private final GLSLParser parser;
+
+  public GlslParserException(GLSLParser parser) {
+    this.parser = parser;
+  }
+
+  /**
+   * Provides access to the parser instance that failed to parse the GLSL shader.
+   * @return Parser instance.
+   */
+  public GLSLParser getParser() {
+    return parser;
+  }
+
+  @Override
+  public String getMessage() {
+    return "Syntax errors occurred during parsing.";
+  }
+
+}

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/CompareAstsDuplicate.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/CompareAstsDuplicate.java
@@ -19,6 +19,7 @@ package com.graphicsfuzz.common.ast;
 import static org.junit.Assert.assertEquals;
 
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import java.io.IOException;
@@ -32,7 +33,7 @@ import java.io.IOException;
 public class CompareAstsDuplicate {
 
   public static void assertEqualAsts(String first, String second)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertEquals(
           PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(first)),
           PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(second))
@@ -40,12 +41,12 @@ public class CompareAstsDuplicate {
   }
 
   public static void assertEqualAsts(String string, TranslationUnit tu)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertEqualAsts(string, PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
 
   public static void assertEqualAsts(TranslationUnit first, TranslationUnit second)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertEqualAsts(PrettyPrinterVisitor.prettyPrintAsString(first),
           PrettyPrinterVisitor.prettyPrintAsString(second));
   }

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -46,6 +46,7 @@ import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.util.ExecHelper.RedirectType;
 import com.graphicsfuzz.util.ExecResult;
 import com.graphicsfuzz.common.util.OpenGlConstants;
@@ -469,7 +470,8 @@ public class TyperTest {
   }
 
   private void checkComputeShaderBuiltin(String builtin, String builtinConstant, BasicType baseType,
-      TypeQualifier qualifier) throws IOException, ParseTimeoutException, InterruptedException {
+      TypeQualifier qualifier) throws IOException, ParseTimeoutException, InterruptedException,
+      GlslParserException {
     TranslationUnit tu = ParseHelper.parse("void main() { " + builtin + "; }");
     Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_310);
     new StandardVisitor() {

--- a/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
@@ -467,26 +467,16 @@ public class ParseHelperTest {
         }.test(ParseHelper.parse(program)));
   }
 
-  @Test
+  @Test(expected = GlslParserException.class)
   public void testDoNotParseBadSignedConstant() throws Exception {
     // Check that lexing of hex constants is working OK.
-    try {
-      ParseHelper.parse("int foo() { return 0x120x12; }");
-      fail("Should not manage to parse.");
-    } catch (RuntimeException runtimeException) {
-      assertTrue(runtimeException.getMessage().startsWith("Syntax errors occurred during parsing"));
-    }
+    ParseHelper.parse("int foo() { return 0x120x12; }");
   }
 
-  @Test
+  @Test(expected = GlslParserException.class)
   public void testDoNotParseBadUnsignedConstant() throws Exception {
     // Check that lexing of hex constants is working OK.
-    try {
-      ParseHelper.parse("uint foo() { return 0x120x12u; }");
-      fail("Should not manage to parse.");
-    } catch (RuntimeException runtimeException) {
-      assertTrue(runtimeException.getMessage().startsWith("Syntax errors occurred during parsing"));
-    }
+    ParseHelper.parse("uint foo() { return 0x120x12u; }");
   }
 
   @Test

--- a/ast/src/test/java/com/graphicsfuzz/common/util/TruncateLoopsTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/util/TruncateLoopsTest.java
@@ -59,7 +59,7 @@ public class TruncateLoopsTest {
   }
 
   private void testProgram(String program, boolean isSane) throws IOException,
-      ParseTimeoutException, InterruptedException {
+      ParseTimeoutException, InterruptedException, GlslParserException {
     TranslationUnit tu =  ParseHelper.parse(program);
     new TruncateLoops(30, "webGL_", tu, true);
     if(isSane) {
@@ -73,7 +73,7 @@ public class TruncateLoopsTest {
   }
 
   private void assertProgramsNotEqual(String program, TranslationUnit otherProgram)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assert !PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program))
         .equals(PrettyPrinterVisitor.prettyPrintAsString(otherProgram));
   }

--- a/common/src/main/java/com/graphicsfuzz/common/util/AddBraces.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/AddBraces.java
@@ -99,7 +99,7 @@ public final class AddBraces {
   }
 
   public static void main(String[] args) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
     TranslationUnit tu = ParseHelper.parse(new File(args[0]));
     new PrettyPrinterVisitor(System.out).visit(transform(tu));
   }

--- a/common/src/main/java/com/graphicsfuzz/common/util/Obfuscator.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/Obfuscator.java
@@ -286,7 +286,7 @@ public class Obfuscator {
   }
 
   public static void main(String[] args)
-        throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final File shader = new File(args[0]);
     final String licenseFilename = args[1];
     ExecResult execResult = new ExecHelper().exec(

--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -455,7 +455,7 @@ public class ShaderJobFileOperations {
   }
 
   public ShaderJob readShaderJobFile(File shaderJobFile)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
 
     assertIsShaderJobFile(shaderJobFile);
 

--- a/common/src/test/java/com/graphicsfuzz/common/util/ObfuscatorTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/ObfuscatorTest.java
@@ -129,7 +129,7 @@ public class ObfuscatorTest {
   }
 
   private void check(String original, String expected) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
     final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(), new UniformsInfo(),
         ParseHelper.parse(original));
     final IRandom generator = new ZeroCannedRandom();

--- a/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
@@ -181,7 +181,7 @@ public class PruneUniformsTest {
 
   private void doPruneTest(String program, String uniforms, String expectedProgram,
         String expectedUniforms, List<String> prefixList, int limit)
-        throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
 
     final File uniformsFile = temporaryFolder.newFile("uniforms.json");
     FileUtils.writeStringToFile(uniformsFile, uniforms, StandardCharsets.UTF_8);

--- a/compare-asts/src/main/java/com/graphicsfuzz/common/util/CompareAsts.java
+++ b/compare-asts/src/main/java/com/graphicsfuzz/common/util/CompareAsts.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 public class CompareAsts {
 
   public static void assertEqualAsts(String first, String second)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertEquals(
           PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(first)),
           PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(second))
@@ -33,25 +33,25 @@ public class CompareAsts {
   }
 
   public static void assertEqualAsts(String string, TranslationUnit tu)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertEqualAsts(string, PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
 
   public static void assertEqualAsts(TranslationUnit first, TranslationUnit second)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertEqualAsts(PrettyPrinterVisitor.prettyPrintAsString(first),
           PrettyPrinterVisitor.prettyPrintAsString(second));
   }
 
   public static boolean isEqualAsts(String first, String second) throws IOException,
-      ParseTimeoutException, InterruptedException {
+      ParseTimeoutException, InterruptedException, GlslParserException {
     return PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(first))
         .equals(
             PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(second)));
   }
 
   public static boolean isEqualAsts(String first, TranslationUnit second) throws IOException,
-      ParseTimeoutException, InterruptedException {
+      ParseTimeoutException, InterruptedException, GlslParserException {
     return isEqualAsts(first, PrettyPrinterVisitor.prettyPrintAsString(second));
   }
 

--- a/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/ShaderProducer.java
+++ b/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/ShaderProducer.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.generator;
 
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.RandomWrapper;
@@ -126,8 +127,8 @@ public class ShaderProducer implements Runnable {
         }
         LOGGER.info("Sent shader job " + sent + ".");
         sent++;
-      } catch (ParseTimeoutException | IOException | AssertionError
-          | InterruptedException exception) {
+      } catch (ParseTimeoutException | IOException | AssertionError | InterruptedException
+          | GlslParserException exception) {
         // Something went wrong - log the details and move on.
         LOGGER.error("Error during generation.", exception);
       }

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
@@ -25,6 +25,7 @@ import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.typing.Typer;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -213,6 +214,7 @@ public class Generate {
    * @throws ParseTimeoutException if parsing takes too long.
    * @throws InterruptedException if something goes wrong invoking an external tool such as the
    *      preprocessor or validator.
+   * @throws GlslParserException if a shader in the job fails to parse.
    */
   public static void generateVariant(ShaderJobFileOperations fileOps,
                                      File referenceShaderJobFile,
@@ -220,7 +222,7 @@ public class Generate {
                                      GeneratorArguments generatorArguments,
                                      int seed,
                                      boolean writeProbabilities)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     // This is mutated into the variant.
     final ShaderJob variantShaderJob = fileOps.readShaderJobFile(referenceShaderJobFile);
 
@@ -312,7 +314,8 @@ public class Generate {
   }
 
   public static void mainHelper(String[] args)
-      throws IOException, ParseTimeoutException, ArgumentParserException, InterruptedException {
+      throws IOException, ParseTimeoutException, ArgumentParserException, InterruptedException,
+      GlslParserException {
     final Namespace ns = parse(args);
 
     Integer seed = ns.get("seed");

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/GlslGenerate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/GlslGenerate.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.generator.tool;
 
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.RandomWrapper;
@@ -72,7 +73,7 @@ public class GlslGenerate {
   }
 
   public static void mainHelper(String[] args) throws ArgumentParserException,
-      InterruptedException, IOException, ParseTimeoutException {
+      InterruptedException, IOException, ParseTimeoutException, GlslParserException {
     final Namespace ns = parse(args);
 
     final File referencesDir = ns.get("references");
@@ -111,7 +112,12 @@ public class GlslGenerate {
         LOGGER.info("Generating a shader family: " + generateShaderFamilyArgs.stream()
             .reduce((String item1, String item2) -> item1 + " " + item2).orElse(""));
       }
-      GenerateShaderFamily.mainHelper(generateShaderFamilyArgs.toArray(new String[0]));
+      try {
+        GenerateShaderFamily.mainHelper(generateShaderFamilyArgs.toArray(new String[0]));
+      } catch (ReferencePreparationException referencePreparationException) {
+        LOGGER.info("Generation of shader family was aborted due to problems preparing the "
+            + "reference.");
+      }
     }
     LOGGER.info("Generation complete.");
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.generator.tool;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.common.util.UniformsInfo;
@@ -76,14 +77,15 @@ public final class PrepareReference {
     } catch (ArgumentParserException exception) {
       exception.getParser().handleError(exception);
       System.exit(1);
-    } catch (IOException | ParseTimeoutException | InterruptedException exception) {
+    } catch (IOException | ParseTimeoutException | InterruptedException
+        | GlslParserException exception) {
       exception.printStackTrace();
       System.exit(1);
     }
   }
 
   public static void mainHelper(String[] args) throws ArgumentParserException, IOException,
-      ParseTimeoutException, InterruptedException {
+      ParseTimeoutException, InterruptedException, GlslParserException {
 
     Namespace ns = parse(args);
 
@@ -107,7 +109,7 @@ public final class PrepareReference {
       int maxUniforms,
       boolean generateUniformBindings,
       ShaderJobFileOperations fileOps) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
 
     final ShaderJob shaderJob = fileOps.readShaderJobFile(referenceShaderJobFile);
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/ReferencePreparationException.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/ReferencePreparationException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.generator.tool;
+
+public class ReferencePreparationException extends Exception {
+
+  private final Exception exception;
+
+  /**
+   * Wraps an exception that occurred during preparation of a reference.
+   * @param exception An exception that occurred during preparation of a reference.
+   */
+  public ReferencePreparationException(Exception exception) {
+    this.exception = exception;
+  }
+
+  /**
+   * Provides the exception that was responsible for reference preparation failing.
+   * @return the wrapped exception.
+   */
+  public Exception getException() {
+    return exception;
+  }
+
+}

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/donation/DonateCode.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/donation/DonateCode.java
@@ -43,6 +43,7 @@ import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.typing.ScopeTreeBuilder;
 import com.graphicsfuzz.common.typing.Typer;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.OpenGlConstants;
@@ -109,7 +110,7 @@ public abstract class DonateCode implements ITransformation {
   abstract void adaptTranslationUnitForSpecificDonation(TranslationUnit tu, IRandom generator);
 
   private TranslationUnit prepareTranslationUnit(File donorFile, IRandom generator)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     TranslationUnit tu = ParseHelper.parse(donorFile);
     addPrefixes(tu, getDeclaredFunctionNames(tu));
     // Add prefixed versions of these builtins, in case they are used
@@ -595,7 +596,8 @@ public abstract class DonateCode implements ITransformation {
         globalVariables.putAll(getGlobalVariablesFromShader(donor));
         structNames.addAll(getStructNamesFromShader(donor));
         donorsToTranslationUnits.put(donorFile, donor);
-      } catch (IOException | ParseTimeoutException | InterruptedException exception) {
+      } catch (IOException | ParseTimeoutException | InterruptedException
+          | GlslParserException exception) {
         throw new RuntimeException("An exception occurred during donor parsing.", exception);
       }
     }

--- a/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/templates/VariableIdentifierExprTemplateTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/templates/VariableIdentifierExprTemplateTest.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.generator.fuzzer.templates;
 
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import java.io.IOException;
@@ -71,7 +72,8 @@ public class VariableIdentifierExprTemplateTest {
     assertTrue(getTemplateFromSingleDeclarationProgram(program).isLValue());
   }
 
-  public VariableIdentifierExprTemplate getTemplateFromSingleDeclarationProgram(String program) throws IOException, ParseTimeoutException, InterruptedException {
+  public VariableIdentifierExprTemplate getTemplateFromSingleDeclarationProgram(String program)
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final VariablesDeclaration variablesDeclaration =
         (VariablesDeclaration) ParseHelper.parse(program).getTopLevelDeclarations().get(0);
     return new VariableIdentifierExprTemplate(variablesDeclaration.getDeclInfo(0).getName(),

--- a/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
@@ -16,14 +16,12 @@
 
 package com.graphicsfuzz.generator.tool;
 
-import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.util.ToolPaths;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import org.junit.Ignore;
@@ -147,7 +145,7 @@ public class GenerateShaderFamilyTest {
   private void checkShaderFamilyGeneration(String samplesSubdir, String referenceShaderName,
                                           int numVariants, int seed,
                                           List<String> extraOptions) throws ArgumentParserException,
-      InterruptedException, IOException, ParseTimeoutException {
+      InterruptedException, IOException, ReferencePreparationException {
     final String reference = Paths.get(ToolPaths.getShadersDirectory(), "samples",
         samplesSubdir, referenceShaderName
         + ".json").toString();

--- a/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateTest.java
@@ -20,6 +20,7 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -254,7 +255,7 @@ public class GenerateTest {
     testValidityOfVertexShaderTransformations(Arrays.asList("--enable-only", "jump"), 5);
   }
 
-  private void testValidityOfVertexShaderTransformations(List<String> extraArgs, int repeatCount) throws IOException, InterruptedException, ParseTimeoutException, ArgumentParserException {
+  private void testValidityOfVertexShaderTransformations(List<String> extraArgs, int repeatCount) throws IOException, InterruptedException, ParseTimeoutException, ArgumentParserException, GlslParserException {
 
     ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
     // TODO: Use fileOps more.

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/CheckAstFeaturesFileJudge.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/CheckAstFeaturesFileJudge.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.reducer;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.common.util.ShaderKind;
@@ -52,7 +53,8 @@ public class CheckAstFeaturesFileJudge implements IFileJudge {
       assert shaderJob.getShaders().size() == 1;
       final TranslationUnit tu = shaderJob.getShaders().get(0);
       return visitorSuppliers.stream().allMatch(item -> item.get().check(tu));
-    } catch (IOException | ParseTimeoutException | InterruptedException exception) {
+    } catch (IOException | ParseTimeoutException | InterruptedException
+        | GlslParserException exception) {
       throw new RuntimeException(exception);
     }
   }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.reducer.tool;
 
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -215,7 +216,8 @@ public class GlslReduce {
   public static void mainHelper(
         String[] args,
         FuzzerServiceManager.Iface managerOverride)
-      throws ArgumentParserException, IOException, ParseTimeoutException, InterruptedException {
+      throws ArgumentParserException, IOException, ParseTimeoutException, InterruptedException,
+      GlslParserException {
 
     ArgumentParser parser = getParser();
 
@@ -436,17 +438,17 @@ public class GlslReduce {
           verbose,
           fileOps);
 
-    } catch (Throwable ex) {
+    } catch (Throwable throwable) {
 
       final File exceptionFile =
           ReductionProgressHelper.getReductionExceptionFile(workDir, shaderJobShortName);
 
       fileOps.writeStringToFile(
           exceptionFile,
-          ExceptionUtils.getStackTrace(ex)
+          ExceptionUtils.getStackTrace(throwable)
       );
 
-      throw ex;
+      throw throwable;
     }
   }
 
@@ -461,7 +463,7 @@ public class GlslReduce {
       boolean continuePreviousReduction,
       boolean verbose,
       ShaderJobFileOperations fileOps)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final ShadingLanguageVersion shadingLanguageVersion =
         getGlslVersionForShaderJob(initialShaderJobFile, fileOps);
     final IRandom random = new RandomWrapper(seed);

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/ReducerBugPoint.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/ReducerBugPoint.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.reducer.tool;
 
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.RandomWrapper;
@@ -89,7 +90,8 @@ public class ReducerBugPoint {
 
 
   public static void main(String[] args)
-      throws IOException, ParseTimeoutException, ArgumentParserException, InterruptedException {
+      throws IOException, ParseTimeoutException, ArgumentParserException, InterruptedException,
+      GlslParserException {
 
     final Namespace ns = parse(args);
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/ReducerBugPointBasic.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/ReducerBugPointBasic.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.reducer.tool;
 
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -80,7 +81,8 @@ public class ReducerBugPointBasic {
 
 
   public static void main(String[] args)
-      throws IOException, ParseTimeoutException, InterruptedException, ArgumentParserException {
+      throws IOException, ParseTimeoutException, InterruptedException, ArgumentParserException,
+      GlslParserException {
 
     final Namespace ns = parse(args);
 
@@ -247,7 +249,7 @@ public class ReducerBugPointBasic {
       ShaderJob shaderJob,
       Exception exception,
       ShaderJobFileOperations fileOps) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
     File tempShaderJobFile = new File("temp.json");
 
     fileOps.writeShaderJobFile(

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/Simplifier.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/Simplifier.java
@@ -20,6 +20,7 @@ import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.common.util.ShaderKind;
@@ -36,7 +37,7 @@ public class Simplifier {
   private static final Logger LOGGER = LoggerFactory.getLogger(Simplifier.class);
 
   public static void main(String[] args) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
     if (args.length != 1) {
       System.err.println("Usage: Simplifier <file>.json");
       System.exit(1);

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
@@ -27,6 +27,7 @@ import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.util.Constants;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
@@ -174,7 +175,7 @@ public class ReductionDriverTest {
 
   private String reduce(IFileJudge judge, String program, String jsonString,
                         boolean reduceEverywhere)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     return reduce(judge, program, jsonString, reduceEverywhere,
           -1, 0);
   }
@@ -183,7 +184,7 @@ public class ReductionDriverTest {
                         boolean reduceEverywhere,
                         int stepLimit,
                         int seed)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     return reduce(judge, fragmentShader, Optional.empty(), jsonString,
         reduceEverywhere,
         stepLimit,
@@ -197,7 +198,7 @@ public class ReductionDriverTest {
                         boolean reduceEverywhere,
                         int stepLimit,
                         int seed)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     assertFalse(new File(testFolder.getRoot(), "temp.frag").exists());
     File tempFragmentShaderFile = testFolder.newFile("temp.frag");
     Optional<File> tempVertexShaderFile = vertexShader.isPresent() ?

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundExprToSubExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundExprToSubExprReductionOpportunitiesTest.java
@@ -19,6 +19,7 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.RandomWrapper;
@@ -82,7 +83,7 @@ public class CompoundExprToSubExprReductionOpportunitiesTest {
   }
 
   private void check(boolean reduceEverywhere, String original, String... expected)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<SimplifyExprReductionOpportunity> ops =
           getOps(tu, reduceEverywhere);

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunitiesTest.java
@@ -19,6 +19,7 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.util.Constants;
 import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.ParseHelper;
@@ -409,7 +410,7 @@ public class CompoundToBlockReductionOpportunitiesTest {
   }
 
   private void check(boolean reduceEverywhere, String original, String... expected)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<CompoundToBlockReductionOpportunity> ops =
           getOps(tu, reduceEverywhere);

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunitiesTest.java
@@ -19,6 +19,7 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import java.io.IOException;
@@ -550,7 +551,7 @@ public class FoldConstantReductionOpportunitiesTest {
 
 
   private void check(String before, int numOps, String after) throws IOException,
-      ParseTimeoutException, InterruptedException {
+      ParseTimeoutException, InterruptedException, GlslParserException {
     final TranslationUnit tu = ParseHelper.parse(before);
     final List<SimplifyExprReductionOpportunity> ops = FoldConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineUniformReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineUniformReductionOpportunitiesTest.java
@@ -22,6 +22,7 @@ import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.RandomWrapper;
@@ -195,7 +196,7 @@ public class InlineUniformReductionOpportunitiesTest {
   }
 
   private ShaderJob checkCanReduceToTarget(ShaderJob shaderJob, int expectedSize, String target)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     boolean found = false;
     for (int i = 0; i < expectedSize; i++) {
       final ShaderJob temp = shaderJob.clone();

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.util.Constants;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
@@ -503,7 +504,7 @@ public class ReductionOpportunitiesTest {
   }
 
   private void tryAllCompatibleOpportunities(String program)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     TranslationUnit tu = ParseHelper.parse(program);
     int numOps = ReductionOpportunities.getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
           new ReducerContext(false,

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/tool/GlslReduceTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/tool/GlslReduceTest.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.reducer.tool;
 
 import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
@@ -155,7 +156,8 @@ public class GlslReduceTest {
         ParseHelper.parse(reducedFinal[0]));
   }
 
-  private File getShaderJobReady() throws IOException, ParseTimeoutException, InterruptedException {
+  private File getShaderJobReady() throws IOException, ParseTimeoutException, InterruptedException,
+      GlslParserException {
     final String fragmentShader = "#version 100\n" +
         "int a;" +
         "int b;" +

--- a/server/src/main/java/com/graphicsfuzz/server/GraphicsFuzzServerCommandDispatcher.java
+++ b/server/src/main/java/com/graphicsfuzz/server/GraphicsFuzzServerCommandDispatcher.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.server;
 
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.reducer.tool.GlslReduce;
 import com.graphicsfuzz.server.thrift.FuzzerServiceManager.Iface;
@@ -29,8 +30,8 @@ public class GraphicsFuzzServerCommandDispatcher implements ICommandDispatcher {
 
   @Override
   public void dispatchCommand(List<String> command, Iface fuzzerServiceManager)
-        throws ShaderDispatchException, ArgumentParserException, InterruptedException,
-        IOException, ParseTimeoutException {
+      throws ShaderDispatchException, ArgumentParserException, InterruptedException,
+      IOException, ParseTimeoutException, GlslParserException {
     switch (command.get(0)) {
       case "run_shader_family":
         RunShaderFamily.mainHelper(

--- a/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.util.Constants;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.util.AvoidDeprecatedGlFragColor;
@@ -201,7 +202,7 @@ public class GeneratorUnitTest {
   private void testTransformation(List<ITransformationSupplier> transformations,
         TransformationProbabilities probabilities, String suffix, List<String> blacklist,
         ShadingLanguageVersion shadingLanguageVersion)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     for (File originalShaderJobFile : Util.getReferenceShaderJobFiles()) {
       final List<ITransformation> transformationsList = new ArrayList<>();
       for (ITransformationSupplier supplier : transformations) {
@@ -229,14 +230,14 @@ public class GeneratorUnitTest {
 
   private void testTransformation100(List<ITransformationSupplier> transformations,
         TransformationProbabilities probabilities, String suffix, List<String> blacklist)
-        throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformation(transformations, probabilities, suffix, blacklist,
           ShadingLanguageVersion.ESSL_100);
   }
 
   private void testTransformation300es(List<ITransformationSupplier> transformations,
         TransformationProbabilities probabilities, String suffix, List<String> blacklist)
-        throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformation(transformations, probabilities, suffix, blacklist,
           ShadingLanguageVersion.ESSL_300);
   }
@@ -246,7 +247,7 @@ public class GeneratorUnitTest {
                                                String suffix,
                                                List<String> blacklist100,
                                                List<String> blacklist300es)
-        throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformation100(transformations, probabilities, suffix, blacklist100);
     testTransformation300es(transformations, probabilities, suffix, blacklist300es);
   }
@@ -255,21 +256,21 @@ public class GeneratorUnitTest {
       TransformationProbabilities probabilities, String suffix,
                                                List<String> blacklist100,
                                                List<String> blacklist300es)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformationMultiVersions(Arrays.asList(transformation), probabilities,
         suffix, blacklist100, blacklist300es);
   }
 
   private void testTransformationMultiVersions(List<ITransformationSupplier> transformations,
         TransformationProbabilities probabilities, String suffix)
-        throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformationMultiVersions(transformations, probabilities, suffix, new ArrayList<>(),
         new ArrayList<>());
   }
 
   private void testTransformationMultiVersions(ITransformationSupplier transformation,
       TransformationProbabilities probabilities, String suffix)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformationMultiVersions(Arrays.asList(transformation), probabilities, suffix,
         new ArrayList<>(), new ArrayList<>());
   }
@@ -278,7 +279,8 @@ public class GeneratorUnitTest {
       TransformationProbabilities probabilities, String suffix, File originalShaderJobFile,
       ShadingLanguageVersion shadingLanguageVersion,
       File referenceImage,
-      boolean skipRender) throws IOException, ParseTimeoutException, InterruptedException {
+      boolean skipRender)
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final ShaderJob shaderJob = fileOps.readShaderJobFile(originalShaderJobFile);
     assertEquals(1, shaderJob.getShaders().size());
     assertEquals(ShaderKind.FRAGMENT, shaderJob.getShaders().get(0).getShaderKind());

--- a/tester/src/test/java/com/graphicsfuzz/tester/MiscellaneousGenerateThenReduceTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/MiscellaneousGenerateThenReduceTest.java
@@ -20,6 +20,7 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -61,7 +62,7 @@ public class MiscellaneousGenerateThenReduceTest {
   }
 
   private void checkControlFlowWrapElimination(String program)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     TranslationUnit tu = ParseHelper.parse(program);
 
     final ShadingLanguageVersion shadingLanguageVersion = ShadingLanguageVersion.GLSL_440;

--- a/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
@@ -26,6 +26,7 @@ import com.graphicsfuzz.common.ast.expr.MemberLookupExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.reducer.tool.GlslReduce;
 import com.graphicsfuzz.util.Constants;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
@@ -146,7 +147,7 @@ public class ReducerUnitTest {
   private TranslationUnit generateSizeLimitedShader(File fragmentShader,
       List<ITransformationSupplier> transformations, IRandom generator,
       ShadingLanguageVersion shadingLanguageVersion) throws IOException, ParseTimeoutException,
-      InterruptedException {
+      InterruptedException, GlslParserException {
     while (true) {
       List<ITransformationSupplier> transformationsCopy = new ArrayList<>();
       transformationsCopy.addAll(transformations);
@@ -374,7 +375,7 @@ public class ReducerUnitTest {
   }
 
   private String runReductionOnShader(File shaderJobFile, IFileJudge fileJudge)
-      throws IOException, ParseTimeoutException, InterruptedException {
+      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final String shaderJobShortName = FilenameUtils.removeExtension(shaderJobFile.getName());
     final ShadingLanguageVersion version =
         ShadingLanguageVersion.getGlslVersionFromFirstTwoLines(

--- a/tester/src/test/java/com/graphicsfuzz/tester/Util.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/Util.java
@@ -20,6 +20,7 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.util.FileHelper;
+import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ImageUtil;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
@@ -54,7 +55,7 @@ public final class Util {
   static File renderShader(ShadingLanguageVersion shadingLanguageVersion,
                            File originalShader,
                            TemporaryFolder temporaryFolder, ShaderJobFileOperations fileOps)
-      throws IOException, InterruptedException, ParseTimeoutException {
+      throws IOException, InterruptedException, ParseTimeoutException, GlslParserException {
     final ShaderJob shaderJob = fileOps.readShaderJobFile(originalShader);
 
     // TODO: having to plug in the version here feels like a hack.  But this is due to the


### PR DESCRIPTION
…arsable.  This means that when generating a shader family we can detect when the reference is bad, abort generation of the family, clean up, and proceed to the next family.