### PR TITLE
Strip layout qualifiers during donation

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -33,6 +33,8 @@ import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.type.ArrayType;
 import com.graphicsfuzz.common.ast.type.BasicType;
+import com.graphicsfuzz.common.ast.type.LayoutQualifier;
+import com.graphicsfuzz.common.ast.type.LayoutQualifierSequence;
 import com.graphicsfuzz.common.ast.type.QualifiedType;
 import com.graphicsfuzz.common.ast.type.StructDefinitionType;
 import com.graphicsfuzz.common.ast.type.StructNameType;
@@ -657,21 +659,25 @@ public abstract class DonateCodeTransformation implements ITransformation {
     if (!(type instanceof QualifiedType)) {
       return type;
     }
-    List<TypeQualifier> newQualifiers = new ArrayList<>();
-    for (TypeQualifier q : ((QualifiedType) type).getQualifiers()) {
+    final QualifiedType qualifiedType = (QualifiedType) type;
+    final List<TypeQualifier> newQualifiers = new ArrayList<>();
+    for (TypeQualifier qualifier : qualifiedType.getQualifiers()) {
+      // There are probably other qualifiers that are not allowed; move them up as we discover this.
       if (Arrays.asList(
           TypeQualifier.IN_PARAM,
           TypeQualifier.INOUT_PARAM,
           TypeQualifier.OUT_PARAM,
           TypeQualifier.UNIFORM,
           TypeQualifier.SHADER_INPUT,
-          TypeQualifier.SHADER_OUTPUT).contains(q)) {
+          TypeQualifier.SHADER_OUTPUT).contains(qualifier)) {
         continue;
       }
-      // Many of the other qualifiers are probably not allowed; move them up as we discover this
-      newQualifiers.add(q);
+      if (qualifier instanceof LayoutQualifierSequence) {
+        continue;
+      }
+      newQualifiers.add(qualifier);
     }
-    return new QualifiedType(((QualifiedType) type).getTargetType(), newQualifiers);
+    return new QualifiedType(qualifiedType.getTargetType(), newQualifiers);
   }
 
   abstract String getPrefix();

--- a/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateShaderFamilyTest.java
@@ -146,6 +146,28 @@ public class GenerateShaderFamilyTest {
   }
 
   @Test
+  public void testGenerateSmallVulkanShaderFamilyWithReferencesAsDonors() throws Exception {
+    // This is designed to guard against bugs whereby donating 310 es features into a 310 es shader
+    // causes problems
+    final String samplesSubdir = "310es";
+    final String referenceShaderName = "squares";
+    final int numVariants = 3;
+    final int seed = 0;
+    final String reference = Paths.get(ToolPaths.getShadersDirectory(), "samples",
+        "310es", "squares.json").toString();
+    // Note that we are using the 310es samples as donors here.
+    final String donors = Paths.get(ToolPaths.getShadersDirectory(),"samples",
+        "310es").toString();
+
+    final List<String> extraOptions = Arrays.asList(
+        "--stop-on-fail",
+        "--max-uniforms",
+        String.valueOf(10),
+        "--generate-uniform-bindings");
+    checkShaderFamilyGeneration(numVariants, seed, extraOptions, reference, donors);
+  }
+
+  @Test
   public void testIgnoreShaderTranslator() throws Exception {
     // shader_translator would reject this due to the non-constant array access; glslangValidator
     // accepts it.


### PR DESCRIPTION
Added shader family test to expose issues with layout qualifiers being applied to local variables during donation, and fixed this problem.