### PR TITLE
Changed BoolConstantExpr so that instead of having two static instanc…

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/ParentMap.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/ParentMap.java
@@ -16,6 +16,8 @@
 
 package com.graphicsfuzz.common.ast;
 
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
+import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +46,13 @@ class ParentMap extends StandardVisitor implements IParentMap {
   protected <T extends IAstNode> void visitChildFromParent(Consumer<T> visitorMethod, T child,
       IAstNode parent) {
     super.visitChildFromParent(visitorMethod, child, parent);
+    // TODO(279): right now there are deliberately cases where a child can have a non-unique parent.
+    // We may want to reconsider this.
+    assert child instanceof Type
+        || child instanceof ArrayInfo
+        || !childToParent.containsKey(child) : "There should be no "
+        + "aliasing in the AST with the exception of types; found multiple parents for '" + child
+        + "' which has class " + child.getClass() + ".";
     childToParent.put(child, parent);
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/BoolConstantExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/BoolConstantExpr.java
@@ -21,11 +21,10 @@ import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 
 public class BoolConstantExpr extends ConstantExpr {
 
-  public static final BoolConstantExpr TRUE = new BoolConstantExpr();
-  public static final BoolConstantExpr FALSE = new BoolConstantExpr();
+  private final boolean isTrue;
 
-  private BoolConstantExpr() {
-
+  public BoolConstantExpr(boolean isTrue) {
+    this.isTrue = isTrue;
   }
 
   @Override
@@ -40,16 +39,16 @@ public class BoolConstantExpr extends ConstantExpr {
 
   @Override
   public BoolConstantExpr clone() {
-    return this;
+    return new BoolConstantExpr(isTrue);
   }
 
   @Override
   public String toString() {
-    if (this == TRUE) {
-      return "true";
-    }
-    assert this == FALSE;
-    return "false";
+    return isTrue ? "true" : "false";
+  }
+
+  public boolean getIsTrue() {
+    return isTrue;
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/ReturnRemover.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/ReturnRemover.java
@@ -152,7 +152,8 @@ public class ReturnRemover {
       }
 
       private ExprStmt setHasReturned() {
-        return new ExprStmt(new BinaryExpr(makeHasReturned(), BoolConstantExpr.TRUE, BinOp.ASSIGN));
+        return new ExprStmt(new BinaryExpr(makeHasReturned(), new BoolConstantExpr(true),
+            BinOp.ASSIGN));
       }
     }.visit(fd);
   }
@@ -167,7 +168,7 @@ public class ReturnRemover {
     fd.getBody().insertStmt(0, new DeclarationStmt(
           new VariablesDeclaration(BasicType.BOOL,
                 new VariableDeclInfo(makeHasReturnedName(), null,
-                      new ScalarInitializer(BoolConstantExpr.FALSE)))));
+                      new ScalarInitializer(new BoolConstantExpr(false))))));
   }
 
   private void addReturnInstrumentation() {

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
@@ -162,7 +162,7 @@ public class BasicType extends BuiltinType {
       return new UIntConstantExpr("1u");
     }
     if (this == BOOL) {
-      return BoolConstantExpr.TRUE;
+      return new BoolConstantExpr(true);
     }
     return new TypeConstructorExpr(toString().toString(), getElementType().getCanonicalConstant());
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -1077,10 +1077,10 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     }
     if (ctx.BOOLCONSTANT() != null) {
       if (ctx.BOOLCONSTANT().getText().equals("true")) {
-        return BoolConstantExpr.TRUE;
+        return new BoolConstantExpr(true);
       }
       assert (ctx.BOOLCONSTANT().getText().equals("false"));
-      return BoolConstantExpr.FALSE;
+      return new BoolConstantExpr(false);
     }
     assert ctx.LPAREN() != null;
     return new ParenExpr(visitExpression(ctx.expression()));

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
@@ -315,6 +315,7 @@ public abstract class StandardVisitor implements IAstVisitor {
   public void visitParameterDecl(ParameterDecl parameterDecl) {
     visitChildFromParent(parameterDecl.getType(), parameterDecl);
     if (parameterDecl.getArrayInfo() != null) {
+      // Only visit the parameter's array information if there actually is array information.
       visitChildFromParent(this::visitArrayInfo, parameterDecl.getArrayInfo(), parameterDecl);
     }
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
@@ -314,7 +314,9 @@ public abstract class StandardVisitor implements IAstVisitor {
   @Override
   public void visitParameterDecl(ParameterDecl parameterDecl) {
     visitChildFromParent(parameterDecl.getType(), parameterDecl);
-    visitChildFromParent(this::visitArrayInfo, parameterDecl.getArrayInfo(), parameterDecl);
+    if (parameterDecl.getArrayInfo() != null) {
+      visitChildFromParent(this::visitArrayInfo, parameterDecl.getArrayInfo(), parameterDecl);
+    }
   }
 
   @Override

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/expr/BinaryExprTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/expr/BinaryExprTest.java
@@ -29,7 +29,7 @@ public class BinaryExprTest {
     VariableIdentifierExpr vie = new VariableIdentifierExpr("x");
     BinaryExpr be = new BinaryExpr(
         vie,
-        BoolConstantExpr.TRUE,
+        new BoolConstantExpr(true),
         BinOp.LAND);
     assertEquals(vie, be.getLhs());
   }
@@ -117,22 +117,22 @@ public class BinaryExprTest {
 
   @Test
   public void getNumChildren() throws Exception {
-    BinaryExpr be = new BinaryExpr(BoolConstantExpr.TRUE,
-        BoolConstantExpr.FALSE, BinOp.LXOR);
+    BinaryExpr be = new BinaryExpr(new BoolConstantExpr(true),
+        new BoolConstantExpr(false), BinOp.LXOR);
     assertEquals(2, be.getNumChildren());
   }
 
   @Test(expected = IndexOutOfBoundsException.class)
   public void getChildBad() {
-    new BinaryExpr(BoolConstantExpr.TRUE,
-        BoolConstantExpr.FALSE, BinOp.LXOR).getChild(2);
+    new BinaryExpr(new BoolConstantExpr(true),
+        new BoolConstantExpr(false), BinOp.LXOR).getChild(2);
   }
 
   @Test(expected = IndexOutOfBoundsException.class)
   public void setChildBad() {
-    new BinaryExpr(BoolConstantExpr.TRUE,
-        BoolConstantExpr.FALSE, BinOp.LXOR).setChild(2,
-          BoolConstantExpr.FALSE);
+    new BinaryExpr(new BoolConstantExpr(true),
+        new BoolConstantExpr(false), BinOp.LXOR).setChild(2,
+          new BoolConstantExpr(false));
   }
 
 }

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/expr/BoolConstantExprTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/expr/BoolConstantExprTest.java
@@ -17,6 +17,9 @@
 package com.graphicsfuzz.common.ast.expr;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -24,8 +27,14 @@ public class BoolConstantExprTest {
 
   @Test
   public void testClone() throws Exception {
-    assertEquals(BoolConstantExpr.TRUE, BoolConstantExpr.TRUE.clone());
-    assertEquals(BoolConstantExpr.FALSE, BoolConstantExpr.FALSE.clone());
+    final BoolConstantExpr trueExpr = new BoolConstantExpr(true);
+    final BoolConstantExpr falseExpr = new BoolConstantExpr(false);
+    assertNotSame(trueExpr, trueExpr.clone());
+    assertNotSame(falseExpr, falseExpr.clone());
+    assertEquals(trueExpr.getIsTrue(), trueExpr.clone().getIsTrue());
+    assertEquals(falseExpr.getIsTrue(), falseExpr.clone().getIsTrue());
+    assertTrue(trueExpr.getIsTrue());
+    assertFalse(falseExpr.getIsTrue());
   }
 
 }

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/expr/FunctionCallExprTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/expr/FunctionCallExprTest.java
@@ -35,7 +35,7 @@ public class FunctionCallExprTest {
   @Before
   public void setUp() {
     arg1 = new BinaryExpr(new IntConstantExpr("1"), new IntConstantExpr("1"), BinOp.ADD);
-    arg2 = BoolConstantExpr.TRUE;
+    arg2 = new BoolConstantExpr(true);
     arg3 = new TypeConstructorExpr("vec2", new FloatConstantExpr("0.0"));
     arg4 = new FunctionCallExpr("voidArgsFunction", new ArrayList<>());
     fce = new FunctionCallExpr("someFunction", arg1, arg2, arg3, arg4);

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/expr/TypeConstructorExprTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/expr/TypeConstructorExprTest.java
@@ -30,7 +30,7 @@ public class TypeConstructorExprTest {
   public void getTypename() throws Exception {
     TypeConstructorExpr e = new TypeConstructorExpr("foo",
         new BinaryExpr(new IntConstantExpr("2"), new IntConstantExpr("1"), BinOp.MOD),
-        BoolConstantExpr.TRUE);
+        new BoolConstantExpr(true));
     assertEquals("foo", e.getTypename());
   }
 
@@ -63,7 +63,7 @@ public class TypeConstructorExprTest {
 
   @Test
   public void removeArg() throws Exception {
-    List<Expr> args = Arrays.asList(BoolConstantExpr.TRUE, BoolConstantExpr.FALSE,
+    List<Expr> args = Arrays.asList(new BoolConstantExpr(true), new BoolConstantExpr(false),
         new IntConstantExpr("3"),
         new IntConstantExpr("4"));
 
@@ -148,7 +148,7 @@ public class TypeConstructorExprTest {
   private static List<Expr> exprsList() {
     return Arrays.asList(new BinaryExpr(new FloatConstantExpr("2.0"),
             new FloatConstantExpr("3.6"), BinOp.MUL),
-        BoolConstantExpr.TRUE,
+        new BoolConstantExpr(true),
         new MemberLookupExpr(new VariableIdentifierExpr("s"), "f"));
   }
 

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/stmt/BlockStmtTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/stmt/BlockStmtTest.java
@@ -29,15 +29,15 @@ public class BlockStmtTest {
   public void testInsertStmt() {
     BlockStmt b = new BlockStmt(Arrays.asList(new NullStmt()), true);
     assertEquals(1, b.getNumStmts());
-    b.insertStmt(0, new ExprStmt(BoolConstantExpr.TRUE));
+    b.insertStmt(0, new ExprStmt(new BoolConstantExpr(true)));
     assertEquals(2, b.getNumStmts());
-    assertEquals(BoolConstantExpr.TRUE, ((ExprStmt)b.getStmt(0)).getExpr());
+    assertTrue(((BoolConstantExpr) ((ExprStmt)b.getStmt(0)).getExpr()).getIsTrue());
     assertTrue(b.getStmt(1) instanceof NullStmt);
   }
 
   @Test
   public void testInsertBefore() {
-    ExprStmt stmt = new ExprStmt(BoolConstantExpr.TRUE);
+    ExprStmt stmt = new ExprStmt(new BoolConstantExpr(true));
     BlockStmt b = new BlockStmt(Arrays.asList(stmt), true);
     assertEquals(1, b.getNumStmts());
     b.insertBefore(stmt, new NullStmt());
@@ -48,8 +48,8 @@ public class BlockStmtTest {
 
   @Test
   public void testInsertAfter() {
-    ExprStmt stmt1 = new ExprStmt(BoolConstantExpr.TRUE);
-    ExprStmt stmt2 = new ExprStmt(BoolConstantExpr.FALSE);
+    ExprStmt stmt1 = new ExprStmt(new BoolConstantExpr(true));
+    ExprStmt stmt2 = new ExprStmt(new BoolConstantExpr(false));
     BlockStmt b = new BlockStmt(Arrays.asList(stmt1, stmt2), true);
     assertEquals(2, b.getNumStmts());
     b.insertAfter(stmt1, new NullStmt());

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/visitors/StandardVisitorTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/visitors/StandardVisitorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.graphicsfuzz.common.ast.visitors;
 
 import com.graphicsfuzz.common.ast.decl.ArrayInfo;

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/visitors/StandardVisitorTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/visitors/StandardVisitorTest.java
@@ -1,0 +1,23 @@
+package com.graphicsfuzz.common.ast.visitors;
+
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
+import com.graphicsfuzz.common.util.ParseHelper;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class StandardVisitorTest {
+
+  @Test
+  public void testNoArrayInfo() throws Exception {
+    new StandardVisitor() {
+
+      @Override
+      public void visitArrayInfo(ArrayInfo arrayInfo) {
+        fail("There is no array info in the AST, so this method should not get called.");
+      }
+
+    }.visit(ParseHelper.parse("void foo(int x) { }"));
+  }
+
+}

--- a/common/src/main/java/com/graphicsfuzz/common/util/CannedRandom.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/CannedRandom.java
@@ -67,7 +67,7 @@ public class CannedRandom implements IRandom {
 
   @Override
   public IRandom spawnChild() {
-    throw new UnsupportedOperationException("Child spawning not available");
+    return this;
   }
 
   public boolean isExhausted() {

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -197,7 +197,7 @@ public final class OpaqueExpressionGenerator {
         Fuzzer fuzzer) {
 
     if (isTooDeep(depth)) {
-      return value ? BoolConstantExpr.TRUE : BoolConstantExpr.FALSE;
+      return value ? new BoolConstantExpr(true) : new BoolConstantExpr(false);
     }
     Expr result = null;
     final int newDepth = depth + 1;
@@ -309,11 +309,11 @@ public final class OpaqueExpressionGenerator {
   }
 
   private Expr falseConstructor(Expr expr) {
-    return macroConstructor(Constants.GLF_FALSE, BoolConstantExpr.FALSE, expr);
+    return macroConstructor(Constants.GLF_FALSE, new BoolConstantExpr(false), expr);
   }
 
   private Expr trueConstructor(Expr expr) {
-    return macroConstructor(Constants.GLF_TRUE, BoolConstantExpr.TRUE, expr);
+    return macroConstructor(Constants.GLF_TRUE, new BoolConstantExpr(true), expr);
   }
 
   private Expr makeRegularIntegerValuedLiteral(BasicType type, String integerPart) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/ConstantExprTemplate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/ConstantExprTemplate.java
@@ -134,7 +134,7 @@ public class ConstantExprTemplate extends AbstractExprTemplate {
   }
 
   private BoolConstantExpr randomBoolLiteral(IRandom generator) {
-    return generator.nextBoolean() ? BoolConstantExpr.TRUE : BoolConstantExpr.FALSE;
+    return generator.nextBoolean() ? new BoolConstantExpr(true) : new BoolConstantExpr(false);
   }
 
   private IntConstantExpr randomIntLiteral(IRandom generator) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/LiteralFuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/LiteralFuzzer.java
@@ -41,7 +41,9 @@ public class LiteralFuzzer {
 
   public Optional<Expr> fuzz(Type type) {
     if (type == BasicType.BOOL) {
-      return Optional.of(generator.nextBoolean() ? BoolConstantExpr.TRUE : BoolConstantExpr.FALSE);
+      return Optional.of(generator.nextBoolean()
+          ? new BoolConstantExpr(true)
+          : new BoolConstantExpr(false));
     }
     if (type == BasicType.INT) {
       return Optional.of(new IntConstantExpr(


### PR DESCRIPTION
…es, TRUE and FALSE, we create separate objects for each instance of 'true' and 'false' in the AST.  This fixes a bug where mutating 'true' in one place was leading to a 'true' in a different place being modified.  In the process, added a check during the building of a parent map to ensure that (except in documented special cases) a node does not have multiple parents.