### PR TITLE
Integrate fuzzy comparison algorithm into reducer and Web UI

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/FuzzyImageComparison.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/FuzzyImageComparison.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
@@ -164,6 +165,13 @@ public class FuzzyImageComparison {
       this.areImagesDifferent = areImagesDifferent;
       this.exitStatus = exitStatus;
       this.configurations = configurations;
+    }
+
+    public String outputsString() {
+      return configurations
+          .stream()
+          .map(FuzzyImageComparison.ThresholdConfiguration::outputsString)
+          .collect(Collectors.joining(" "));
     }
   }
 

--- a/common/src/main/java/com/graphicsfuzz/common/util/FuzzyImageComparison.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/FuzzyImageComparison.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.common.util;
 
+import com.google.gson.annotations.SerializedName;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -151,8 +152,17 @@ public class FuzzyImageComparison {
    */
   @SuppressWarnings("WeakerAccess")
   public static final class MainResult {
+
+    // TODO: Yet another use of untyped JSON. We should use Thrift or protobufs.
+    public static final String ARE_IMAGES_DIFFERENT_KEY = "are_images_different";
+
+    @SerializedName(ARE_IMAGES_DIFFERENT_KEY)
     public boolean areImagesDifferent;
+
+    @SerializedName("exit_status")
     public int exitStatus;
+
+    @SerializedName("configurations")
     public List<ThresholdConfiguration> configurations;
 
     public static int EXIT_STATUS_SIMILAR = 0;

--- a/common/src/main/java/com/graphicsfuzz/common/util/ImageUtil.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ImageUtil.java
@@ -122,17 +122,10 @@ public class ImageUtil {
     return opencv_core.PSNR(image1, image2);
   }
 
-  public static boolean identicalImages(File file1, File file2) {
+  public static boolean identicalImages(File file1, File file2) throws IOException {
 
-    BufferedImage img1 = null;
-    BufferedImage img2 = null;
-
-    try {
-      img1 = ImageIO.read(file1);
-      img2 = ImageIO.read(file2);
-    } catch (IOException exception) {
-      exception.printStackTrace();
-    }
+    BufferedImage img1 = ImageIO.read(file1);
+    BufferedImage img2 = ImageIO.read(file2);
 
     int height = img1.getHeight();
     int width = img1.getWidth();
@@ -140,9 +133,9 @@ public class ImageUtil {
       return false;
     }
 
-    for (int i = 0; i < height; i++) {
-      for (int j = 0; j < width; j++) {
-        if (img1.getRGB(i, j) != img2.getRGB(i, j)) {
+    for (int y = 0; y < height; ++y) {
+      for (int x = 0; x < width; ++x) {
+        if (img1.getRGB(x, y) != img2.getRGB(x, y)) {
           return false;
         }
       }

--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -111,8 +111,7 @@ public class ShaderJobFileOperations {
 
     switch (metric) {
 
-      case HISTOGRAM_CHISQR:
-      {
+      case HISTOGRAM_CHISQR: {
         final double diff = ImageUtil.compareHistograms(
             ImageUtil.getHistogram(reference.toString()),
             ImageUtil.getHistogram(variant.toString()));
@@ -120,15 +119,13 @@ public class ShaderJobFileOperations {
         comparisonValue = String.valueOf(diff);
         break;
       }
-      case PSNR:
-      {
+      case PSNR: {
         final double diff = ImageUtil.comparePSNR(reference, variant);
         result = (aboveThresholdIsInteresting ? diff > threshold : diff <= threshold);
         comparisonValue = String.valueOf(diff);
         break;
       }
-      case FUZZY_DIFF:
-      {
+      case FUZZY_DIFF: {
         try {
           FuzzyImageComparison.MainResult mainResult =
               FuzzyImageComparison.mainHelper(

--- a/common/src/main/java/com/graphicsfuzz/shadersets/IImageFileComparator.java
+++ b/common/src/main/java/com/graphicsfuzz/shadersets/IImageFileComparator.java
@@ -17,7 +17,8 @@
 package com.graphicsfuzz.shadersets;
 
 import java.io.File;
+import java.io.IOException;
 
 public interface IImageFileComparator {
-  boolean areFilesInteresting(File shaderResultFileReference, File shaderResultFileVariant);
+  boolean areFilesInteresting(File shaderResultFileReference, File shaderResultFileVariant) throws IOException;
 }

--- a/common/src/main/java/com/graphicsfuzz/shadersets/IImageFileComparator.java
+++ b/common/src/main/java/com/graphicsfuzz/shadersets/IImageFileComparator.java
@@ -20,5 +20,6 @@ import java.io.File;
 import java.io.IOException;
 
 public interface IImageFileComparator {
-  boolean areFilesInteresting(File shaderResultFileReference, File shaderResultFileVariant) throws IOException;
+  boolean areFilesInteresting(File shaderResultFileReference, File shaderResultFileVariant)
+      throws IOException;
 }

--- a/common/src/main/java/com/graphicsfuzz/shadersets/MetricImageFileComparator.java
+++ b/common/src/main/java/com/graphicsfuzz/shadersets/MetricImageFileComparator.java
@@ -20,6 +20,7 @@ import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.server.thrift.ImageComparisonMetric;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,10 +45,11 @@ public class MetricImageFileComparator implements IImageFileComparator {
   }
 
   @Override
-  public boolean areFilesInteresting(File shaderResultFileReference, File shaderResultFileVariant) {
+  public boolean areFilesInteresting(File shaderResultFileReference, File shaderResultFileVariant)
+      throws IOException {
     try {
 
-      return fileOps.areImagesOfShaderResultsSimilar(
+      return fileOps.areImagesOfShaderResultsInteresting(
           shaderResultFileReference,
           shaderResultFileVariant,
           metric,

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
@@ -62,6 +62,15 @@ public class GlslReduce {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GlslReduce.class);
 
+  public static final String METRICS_HELP_SHARED =
+      "When reducing based on images being different, recommended related settings are:\n\n"
+      + ImageComparisonMetric.FUZZY_DIFF
+      + ": --reduction-kind ABOVE_THRESHOLD (provided threshold is ignored)\n\n"
+      + ImageComparisonMetric.HISTOGRAM_CHISQR
+      + ": --reduction-kind ABOVE_THRESHOLD --threshold 100.0\n\n"
+      + ImageComparisonMetric.PSNR
+      + ": --reduction-kind BELOW_THRESHOLD --threshold 30.0\n\n";
+
   private static ArgumentParser getParser() {
 
     ArgumentParser parser = ArgumentParsers.newArgumentParser("glsl-reduce")
@@ -142,17 +151,11 @@ public class GlslReduce {
 
     parser.addArgument("--metric")
         .help("Metric used for image comparison.  Options are:\n"
+            + "   " + ImageComparisonMetric.FUZZY_DIFF + "\n"
             + "   " + ImageComparisonMetric.HISTOGRAM_CHISQR + "\n"
             + "   " + ImageComparisonMetric.PSNR + "\n"
-            + "   " + ImageComparisonMetric.FUZZY_DIFF + "\n\n"
-            + "When reducing based on images being different, recommended related settings are:\n\n"
-            + ImageComparisonMetric.HISTOGRAM_CHISQR
-            + ": --reduction-kind ABOVE_THRESHOLD --threshold 100.0\n\n"
-            + ImageComparisonMetric.PSNR
-            + ": --reduction-kind BELOW_THRESHOLD --threshold 30.0\n\n"
-            + ImageComparisonMetric.FUZZY_DIFF
-            + ": --reduction-kind ABOVE_THRESHOLD (provided threshold is ignored)\n\n")
-        .setDefault(ImageComparisonMetric.HISTOGRAM_CHISQR.toString())
+            + "\n" + METRICS_HELP_SHARED)
+        .setDefault(ImageComparisonMetric.FUZZY_DIFF.toString())
         .type(String.class);
 
     parser.addArgument("--reference")

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
@@ -143,7 +143,15 @@ public class GlslReduce {
     parser.addArgument("--metric")
         .help("Metric used for image comparison.  Options are:\n"
             + "   " + ImageComparisonMetric.HISTOGRAM_CHISQR + "\n"
-            + "   " + ImageComparisonMetric.PSNR + "\n")
+            + "   " + ImageComparisonMetric.PSNR + "\n"
+            + "   " + ImageComparisonMetric.FUZZY_DIFF + "\n\n"
+            + "When reducing based on images being different, recommended related settings are:\n\n"
+            + ImageComparisonMetric.HISTOGRAM_CHISQR
+            + ": --reduction-kind ABOVE_THRESHOLD --threshold 100.0\n\n"
+            + ImageComparisonMetric.PSNR
+            + ": --reduction-kind BELOW_THRESHOLD --threshold 30.0\n\n"
+            + ImageComparisonMetric.FUZZY_DIFF
+            + ": --reduction-kind ABOVE_THRESHOLD (provided threshold is ignored)\n\n")
         .setDefault(ImageComparisonMetric.HISTOGRAM_CHISQR.toString())
         .type(String.class);
 
@@ -152,7 +160,7 @@ public class GlslReduce {
           .type(File.class);
 
     parser.addArgument("--threshold")
-          .help("Threshold used for image comparison.")
+          .help("Threshold used for image comparison. See --metric for suggested values.")
           .setDefault(100.0)
           .type(Double.class);
 

--- a/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
@@ -24,6 +24,7 @@ import com.graphicsfuzz.common.util.FuzzyImageComparison;
 import com.graphicsfuzz.common.util.ReductionProgressHelper;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.reducer.ReductionKind;
+import com.graphicsfuzz.reducer.tool.GlslReduce;
 import com.graphicsfuzz.server.thrift.CommandInfo;
 import com.graphicsfuzz.server.thrift.CommandResult;
 import com.graphicsfuzz.server.thrift.FuzzerServiceManager;
@@ -1927,7 +1928,8 @@ public class WebUi extends HttpServlet {
         "<tr>",
         "<td align='right'><p class='no_space'>Reduction Mode:</p></td>",
         "<td>",
-        "<select name='reduction-kind' class='reduce_col' onchange='selectReduceKind(this);'>",
+        "<select name='reduction-kind' class='reduce_col' ",
+        "onchange='updateReductionElements(this);'>",
         "<option value='ABOVE_THRESHOLD'>Above Threshold</option>",
         (success
             ? "<option value='NO_IMAGE'>No Image</option>"
@@ -1945,16 +1947,14 @@ public class WebUi extends HttpServlet {
         ),
         "<td align='right'><p class='no_space'>Comparison metric:</p></td>",
         "<td>",
-        "<select name='metric' class='reduce_col'>",
+        "<select name='metric' class='reduce_col' onchange='updateReductionElements(this);'>",
+        "<option value='FUZZY_DIFF'>FUZZY_DIFF</option>",
         "<option value='HISTOGRAM_CHISQR'>HISTOGRAM_CHISQR</option>",
         "<option value='PSNR'>PSNR</option>",
         "</select>",
         "</td>",
         "</tr>",
-        (success
-            ? "<tr id='threshold_tr' class=''>"
-            : "<tr id='threshold_tr' class='invisible'>"
-        ),
+        "<tr id='threshold_tr' class='invisible'>",
         "<td align='right'><p class='no_space'>Threshold:</p></td>",
         "<td><input class='reduce_col' name='threshold' value='100.0'/></td>",
         "</tr>",
@@ -2041,6 +2041,11 @@ public class WebUi extends HttpServlet {
         "</table>",
         "<input type='submit' value='Start Reduction'/>",
         "</fieldset>",
+        "<pre id='metric_hints' style='font-size: 10px'>Comparison metric hints ",
+        "(from `glsl-reduce -h`):\n\n",
+        GlslReduce.METRICS_HELP_SHARED.replaceAll("\n\n", "\n"),
+        "\n\n",
+        "</pre>",
         "</form>");
   }
 

--- a/server/src/main/resources/public/graphicsfuzz.css
+++ b/server/src/main/resources/public/graphicsfuzz.css
@@ -46,6 +46,14 @@ td.wrongimg img {
   border: 3px solid red;
 }
 
+td.metricsdisimg {
+  background-color: #ffff80;
+}
+
+td.metricsdisimg img {
+  border: 3px solid purple;
+}
+
 td.nondet {
   background-color: #eeccff;
 }

--- a/server/src/main/resources/public/graphicsfuzz.css
+++ b/server/src/main/resources/public/graphicsfuzz.css
@@ -39,7 +39,7 @@ td.warnimg img {
 }
 
 td.wrongimg {
-  background-color: #ffff80;
+  background-color: #ff7780;
 }
 
 td.wrongimg img {
@@ -51,7 +51,7 @@ td.metricsdisimg {
 }
 
 td.metricsdisimg img {
-  border: 3px solid purple;
+  border: 3px solid red;
 }
 
 td.nondet {

--- a/server/src/main/resources/public/graphicsfuzz.js
+++ b/server/src/main/resources/public/graphicsfuzz.js
@@ -80,13 +80,22 @@ function setClass(elem, c, on) {
   }
 }
 
-function selectReduceKind(elem) {
-  var val = elem.value;
-  var error_string_visible = (val !== "NO_IMAGE");
-  var threshold_visible = (val !== "BELOW_THRESHOLD" && val !== "ABOVE_THRESHOLD");
-  setClass(error_string_tr, "invisible", error_string_visible);
-  setClass(threshold_tr, "invisible", threshold_visible);
-  setClass(metric_tr, "invisible", threshold_visible);
+function updateReductionElements(elem) {
+  var reduction_kind_val =
+      document.getElementsByName("reduction-kind")[0].selectedOptions[0].value;
+  var metric_val =
+      document.getElementsByName("metric")[0].selectedOptions[0].value;
+
+  var error_string_invisible = (reduction_kind_val !== "NO_IMAGE");
+  var metric_invisible =
+      (reduction_kind_val !== "BELOW_THRESHOLD" && reduction_kind_val !== "ABOVE_THRESHOLD");
+  var threshold_invisible = (metric_invisible || metric_val === "FUZZY_DIFF");
+
+  setClass(error_string_tr, "invisible", error_string_invisible);
+  setClass(metric_tr, "invisible", metric_invisible);
+  setClass(metric_hints, "invisible", metric_invisible);
+  setClass(threshold_tr, "invisible", threshold_invisible);
+
 }
 
 var lastChecked = -1;

--- a/thrift/src/main/thrift/FuzzerService.thrift
+++ b/thrift/src/main/thrift/FuzzerService.thrift
@@ -64,7 +64,8 @@ enum ReductionKind {
 
 enum ImageComparisonMetric {
     HISTOGRAM_CHISQR,
-    PSNR
+    PSNR,
+    FUZZY_DIFF
 }
 
 enum WorkerNameError {

--- a/tool/src/main/java/com/graphicsfuzz/tool/FuzzyImageComparisonTool.java
+++ b/tool/src/main/java/com/graphicsfuzz/tool/FuzzyImageComparisonTool.java
@@ -27,15 +27,7 @@ public class FuzzyImageComparisonTool {
   public static void main(String[] args) throws IOException {
     try {
       FuzzyImageComparison.MainResult result = FuzzyImageComparison.mainHelper(args);
-
-      // Print space-separated outputs for each configuration.
-      System.out.println(
-          result
-            .configurations
-            .stream()
-            .map(FuzzyImageComparison.ThresholdConfiguration::outputsString)
-            .collect(Collectors.joining(" "))
-      );
+      System.out.println(result.outputsString());
       System.exit(result.exitStatus);
 
     } catch (ArgumentParserException exception) {


### PR DESCRIPTION
Fix #283 

* Make FuzzyImageComparison.MainResult serializable to JSON and to a summary output string.
* Add FUZZY_DIFF as a metric type. 
* Update help of glsl-reduce for FUZZY_DIFF metric, plus add some examples. Also add these "hints" to the WebUI. 
* Add CSS for "metrics disagree".
* Small fix to identicalImages function (mostly unrelated fix).
* Add fuzzy diff metric to the metrics in .info.json files and simplify this code.
* WebUI: replace image comparison methods with one method and refactor. Use fuzzy diff algorithm and support "metrics disagree" result.
* Make fuzzy diff the default algorithm in the reducer and WebUI. 
* Update WebUI reduction page. 