### PR TITLE
Guard against null pointer exceptions when working with empty for loops

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/ReturnRemover.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/ReturnRemover.java
@@ -134,7 +134,9 @@ public class ReturnRemover {
           loopStmt.setCondition(
                 new BinaryExpr(
                       new ParenExpr(new UnaryExpr(makeHasReturned(), UnOp.LNOT)),
-                      loopStmt.getCondition(), BinOp.LAND));
+                      loopStmt.hasCondition() ? loopStmt.getCondition() :
+                          new BoolConstantExpr(true),
+                    BinOp.LAND));
         }
       }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/DoStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/DoStmt.java
@@ -26,6 +26,11 @@ public class DoStmt extends LoopStmt {
   }
 
   @Override
+  public boolean hasCondition() {
+    return true;
+  }
+
+  @Override
   public void accept(IAstVisitor visitor) {
     visitor.visitDoStmt(this);
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/ForStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/ForStmt.java
@@ -31,10 +31,7 @@ public class ForStmt extends LoopStmt {
     this.increment = increment;
   }
 
-  /**
-   * Reports whether a condition for the loop is present (it is not in e.g. "for(init; ; inc)"
-   * @return Whether condition is present.
-   */
+  @Override
   public boolean hasCondition() {
     return getCondition() != null;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/ForStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/ForStmt.java
@@ -59,7 +59,10 @@ public class ForStmt extends LoopStmt {
 
   @Override
   public ForStmt clone() {
-    return new ForStmt(init.clone(), getCondition().clone(), increment.clone(), getBody().clone());
+    return new ForStmt(init.clone(),
+        hasCondition() ? getCondition().clone() : null,
+        hasIncrement() ? increment.clone() : null,
+        getBody().clone());
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/LoopStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/LoopStmt.java
@@ -38,6 +38,12 @@ public abstract class LoopStmt extends Stmt {
     this.body = body;
   }
 
+  /**
+   * Reports whether a condition for the loop is present (it is not in e.g. "for(init; ; inc)"
+   * @return Whether condition is present.
+   */
+  public abstract boolean hasCondition();
+
   public final Expr getCondition() {
     return condition;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/WhileStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/WhileStmt.java
@@ -26,6 +26,11 @@ public class WhileStmt extends LoopStmt {
   }
 
   @Override
+  public boolean hasCondition() {
+    return true;
+  }
+
+  @Override
   public void accept(IAstVisitor visitor) {
     visitor.visitWhileStmt(this);
   }

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/inliner/ReturnRemoverTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/inliner/ReturnRemoverTest.java
@@ -222,6 +222,35 @@ public class ReturnRemoverTest {
   }
 
   @Test
+  public void testReturnsRemovedEmptyFor() throws Exception {
+    final String program = "void foo() {"
+        + "  int i = 0;"
+        + "  for(;;) {"
+        + "    if (i > 5) {"
+        + "      return;"
+        + "    }"
+        + "    i++;"
+        + "  }"
+        + "}";
+    final String expected = "void foo() {"
+        + "  bool foo_has_returned = false;"
+        + "  int i = 0;"
+        + "  for(; (!foo_has_returned) && true; ) {"
+        + "    if (i > 5) {"
+        + "      foo_has_returned = true;"
+        + "    }"
+        + "    if (!foo_has_returned) {"
+        + "      i++;"
+        + "    }"
+        + "  }"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final FunctionDefinition fd = findFunctionDefinition(tu, "foo");
+    ReturnRemover.removeReturns(fd, ShadingLanguageVersion.ESSL_310);
+    CompareAstsDuplicate.assertEqualAsts(expected, tu);
+  }
+
+  @Test
   public void testNoReturnNoOp() throws Exception {
     final String program = "void foo() {"
           + "  int x = 2;"

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/stmt/ForStmtTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/stmt/ForStmtTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.graphicsfuzz.common.ast.CompareAstsDuplicate;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
@@ -93,6 +94,13 @@ public class ForStmtTest {
         .hasCondition());
     assertFalse(stmt
         .hasIncrement());
+  }
+
+  @Test
+  public void testCloneEmptyFor() throws Exception {
+    final TranslationUnit tu = ParseHelper.parse("void main() { for (;;) ; }");
+    final TranslationUnit tu2 = tu.clone();
+    CompareAstsDuplicate.assertEqualAsts(tu, tu2);
   }
 
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/SplitForLoopMutation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/SplitForLoopMutation.java
@@ -124,6 +124,7 @@ public class SplitForLoopMutation implements Mutation {
     // We need the loop increment to be ++ or --.  First, check that it is a unary expression
     Expr increment = forStmt.getIncrement();
     if (!(increment instanceof UnaryExpr)) {
+      // Note: instanceof handles the case where there is no increment
       return Optional.empty();
     }
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LoopMergeReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LoopMergeReductionOpportunity.java
@@ -66,6 +66,7 @@ public class LoopMergeReductionOpportunity extends AbstractReductionOpportunity 
       return false;
     }
     if (!(firstLoop.getIncrement() instanceof UnaryExpr)) {
+      // Note: instanceof handles the case where there is no increment
       return false;
     }
     if (!(((UnaryExpr) firstLoop.getIncrement()).getExpr() instanceof VariableIdentifierExpr)) {

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
@@ -1084,4 +1084,37 @@ public class ReductionOpportunitiesTest {
     CompareAsts.assertEqualAsts("#version 310 es\nvoid main() { }", tu);
   }
 
+  @Test
+  public void testReductionOpportunitiesOnEmptyForLoops() throws Exception {
+    final TranslationUnit tu = ParseHelper.parse("#version 310 es\n"
+        + "precision highp float;\n"
+        + "void main() {"
+        + "  for(int i1 = 0;;) {"
+        + "    for(int i2 = 0;;) {"
+        + "      for(;;) {"
+        + "        for(int i3 = 0;;) {"
+        + "          x++;"
+        + "          if (x > 10) break;"
+        + "        }"
+        + "        for(int i3 = 0;;) {"
+        + "          x++;"
+        + "          if (x > 10) break;"
+        + "        }"
+        + "        x++;"
+        + "        if(x > 20) break;"
+        + "      }"
+        + "      x++;"
+        + "      if(x > 30) break;"
+        + "    }"
+        + "    x++;"
+        + "    if(x > 40) break;"
+        + "  };"
+        + "}");
+    List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
+        MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+            ShadingLanguageVersion.GLSL_440,
+            new RandomWrapper(0), new IdGenerator(), true), fileOps);
+    ops.forEach(IReductionOpportunity::applyReduction);
+  }
+
 }


### PR DESCRIPTION
This PR hardens up the code base by removing the assumption that a for loop has a condition and an increment.  We have seen shaders in the wild that do not, and some of our compute shader samples do not.