### PR TITLE
Fixes issues that were blocking handling of shaders in the wild.

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/TranslationUnit.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/TranslationUnit.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.common.ast;
 
 import com.graphicsfuzz.common.ast.decl.Declaration;
+import com.graphicsfuzz.common.ast.decl.PrecisionDeclaration;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.type.StructDefinitionType;

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/TranslationUnit.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/TranslationUnit.java
@@ -17,7 +17,6 @@
 package com.graphicsfuzz.common.ast;
 
 import com.graphicsfuzz.common.ast.decl.Declaration;
-import com.graphicsfuzz.common.ast.decl.PrecisionDeclaration;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.type.StructDefinitionType;

--- a/common/src/main/java/com/graphicsfuzz/common/transformreduce/GlslShaderJob.java
+++ b/common/src/main/java/com/graphicsfuzz/common/transformreduce/GlslShaderJob.java
@@ -126,6 +126,13 @@ public class GlslShaderJob implements ShaderJob {
             } while (usedBindings.contains(nextBinding));
           }
           final int binding = pipelineInfo.getBinding(uniformName);
+
+          // Keep any qualifiers apart from "uniform".
+          final QualifiedType memberType = new QualifiedType(qualifiedType.getWithoutQualifiers(),
+              qualifiedType.getQualifiers()
+                  .stream()
+                  .filter(item -> item != TypeQualifier.UNIFORM)
+                  .collect(Collectors.toList()));
           newTopLevelDeclarations.add(
               new InterfaceBlock(
                   Optional.of(new LayoutQualifierSequence(new SetLayoutQualifier(0),


### PR DESCRIPTION
Fixed pretty-printing of for loop with empty header, and removed some assumptions about available precision that were being made when 'injectionSwitch' or structs were added.