### PR TITLE
runspv: improve subprocess_helper

### DIFF
--- a/python/src/main/python/drivers/runspv.py
+++ b/python/src/main/python/drivers/runspv.py
@@ -185,6 +185,14 @@ def spirvdis_path():
     return tool_on_path('spirv-dis')
 
 
+def adb_path():
+    if 'ANDROID_HOME' in os.environ:
+        adb = os.path.join(os.environ['ANDROID_HOME'], 'platform-tools', 'adb')
+        if os.path.isfile(adb):
+            return adb
+    tool_on_path('adb')
+
+
 def remove_end(str_in: str, str_end: str):
     assert str_in.endswith(str_end), 'Expected {} to end with {}'.format(str_in, str_end)
     return str_in[:-len(str_end)]
@@ -263,7 +271,7 @@ def adb_helper(
     stdout: Union[None, int, IO[Any]]=subprocess.PIPE,
     verbose=False
 ):
-    adb_cmd = ['adb'] + adb_args
+    adb_cmd = [adb_path()] + adb_args
 
     try:
         return subprocess_helper(

--- a/python/src/main/python/drivers/runspv.py
+++ b/python/src/main/python/drivers/runspv.py
@@ -257,7 +257,12 @@ ANDROID_LEGACY_APP = 'com.graphicsfuzz.vkworker'
 TIMEOUT_APP = 30
 
 
-def adb_helper(adb_args: List[str], check, stdout: Union[None, int, IO[Any]]=subprocess.PIPE):
+def adb_helper(
+    adb_args: List[str],
+    check,
+    stdout: Union[None, int, IO[Any]]=subprocess.PIPE,
+    verbose=False
+):
     adb_cmd = ['adb'] + adb_args
 
     try:
@@ -266,18 +271,27 @@ def adb_helper(adb_args: List[str], check, stdout: Union[None, int, IO[Any]]=sub
             check=check,
             timeout=TIMEOUT_RUN,
             stdout=stdout,
+            verbose=verbose
         )
     except subprocess.TimeoutExpired as err:
         print('adb command timed out')
         raise err
 
 
-def adb_check(adb_args: List[str], stdout: Union[None, int, IO[Any]]=subprocess.PIPE):
-    return adb_helper(adb_args, True, stdout)
+def adb_check(
+    adb_args: List[str],
+    stdout: Union[None, int, IO[Any]]=subprocess.PIPE,
+    verbose=False
+):
+    return adb_helper(adb_args, True, stdout, verbose)
 
 
-def adb_can_fail(adb_args: List[str], stdout: Union[None, int, IO[Any]]=subprocess.PIPE):
-    return adb_helper(adb_args, False, stdout)
+def adb_can_fail(
+    adb_args: List[str],
+    stdout: Union[None, int, IO[Any]]=subprocess.PIPE,
+    verbose=False
+):
+    return adb_helper(adb_args, False, stdout, verbose)
 
 
 def stay_awake_warning():
@@ -851,8 +865,14 @@ def comp_json_to_amberscript(comp_json):
     binding = j['buffer']['binding']
     offset = 0
     for field_info in j['buffer']['fields']:
-        result += 'ssbo ' + str(binding) + ' subdata ' + translate_type_for_amber(field_info['type']) + ' '\
-                  + str(offset)
+        result += (
+            'ssbo '
+            + str(binding)
+            + ' subdata '
+            + translate_type_for_amber(field_info['type'])
+            + ' '
+            + str(offset)
+        )
         for datum in field_info['data']:
             result += ' ' + str(datum)
             offset += 4
@@ -934,7 +954,14 @@ def get_ssbo_binding(comp_json):
     return binding
 
 
-def run_compute_amber(comp: str, json_file: str, output_dir: str, force: bool, is_android: bool, skip_render: bool):
+def run_compute_amber(
+    comp: str,
+    json_file: str,
+    output_dir: str,
+    force: bool,
+    is_android: bool,
+    skip_render: bool
+):
     assert os.path.isfile(comp)
     assert os.path.isfile(json_file)
 


### PR DESCRIPTION
Probably fix #306 (amber desktop error messages are not captured)

Probably fix #301

stdout and stderr are now captured by default (but not printed, as this is too verbose). We print the command and returncode, which is helpful for understanding what runspv is doing. "check=True" by default. 