### PR TITLE
Document colors of result tables with a legend in the UI

### DIFF
--- a/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Simple Web UI.
  *
- * <p>The two entry points are doGet() and doPost(). They dispatche response handling based on the
+ * <p>The two entry points are doGet() and doPost(). They dispatch response handling based on the
  * HTTP request path, which we call 'route'. Dedicated functions build the relevant web response.
  * The StringBuilder field 'html' is used to progressively construct the HTML, and is eventually
  * send back as a response.
@@ -594,6 +594,27 @@ public class WebUi extends HttpServlet {
     htmlAppendLn("</div>");
 
     // Shader family results table
+    htmlAppendLn("<div class='ui segment'>\n",
+        "<h4>Legend for background colors in result table</h4>",
+        "<table class='ui celled compact collapsing table'>",
+        "<thead><tr><th>Color</th><th>Meaning</th></tr></thead>",
+        "<tbody>",
+        "<tr><td class=''></td>",
+        "<td>Variant is identical to reference</td></tr>",
+        "<tr><td class='wrongimg'></td>",
+        "<td>Variant is significantly different from reference</td></tr>",
+        "<tr><td class='warnimg'></td>",
+        "<td>Variant is similar but not identical to reference</td></tr>",
+        "<tr><td class='gfz-error'></td>",
+        "<td>Rendering the variant led to an error</td></tr>",
+        "<tr><td class='nondet'></td>",
+        "<td>Variant leads to non-deterministic rendering</td></tr>",
+        "<tr><td class='metricsdisimg'></td>",
+        "<td>The image comparison metrics used to compare variant and reference",
+        "disagree on whether they are different or not</td></tr>",
+        "</tbody>",
+        "</table>",
+        "</div>");
 
     htmlAppendLn("<div class='ui segment'>\n",
         "<h3>Results table</h3>");

--- a/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/WebUi.java
@@ -594,27 +594,7 @@ public class WebUi extends HttpServlet {
     htmlAppendLn("</div>");
 
     // Shader family results table
-    htmlAppendLn("<div class='ui segment'>\n",
-        "<h4>Legend for background colors in result table</h4>",
-        "<table class='ui celled compact collapsing table'>",
-        "<thead><tr><th>Color</th><th>Meaning</th></tr></thead>",
-        "<tbody>",
-        "<tr><td class=''></td>",
-        "<td>Variant is identical to reference</td></tr>",
-        "<tr><td class='wrongimg'></td>",
-        "<td>Variant is significantly different from reference</td></tr>",
-        "<tr><td class='warnimg'></td>",
-        "<td>Variant is similar but not identical to reference</td></tr>",
-        "<tr><td class='gfz-error'></td>",
-        "<td>Rendering the variant led to an error</td></tr>",
-        "<tr><td class='nondet'></td>",
-        "<td>Variant leads to non-deterministic rendering</td></tr>",
-        "<tr><td class='metricsdisimg'></td>",
-        "<td>The image comparison metrics used to compare variant and reference",
-        "disagree on whether they are different or not</td></tr>",
-        "</tbody>",
-        "</table>",
-        "</div>");
+    htmlResultColorLegendTable();
 
     htmlAppendLn("<div class='ui segment'>\n",
         "<h3>Results table</h3>");
@@ -640,6 +620,8 @@ public class WebUi extends HttpServlet {
     String workerName = path[2];
 
     htmlHeaderResultTable(workerName + " all results");
+
+    htmlResultColorLegendTable();
 
     htmlAppendLn("<div class='ui segment'>",
         "<h3>All results for worker: ",  workerName, "</h3>",
@@ -754,6 +736,8 @@ public class WebUi extends HttpServlet {
     String shaderFamily = request.getPathInfo().split("/")[2];
 
     htmlHeaderResultTable(shaderFamily + " all results");
+
+    htmlResultColorLegendTable();
 
     htmlAppendLn("<div class='ui segment'>\n",
         "<h3>All results for shader family: ", shaderFamily, "</h3>");
@@ -1219,6 +1203,8 @@ public class WebUi extends HttpServlet {
     response.setContentType("text/html");
 
     htmlHeaderResultTable("Compare Results");
+
+    htmlResultColorLegendTable();
 
     htmlAppendLn("<div class='ui segment'>\n",
         "<h3>Comparative results</h3>\n");
@@ -2155,6 +2141,30 @@ public class WebUi extends HttpServlet {
       htmlAppendLn("</tr>");
     }
     htmlAppendLn("</tbody>\n</table>");
+  }
+
+  private void htmlResultColorLegendTable() {
+    htmlAppendLn("<div class='ui segment'>\n",
+        "<h4>Legend for background colors in result table</h4>",
+        "<table class='ui celled compact collapsing table'>",
+        "<thead><tr><th>Color</th><th>Meaning</th></tr></thead>",
+        "<tbody>",
+        "<tr><td class=''></td>",
+        "<td>Variant is identical to reference</td></tr>",
+        "<tr><td class='wrongimg'></td>",
+        "<td>Variant is significantly different from reference</td></tr>",
+        "<tr><td class='warnimg'></td>",
+        "<td>Variant is similar but not identical to reference</td></tr>",
+        "<tr><td class='gfz-error'></td>",
+        "<td>Rendering the variant led to an error</td></tr>",
+        "<tr><td class='nondet'></td>",
+        "<td>Variant leads to non-deterministic rendering</td></tr>",
+        "<tr><td class='metricsdisimg'></td>",
+        "<td>The image comparison metrics used to compare variant and reference",
+        "disagree on whether they are different or not</td></tr>",
+        "</tbody>",
+        "</table>",
+        "</div>");
   }
 
 }

--- a/server/src/main/resources/public/graphicsfuzz.css
+++ b/server/src/main/resources/public/graphicsfuzz.css
@@ -30,24 +30,28 @@ body {
   height: 100px;
 }
 
-td.warnimg {
-  background-color: #ffccff;
-}
-
-td.warnimg img {
-  border: 3px solid blue;
+td.gfz-error {
+  background-color: #ffaaaa;
 }
 
 td.wrongimg {
-  background-color: #ff7780;
+  background-color: #ffff44;
 }
 
 td.wrongimg img {
   border: 3px solid red;
 }
 
+td.warnimg {
+  background-color: #ccccbb;
+}
+
+td.warnimg img {
+  border: 3px solid blue;
+}
+
 td.metricsdisimg {
-  background-color: #ffff80;
+  background-color: #dd99ff;
 }
 
 td.metricsdisimg img {
@@ -55,15 +59,11 @@ td.metricsdisimg img {
 }
 
 td.nondet {
-  background-color: #eeccff;
+  background-color: #eecc88;
 }
 
 td.nondet img {
   border: 3px solid red;
-}
-
-td.gfz-error {
-  background-color: #ffb3b3;
 }
 
 div.resultmain {


### PR DESCRIPTION
The legend only shows up in pages which have a result table.

NOTE: this change revealed that some colors were too close to each other, so I also updated the colors.

The legend looks like this:
![legend](https://user-images.githubusercontent.com/6726747/53503680-71392d00-3aa8-11e9-9b58-12502b442f06.png)
