### PR TITLE
Update doc to replace legacy worker by runspv and amber

### DIFF
--- a/docs/glsl-fuzz-develop.md
+++ b/docs/glsl-fuzz-develop.md
@@ -89,8 +89,8 @@ or read the [walkthrough for a brief overview of using all tools
 
 The Vulkan worker relies on amber; see the [amber project
 documentation](https://github.com/google/amber) on how to build it. For Android,
-you will need to build the Android native executable `amber_ndk`, and push it on
-the device under `/data/local/tmp`.
+you will need to build the Android native executable `amber_ndk`, and push it to
+your device under `/data/local/tmp/`.
 
 ### Build the OpenGL worker (gles-worker)
 

--- a/docs/glsl-fuzz-develop.md
+++ b/docs/glsl-fuzz-develop.md
@@ -15,13 +15,6 @@ page](glsl-fuzz-releases.md).
 * [Maven](https://maven.apache.org/)
 * [Python 3.5+](https://www.python.org/)
 
-* For our Android workers: [Android SDK & NDK](android-notes.md)
-* For the Vulkan desktop worker: [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
-
-> Our *workers* are applications that run on the device you wish to test;
-> they communicate with the `glsl-server` application that is typically run on
-> a more powerful x86 machine.
-
 ### Get a local copy of this repository
 
 To clone this repository:
@@ -85,42 +78,12 @@ See [documentation for these tools](../README.md#Tools)
 or read the [walkthrough for a brief overview of using all tools
 (also requires downloading or building some worker applications)](glsl-fuzz-walkthrough.md).
 
-### Build the Vulkan worker (vulkan-worker)
+### Build amber for the Vulkan worker
 
-#### Android
-
-Ensure that the `ANDROID_HOME=/path/to/android-sdk` and
-`ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle` environment variables are set.
-
-```shell
-cd vulkan-worker
-./gradlew assembleDebug
-```
-
-The resulting APK is here:
-
-`vulkan-worker/src/android/build/outputs/apk/debug/vulkan-worker-android-debug.apk`
-
-#### Linux
-
-Make sure the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
-is installed and the environment variable `VULKAN_SDK` is
-properly set.
-
-```sh
-cd vulkan-worker
-
-mkdir build
-cd build
-
-cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug  # Or: -G "Ninja"
-cmake --build . --config Debug
-cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_TYPE=Debug -P cmake_install.cmake
-```
-
-The resulting binary is here: `vulkan-worker/build/install/vkworker`.
-
-The last step (install) is optional, in which case the binary can be found here: `vulkan-worker/build/vkworker`.
+The vulkan worker relies on amber, see the [amber project
+documentation](https://github.com/google/amber) on how to build it. For Android,
+you will need to build the Android native executable `amber_ndk`, and push it on
+the device under `/data/local/tmp`.
 
 ### Build the OpenGL worker (gles-worker)
 

--- a/docs/glsl-fuzz-develop.md
+++ b/docs/glsl-fuzz-develop.md
@@ -15,6 +15,13 @@ page](glsl-fuzz-releases.md).
 * [Maven](https://maven.apache.org/)
 * [Python 3.5+](https://www.python.org/)
 
+* For our Android workers: [Android SDK & NDK](android-notes.md)
+* For the Vulkan desktop worker: [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
+
+> Our *workers* are applications that run on the device you wish to test; they
+> communicate with the `glsl-server` application that is typically run on a more
+> powerful x86 machine.
+
 ### Get a local copy of this repository
 
 To clone this repository:
@@ -80,7 +87,7 @@ or read the [walkthrough for a brief overview of using all tools
 
 ### Build amber for the Vulkan worker
 
-The vulkan worker relies on amber, see the [amber project
+The Vulkan worker relies on amber; see the [amber project
 documentation](https://github.com/google/amber) on how to build it. For Android,
 you will need to build the Android native executable `amber_ndk`, and push it on
 the device under `/data/local/tmp`.

--- a/docs/glsl-fuzz-generate.md
+++ b/docs/glsl-fuzz-generate.md
@@ -118,7 +118,7 @@ our well-tested use-case is
 a shader job that contains a fragment shader
 and a set of uniform values.
 Our worker applications that are used to render a frame
-can only set uniforms
+can only set uniforms for now
 (they cannot set textures, etc.).
 
 For example, from our release zip:

--- a/docs/glsl-fuzz-walkthrough.md
+++ b/docs/glsl-fuzz-walkthrough.md
@@ -49,16 +49,17 @@ If building from source, this directory can be found at `graphicsfuzz/target/gra
 
 ### amber
 
-In March 2019 we depreciated our legacy vulkan worker to instead rely on
-[amber](https://github.com/google/amber) by default.
+In March 2019 we deprecated our legacy Vulkan worker to instead rely on
+[amber](https://github.com/google/amber) by default. (See the [legacy Vulkan
+worker documentation](legacy-vulkan-worker.md) in case of need.)
 
 For testing Vulkan drivers on Android, you need to build amber as a native
 Android executable, and place that executable in `/data/local/tmp` on any device
 where you want to run tests.
 
-As of March 2019, building amber as a native executable should require the
-following (amber commit `f0a3613b727c240ae8b98e232e655db71d87217e` is known to
-work):
+As of March 2019, building amber as a native Android executable should require
+the following (amber commit `f0a3613b727c240ae8b98e232e655db71d87217e` is known
+to work):
 
 ```
 git clone git@github.com:google/amber
@@ -71,7 +72,7 @@ mkdir app
 mkdir libs
 ${ANDROID_NDK_HOME}/ndk-build -C ../samples NDK_PROJECT_PATH=. NDK_LIBS_OUT=`pwd`/libs NDK_APP_OUT=`pwd`/app
 
-# the resulting native executable will be under build/libs/<abi>/amber_ndk
+# The resulting native executable will be under build/libs/<abi>/amber_ndk
 
 # Don't forget to install it on any Android device you want to test, with the
 # matching ABI, e.g. for ARM 64 bits devices:
@@ -314,10 +315,10 @@ to test the devices on which the workers run.
 
 ### Vulkan worker
 
-The vulkan worker is based on amber (see [amber in requirements](#amber)) to
+The Vulkan worker is based on amber (see [amber in requirements](#amber)) to
 enable testing Vulkan drivers on Android, Linux, and Windows.
 
-> We used to ship our own legacy vulkan worker app, which is now
+> We used to ship our own legacy Vulkan worker app, which is now
 > depreciated. Please switch to amber.
 
 For Android, the Vulkan worker requires running `glsl-to-spv-worker` on a desktop machine, with
@@ -335,7 +336,7 @@ glsl-server     <--- HTTP --->    glsl-to-spv-worker (calls runspv)   --- adb co
 > [We describe this in more detail below](#running-shaders-from-the-command-line).
 
 To start a Vulkan worker, make sure amber is installed (see [amber in
-requirements](#amber)). On desktops, `amber` should be on your PATH.
+requirements](#amber)). On desktop, `amber` should be on your PATH.
 
 You can then use the `glsl-to-spv-worker` script to connect to the server:
 
@@ -663,7 +664,7 @@ The `status` field is a string summarizing the result. It can be:
 * `CRASH`: the variant led to a driver crash
 * `NONDET`: the variant led to a non-deterministic rendering
 *  `TIMEOUT`: the variant took too long to be processed (in the case of the
-    vulkan worker, this may indicate glslangValidator or spirv-opt taking too
+    Vulkan worker, this may indicate glslangValidator or spirv-opt taking too
     long to process the variant)
 * `UNEXPECTED_ERROR`: the variant led to an unexpected error
 
@@ -717,9 +718,10 @@ The output `.txt` files contain the run log for each shader.
 
 ### `runspv`
 
-As described earlier, the Vulkan worker uses `runspv` to run shaders on the
-device. You can use this script directly if you want to re-run some shaders.
-Your device must show in `adb devices`.  For example:
+As described under the [Vulkan worker](vulkan-worker) section, the Vulkan worker
+uses `runspv` to run shaders on the device. You can use this script directly if
+you want to re-run some shaders.  Your device must show in `adb devices`.  For
+example:
 
 ```sh
 runspv --spirvopt=-O --serial 123ABC android variant_005.json outdir

--- a/docs/glsl-fuzz-walkthrough.md
+++ b/docs/glsl-fuzz-walkthrough.md
@@ -47,6 +47,43 @@ Add the following directories to your path:
 The `graphicsfuzz/` directory is the unzipped release.
 If building from source, this directory can be found at `graphicsfuzz/target/graphicsfuzz/`.
 
+### amber
+
+In March 2019 we depreciated our legacy vulkan worker to instead rely on
+[amber](https://github.com/google/amber) by default.
+
+For testing Vulkan drivers on Android, you need to build amber as a native
+Android executable, and place that executable in `/data/local/tmp` on any device
+where you want to run tests.
+
+As of March 2019, building amber as a native executable should require the
+following (amber commit `f0a3613b727c240ae8b98e232e655db71d87217e` is known to
+work):
+
+```
+git clone git@github.com:google/amber
+cd amber
+./tools/git-sync-deps
+./tools/update_build_version.py . samples/ third_party/
+mkdir build
+cd build
+mkdir app
+mkdir libs
+${ANDROID_NDK_HOME}/ndk-build -C ../samples NDK_PROJECT_PATH=. NDK_LIBS_OUT=`pwd`/libs NDK_APP_OUT=`pwd`/app
+
+# the resulting native executable will be under build/libs/<abi>/amber_ndk
+
+# Don't forget to install it on any Android device you want to test, with the
+# matching ABI, e.g. for ARM 64 bits devices:
+adb push libs/arm64-v8a/amber_ndk /data/local/tmp/
+```
+
+For testing Vulkan drivers on desktop, you need to build amber on the relevant
+platform, and add it to your path.
+
+Please refer to the [amber repo](https://github.com/google/amber) for up-to-date
+documentation on how to build it.
+
 ### Java 8+
 
 You will also need to install the latest version of the Java 8 Development Kit,
@@ -272,9 +309,69 @@ some connected workers.
 
 ## Running workers
 
-We will now run some worker applications
-that connect to the server, allowing us to test the devices on which
-the workers run.
+We will now run some worker applications that connect to the server, allowing us
+to test the devices on which the workers run.
+
+### Vulkan worker
+
+The vulkan worker is based on amber (see [amber in requirements](#amber)) to
+enable testing Vulkan drivers on Android, Linux, and Windows.
+
+> We used to ship our own legacy vulkan worker app, which is now
+> depreciated. Please switch to amber.
+
+For Android, the Vulkan worker requires running `glsl-to-spv-worker` on a desktop machine, with
+the Android device accessible via adb:
+
+```
+glsl-server     <--- HTTP --->    glsl-to-spv-worker (calls runspv)   --- adb commands --->   amber, or legacy vulkan worker
+(on a desktop)                    (on a desktop)                                              (on an Android device)
+```
+
+> Note that the `runspv` script uses the `adb` tool to copy the shader files to
+> the device, run amber or the legacy worker, and copy back the results.
+> `runspv` can be used as a standalone tool to run shaders, with possible prior
+> conversion to SPIR-V.
+> [We describe this in more detail below](#running-shaders-from-the-command-line).
+
+To start a Vulkan worker, make sure amber is installed (see [amber in
+requirements](#amber)). On desktops, `amber` should be on your PATH.
+
+You can then use the `glsl-to-spv-worker` script to connect to the server:
+
+```sh
+# Execute the worker script, pass the target ('android' or 'host') and the
+# worker name as arguments.
+# Add `--help` to see options
+# Add `--server` to specify a server URL (default is http://localhost:8080)
+# Add `--spirvopt=-O` to run `spirv-opt -O` on every shader.
+# Add `--serial 123ABC` to specify the serial number of the Android device
+#   to target (found using `adb devices -l`)
+glsl-to-spv-worker android pixel3
+```
+
+Note that running `spirv-opt` on each shader by adding the `--spirvopt=ARGS`
+argument can help find additional bugs that would otherwise not be found.  This
+approach can also find bugs in `spirv-opt` itself.
+
+You should see `No job` repeatedly output to the terminal.
+
+If you see `Cannot connect to server` then the worker script is failing to
+connect to the server.
+
+The intermediate files are saved in the current directory under
+a `WORKERNAME/` directory.
+For example, we might have a worker name of `pixel3`
+and so under `pixel3/` we will see:
+
+```sh
+tmpscript.shader_test    # The amber script for the latest test to have been ran
+variant_005.json         # The shader job file (containing uniforms data).
+variant_005.frag         # The GLSL fragment shader.
+variant_005.frag.spv     # The SPIR-V version of the fragment shader.
+```
+
+Don't care about the other kinds of worker? [Skip ahead to running shaders on workers](#running-shaders-on-the-worker-applications).
 
 ### `gles-desktop-worker`
 
@@ -370,99 +467,6 @@ The app will show a second dialogue where you must enter the worker name.  Once
 you have entered a name, you should see a mostly black screen with animated text
 that contains `state: GET_JOB`.  If you see `state: NO_CONNECTION` then the
 worker application is failing to connect to the server.
-
-Don't care about the other kinds of worker?  [Skip ahead to running shaders on workers](#running-shaders-on-the-worker-applications).
-
-### `vulkan-worker-android`
-
-> Warning: you must ensure the screen of your Android device stays on.
-> You should therefore enable "Stay awake" in developer settings.
-> See [Android notes](android-notes.md#useful-device-settings) for a description of how to enable this setting.
-
-You can use the `vulkan-worker-android` app
-to test the Vulkan drivers on an Android device.
-This worker requires running a `glsl-to-spv-worker`
-on a desktop machine,
-with an Android device (connected via USB) that has the `vulkan-worker-android` app installed.
-
-```
-glsl-server     <--- HTTP --->    glsl-to-spv-worker (calls vkrun.py)   --- adb commands --->    vulkan-worker-android app
-(on a desktop)                    (on a desktop)                                                 (on an Android device)
-```
-
-
-The `glsl-to-spv-worker` script translates the GLSL shaders to SPIR-V
-via `glslangValidator` before sending the shader to
-the `vulkan-worker-android` app running on the Android device.
-
-> Note that the `vkrun.py` Python script
-> uses the `adb` tool to
-> copy the SPIR-V files to the device,
-> run the `vulkan-worker-android` app,
-> and copy back the results.
-> `vkrun` can be used as a standalone tool to
-> re-run SPIR-V shaders on the device.
-> [We describe this in more detail below](#running-shaders-from-the-command-line).
-
-The intermediate files are saved in the current directory under
-a `WORKERNAME/` directory.
-For example, we might have a worker name of `pixel3`
-and so under `pixel3/` we will see:
-
-```
-test.vert                # The default GLSL vertex shader.
-variant_005.json         # The shader job file (containing uniforms data).
-variant_005.frag         # The GLSL fragment shader.
-variant_005.frag.spv     # The SPIR-V version of the fragment shader.
-variant_005.frag.spv.opt # The optimized SPIR-V version of the fragment shader
-                         # (assuming e.g. --spirvopt=-O was passed to glsl-to-spirv-worker).
-variant_005.vert.spv     # The SPIR-V version of the default vertex shader.
-```
-
-Download the latest `vulkan-worker-android-debug.apk` file
-from the [releases page](glsl-fuzz-releases.md)
-and install it on your Android device.
-You can download the .apk file from your device directly
-(e.g. using the Chrome app) and open the .apk file to install it,
-or you can install it using `adb`.
-
-> You may need to allow installation of apps from unknown sources. See the
-> [Android notes](android-notes.md) for various settings that you may need to change on your Android device, and for other ways of installing the app.
-
-There is no point in manually running this app from the Android device; it will crash unless
-it finds shaders in the `/sdcard/graphicsfuzz` directory.
-
-You can run the worker as follows.
-
-> Note that `glsl-to-spv-worker` assumes `adb` is on your PATH.
-
-```sh
-# Install the apk, if not installed already.
-adb install vulkan-worker-android-debug.apk
-
-# Make sure the app can read/write /sdcard/
-adb shell pm grant com.graphicsfuzz.vkworker android.permission.READ_EXTERNAL_STORAGE
-adb shell pm grant com.graphicsfuzz.vkworker android.permission.WRITE_EXTERNAL_STORAGE
-
-# Execute the worker script. Pass the worker name as an argument
-# and the serial number (or "IP:port") of the Android device (found using `adb devices -l`).
-# For more information on adb and serial numbers, see:
-#  https://developer.android.com/studio/command-line/adb
-# Add `--help` to see options
-# Add `--server` to specify a server URL (default is http://localhost:8080)
-# Add `--spirvopt=-O` to run `spirv-opt -O` on every shader.
-glsl-to-spv-worker galaxy-s9-vulkan --serial 21372144e90c7fae
-```
-
-Note that running `spirv-opt` on each shader by adding the `--spirvopt=ARGS` argument
-can help find additional bugs that would otherwise not be found.
-This approach can also find bugs in `spirv-opt` itself.
-
-You should see `No job` repeatedly output to the terminal.
-
-If you see `Cannot connect to server`
-then the worker script
-is failing to connect to the server.
 
 
 ## Running shaders on the worker applications
@@ -711,26 +715,18 @@ The results will be output to the current directory by default, or to the direct
 by `--output`.
 The output `.txt` files contain the run log for each shader.
 
-### vkrun
+### `runspv`
 
-As described earlier,
-the Vulkan worker uses `vkrun`
-to run SPIR-V shaders on the device.
-You can use this script directly
-if you want to re-run some SPIR-V shaders.
-The vertex shader must be provided explicitly, by default you can use our "passthrough"
-vertex shader available in
-`vulkan-worker/samples/shader.vert.spv`.
-Your device must show in `adb devices`.
-For example:
+As described earlier, the Vulkan worker uses `runspv` to run shaders on the
+device. You can use this script directly if you want to re-run some shaders.
+Your device must show in `adb devices`.  For example:
 
 ```sh
-vkrun variant_005.vert.spv variant_005.frag.spv variant_005.json --serial ABCD
+runspv --spirvopt=-O --serial 123ABC android variant_005.json outdir
 ```
 
-where `ABCD` is the device serial number shown in `adb devices`.
-The results of running the shader will be output to
-`results/`.
+where `123ABC` is the device serial number shown in `adb devices`. The results
+of running the shader will be output to `outdir/`.
 
 ## Reducing shaders from the command line using `glsl-reduce`
 

--- a/docs/glsl-fuzz-walkthrough.md
+++ b/docs/glsl-fuzz-walkthrough.md
@@ -737,7 +737,7 @@ runspv android variant_005.json outdir
 
 However, note that `runspv` will fail if you have, for example, 
 both `variant_005.frag` and `variant_005.frag.spv`;
-you must delete one of these files so `runspv` knows which file you want to test.
+you must delete one of these files so `runspv` knows which file you want to test,
 The temporary files and results will be output to `outdir/`.
 
 ## Reducing shaders from the command line using `glsl-reduce`

--- a/docs/legacy-vulkan-worker.md
+++ b/docs/legacy-vulkan-worker.md
@@ -1,6 +1,6 @@
 # GraphicsFuzz legacy Vulkan worker
 
-The legacy vulkan worker has been depreciated in March 2019. This documentation
+The legacy vulkan worker has been deprecated in March 2019. This documentation
 is an archive that is not meant to be up-to-date.
 
 ## Using the worker

--- a/docs/legacy-vulkan-worker.md
+++ b/docs/legacy-vulkan-worker.md
@@ -1,0 +1,99 @@
+# GraphicsFuzz legacy Vulkan worker
+
+The legacy vulkan worker has been depreciated in March 2019. This documentation
+is an archive that is not meant to be up-to-date.
+
+## Using the worker
+
+The legacy vulkan worker comes as an APK available from the [releases page](glsl-fuzz-releases.md).
+
+> Warning: you must ensure the screen of your Android device stays on.
+> You should therefore enable "Stay awake" in developer settings.
+> See [Android notes](android-notes.md#useful-device-settings) for a description of how to enable this setting.
+
+Download the latest `vulkan-worker-android-debug.apk` file
+from the [releases page](glsl-fuzz-releases.md)
+and install it on your Android device.
+You can download the .apk file from your device directly
+(e.g. using the Chrome app) and open the .apk file to install it,
+or you can install it using `adb`.
+
+> You may need to allow installation of apps from unknown sources. See the
+> [Android notes](android-notes.md) for various settings that you may need to change on your Android device, and for other ways of installing the app.
+
+There is no point in manually running this app from the Android device; it will crash unless
+it finds shaders in the `/sdcard/graphicsfuzz` directory.
+
+You can run the worker as follows.
+
+> Note that `glsl-to-spv-worker` assumes `adb` is on your PATH.
+
+```sh
+# Install the apk, if not installed already.
+adb install vulkan-worker-android-debug.apk
+
+# Make sure the app can read/write /sdcard/
+adb shell pm grant com.graphicsfuzz.vkworker android.permission.READ_EXTERNAL_STORAGE
+adb shell pm grant com.graphicsfuzz.vkworker android.permission.WRITE_EXTERNAL_STORAGE
+
+# Execute the worker script. Pass the worker name as an argument
+# and the serial number (or "IP:port") of the Android device (found using `adb devices -l`).
+# For more information on adb and serial numbers, see:
+#  https://developer.android.com/studio/command-line/adb
+# Add `--help` to see options
+# Add `--server` to specify a server URL (default is http://localhost:8080)
+# Add `--spirvopt=-O` to run `spirv-opt -O` on every shader.
+glsl-to-spv-worker galaxy-s9-vulkan --serial 21372144e90c7fae
+```
+
+Note that running `spirv-opt` on each shader by adding the `--spirvopt=ARGS` argument
+can help find additional bugs that would otherwise not be found.
+This approach can also find bugs in `spirv-opt` itself.
+
+You should see `No job` repeatedly output to the terminal.
+
+If you see `Cannot connect to server`
+then the worker script
+is failing to connect to the server.
+
+## Building the legacy worker
+
+### Requirements:
+
+* For our Android workers: [Android SDK & NDK](android-notes.md)
+* For the Vulkan desktop worker: [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
+
+### Android
+
+Ensure that the `ANDROID_HOME=/path/to/android-sdk` and
+`ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle` environment variables are set.
+
+```shell
+cd vulkan-worker
+./gradlew assembleDebug
+```
+
+The resulting APK is here:
+
+`vulkan-worker/src/android/build/outputs/apk/debug/vulkan-worker-android-debug.apk`
+
+### Linux
+
+Make sure the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
+is installed and the environment variable `VULKAN_SDK` is
+properly set.
+
+```sh
+cd vulkan-worker
+
+mkdir build
+cd build
+
+cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug  # Or: -G "Ninja"
+cmake --build . --config Debug
+cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_TYPE=Debug -P cmake_install.cmake
+```
+
+The resulting binary is here: `vulkan-worker/build/install/vkworker`.
+
+The last step (install) is optional, in which case the binary can be found here: `vulkan-worker/build/vkworker`.


### PR DESCRIPTION
Fix #288 

Put the legacy worker documentation aside in `legacy-vulkan-worker.md`.