### PR TITLE
Allow disabling validation

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/GenerateShaderFamily.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/GenerateShaderFamily.java
@@ -347,9 +347,9 @@ public class GenerateShaderFamily {
       throws IOException, InterruptedException {
 
     final boolean shaderJobIsValid =
-      (disableGlslangValidator || fileOps.areShadersValid(variantShaderJobFile, false))
+        (disableGlslangValidator || fileOps.areShadersValid(variantShaderJobFile, false))
           &&
-      (disableShaderTranslator || fileOps.areShadersValidShaderTranslator(variantShaderJobFile,
+        (disableShaderTranslator || fileOps.areShadersValidShaderTranslator(variantShaderJobFile,
           false));
 
     if (!shaderJobIsValid) {

--- a/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import org.apache.commons.io.FileUtils;
@@ -164,7 +165,9 @@ public class GenerateShaderFamilyTest {
 
     final String donors = Paths.get(ToolPaths.getShadersDirectory(),"samples",
         "donors").toString();
-    checkShaderFamilyGeneration(2, 0, new ArrayList<>(), referenceJsonFile.getAbsolutePath(), donors);
+    checkShaderFamilyGeneration(2, 0, Collections.singletonList("--disable-shader-translator"),
+        referenceJsonFile.getAbsolutePath(),
+        donors);
   }
 
   private void checkShaderFamilyGeneration(String samplesSubdir, String referenceShaderName,

--- a/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
@@ -165,7 +165,33 @@ public class GenerateShaderFamilyTest {
 
     final String donors = Paths.get(ToolPaths.getShadersDirectory(),"samples",
         "donors").toString();
+    // Disable shader_translator, so we should still get family generated
     checkShaderFamilyGeneration(2, 0, Collections.singletonList("--disable-shader-translator"),
+        referenceJsonFile.getAbsolutePath(),
+        donors);
+  }
+
+  @Test
+  public void testIgnoreGlslangValidator() throws Exception {
+    // shader_translator will not be invoked on this shader, and glslangValidator would reject it
+    // due to it using a made up extension.
+    final String reference = "#version 440\n"
+        + "#extension does_not_exist : nothing\n"
+        + "\n"
+        + "precision mediump float;\n"
+        + "void main() {\n"
+        + "}\n";
+    final File referenceFragFile = temporaryFolder.newFile("reference.frag");
+    final File referenceJsonFile = temporaryFolder.newFile("reference.json");
+    FileUtils.writeStringToFile(referenceFragFile, reference, StandardCharsets.UTF_8);
+    FileUtils.writeStringToFile(referenceJsonFile, "{}", StandardCharsets.UTF_8);
+
+    final String donors = Paths.get(ToolPaths.getShadersDirectory(),"samples",
+        "donors").toString();
+    // Disabling glslangValidator should lead to a family being generated, as the rest of the tool
+    // chain will just ignore the imaginary extension.
+    checkShaderFamilyGeneration(2, 0,
+        Collections.singletonList("--disable-glslangValidator"),
         referenceJsonFile.getAbsolutePath(),
         donors);
   }


### PR DESCRIPTION
Provides options for disabling shader_translator and/or glslangValidator.  Allows us to work around limitations in these tools if needed.