### PR TITLE
Add initial version of libFuzzer custom mutator server

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/typing/DuplicateVariableException.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/DuplicateVariableException.java
@@ -16,7 +16,7 @@
 
 package com.graphicsfuzz.common.typing;
 
-class DuplicateVariableException extends RuntimeException {
+public class DuplicateVariableException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -140,12 +140,14 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::string shader(reinterpret_cast<const char*>(data), size);
+  // Give the user some feedback since the coverage won't grow much in an empty
+  // fuzzer.
   std::cout << shader << std::endl;
   return 0;
 }
 EOF
 
-# Must use clang-6.0 or greater (sudo apt install clang-6.0 && clang-6.0 ...).
+# Must use clang-6.0 or greater (sudo apt install clang-6.0 && clang-6.0 -fsanitize=fuzzer...).
 clang++ -g -fsanitize=fuzzer,address fuzzer.cc -o fuzzer
 ```
 

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -7,6 +7,10 @@ GraphicsFuzz can be used with [libFuzzer](http://llvm.org/docs/LibFuzzer.html)
 as a [custom mutator](https://cs.chromium.org/chromium/src/third_party/libFuzzer/src/FuzzerInterface.h)
 for fuzzing that is both coverage-guided and [structure-aware](https://github.com/google/fuzzer-test-suite/blob/master/tutorial/structure-aware-fuzzing.md).
 
+In examples below, the `graphicsfuzz/` directory is the unzipped release. If
+building from source, this directory can be found at
+`graphicsfuzz/target/graphicsfuzz/`.
+
 ## Using the Integration
 
 1. Build GraphicsFuzz.
@@ -23,130 +27,8 @@ Listening on port: 8666
    terminate). An example is provided below:
 
 ```bash
-cat << EOF > fuzzer.cc
-#include <arpa/inet.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include <algorithm>
-#include <cerrno>
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <string>
-
-void CHECK(bool condition, const char* message) {
-  if (condition)
-    return;
-  perror(message);
-  exit(EXIT_FAILURE);
-}
-
-static int sock;
-
-void ReadBuffer(uint8_t* data, size_t size) {
-  size_t bytes_read = 0;
-  while (bytes_read < size) {
-    void* buf = data + bytes_read;
-    size_t count = size - bytes_read;
-    ssize_t result = TEMP_FAILURE_RETRY(read(sock, buf, count));
-    CHECK(result >= 1, "short read");
-    bytes_read += static_cast<size_t>(result);
-  }
-}
-
-void Discard(size_t total_bytes_to_discard) {
-  if (!total_bytes_to_discard) return;
-
-  static const size_t discard_buffer_size = 1024;
-  static uint8_t discard_buffer[discard_buffer_size];
-
-  size_t num_discarded = 0;
-  while (num_discarded < total_bytes_to_discard) {
-    size_t num_to_discard =
-        std::min(total_bytes_to_discard - num_discarded, discard_buffer_size);
-    ReadBuffer(discard_buffer, num_to_discard);
-    num_discarded += num_to_discard;
-  }
-}
-
-struct __attribute__((packed)) MutateRequestHeader {
-  uint64_t size;
-  uint32_t seed;
-  uint8_t is_fragment;
-};
-
-static struct sockaddr_in serv_addr;
-extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
-                                          size_t max_size, unsigned int seed) {
-  if (size <= 1) {
-    // Handle common invalid testcases gracefully.
-    static const std::string basic_shader = "void main(void) { }";
-    if (basic_shader.size() < max_size) {
-      memcpy(reinterpret_cast<char*>(data), basic_shader.c_str(),
-             basic_shader.size());
-      return basic_shader.size();
-    }
-  }
-
-  // Open a connection to the CustomMutatorServer.
-  if (!sock) {
-    sock = socket(AF_INET, SOCK_STREAM, 0);
-    CHECK(sock >= 0, "Could not create socket");
-    static struct sockaddr_in serv_addr;
-    serv_addr.sin_family = AF_INET;
-    static const int port = 8666;
-    serv_addr.sin_port = htons(port);
-    CHECK(inet_pton(AF_INET, "0.0.0.0", &serv_addr.sin_addr) != -1,
-          "invalid address");
-
-    CHECK(connect(sock, reinterpret_cast<const struct sockaddr*>(&serv_addr),
-                  sizeof(serv_addr)) >= 0,
-          "connection failed");
-  }
-
-  static MutateRequestHeader request_header;
-  request_header.size = size;
-  request_header.seed = seed;
-  // In this example we only start with a fragment shader, so every shader must
-  // be a fragment shader.
-  request_header.is_fragment = true;
-  static int flags = 0;
-  // Send the mutation request.
-  ssize_t num_bytes_sent =
-      send(sock, reinterpret_cast<const void*>(&request_header),
-           sizeof(request_header), flags);
-  CHECK(num_bytes_sent == sizeof(request_header), "short write");
-  // Send the shader.
-  num_bytes_sent = send(sock, reinterpret_cast<const void*>(data), size, flags);
-  CHECK(static_cast<size_t>(num_bytes_sent) == size, "short write");
-
-  // Read the response shader size and contents.
-  uint8_t mutated_size_bytes[sizeof(size_t)];
-  ReadBuffer(mutated_size_bytes, sizeof(size_t));
-  size_t mutated_buf_length = *(reinterpret_cast<size_t*>(mutated_size_bytes));
-  if (mutated_buf_length > max_size) {
-    Discard(mutated_buf_length);
-    std::cout << "discard" << std::endl;
-    return size;
-  }
-  size_t read_size = std::min(max_size, mutated_buf_length);
-  ReadBuffer(data, read_size);
-  return read_size;
-}
-
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  std::string shader(reinterpret_cast<const char*>(data), size);
-  // Give the user some feedback since the coverage won't grow much in an empty
-  // fuzzer.
-  std::cout << shader << std::endl;
-  return 0;
-}
-EOF
-
 # Must use clang-6.0 or greater (sudo apt install clang-6.0 && clang-6.0 -fsanitize=fuzzer...).
-clang++ -g -fsanitize=fuzzer,address fuzzer.cc -o fuzzer
+clang++ -g -fsanitize=fuzzer,address graphicsfuzz/examples/libFuzzer-integration/tcp_fuzzer.cc -o fuzzer
 ```
 
 4. Run the fuzz target (using a corpus is optional with the example above, but
@@ -197,125 +79,13 @@ instructions may not be exactly right on your machine.
 2. Build a fuzz target (in a new shell, since the previous example won't
    terminate). An example is provided below:
 ```bash
-cat << EOF > jni-fuzzer.cc
-// TODO(381): Fix memory leaks.
-#include <unistd.h>
-
-#include <cerrno>
-#include <cstring>
-#include <ctime>
-#include <iostream>
-#include <string>
-
-#include <jni.h>
-
-class JVM {
- private:
-  std::string kCustomMutatorServerClassName =
-      "com/graphicsfuzz/generator/tool/CustomMutatorServer";
-  std::string kMutateMethodName = "mutate";
-  std::string kMutateMethodSignature =
-      "(Ljava/lang/String;IZ)Ljava/lang/String;";
-  std::string kClassPathOption = "-Djava.class.path=";
-  char* option_c_str;
-
-  JavaVM* java_vm;
-  JavaVMInitArgs vm_args;
-  JavaVMOption vm_options;
-
- public:
-  JNIEnv* jni_env;
-  jclass server_class;
-  jmethodID mutate_method;
-
-  JVM() {
-    vm_args.version = JNI_VERSION_1_6;
-    vm_args.nOptions = 1;
-
-    const char* jar_path = getenv("GRAPHICSFUZZ_JAR_PATH");
-    if (!jar_path) {
-      std::cout << "GRAPHICSFUZZ_JAR_PATH not Specified" << std::endl;
-      exit(1);
-    }
-    size_t option_size = strlen(jar_path) + 1 + kClassPathOption.size();
-    option_c_str = new char[option_size];
-    std::string option_string = kClassPathOption.append(jar_path);
-    memcpy(option_c_str, option_string.c_str(), option_string.size() + 1);
-    vm_options.optionString = option_c_str;
-    vm_args.options = &vm_options;
-    int result = JNI_CreateJavaVM(&java_vm, reinterpret_cast<void**>(&jni_env),
-                                  &vm_args);
-    if (!jni_env || result < 0) {
-      fprintf(stderr, "Failed to create JVM\n");
-      exit(1);
-    }
-    server_class = jni_env->FindClass(kCustomMutatorServerClassName.c_str());
-    mutate_method =
-        jni_env->GetStaticMethodID(server_class, kMutateMethodName.c_str(),
-                                   kMutateMethodSignature.c_str());
-  }
-
-  // TODO(381): Figure out how to do this without crashing.
-  // ~JVM() { java_vm->DestroyJavaVM(); }
-};
-
-extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
-                                          size_t max_size, unsigned int seed) {
-  static JVM jvm;
-
-  if (size <= 1) {
-    // Handle common invalid testcases gracefully.
-    static const std::string basic_shader = "void main(void) { }";
-    if (basic_shader.size() < max_size) {
-      memcpy(reinterpret_cast<char*>(data), basic_shader.c_str(),
-             basic_shader.size());
-      return basic_shader.size();
-    }
-  }
-
-  jint j_seed = seed;
-
-  // TODO(381): Allow use of vertex shaders. This might break if someone uses a
-  // corpus with fragment shaders.
-  jboolean is_fragment = true;
-
-  // Convert data to a Java string, call mutate and then free it.
-  std::string* shader_string =
-      new std::string(reinterpret_cast<char*>(data), size);
-  jstring input_shader = jvm.jni_env->NewStringUTF(shader_string->c_str());
-  jstring j_mutated_shader = reinterpret_cast<jstring>(
-      jvm.jni_env->CallStaticObjectMethod(jvm.server_class, jvm.mutate_method,
-                                          input_shader, j_seed, is_fragment));
-  jvm.jni_env->ReleaseStringUTFChars(input_shader, shader_string->c_str());
-  if (!j_mutated_shader) {
-    return size;
-  }
-
-  jboolean is_copy;
-  const char* mutated_shader =
-      jvm.jni_env->GetStringUTFChars(j_mutated_shader, &is_copy);
-  size_t mutated_size = jvm.jni_env->GetStringUTFLength(j_mutated_shader);
-  if (mutated_size > max_size) return size;
-  memcpy(reinterpret_cast<char*>(data), mutated_shader, mutated_size);
-  if (is_copy) {
-    jvm.jni_env->ReleaseStringUTFChars(j_mutated_shader, mutated_shader);
-  }
-  return mutated_size;
-}
-
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  std::string shader(reinterpret_cast<const char*>(data), size);
-  std::cout << shader << std::endl;
-  return 0;
-}
-EOF
 
 # Must use clang-6.0 or greater (sudo apt install clang-6.0 && clang-6.0 -fsanitize=fuzzer...).
 clang++ -g -fsanitize=fuzzer,address \
   -I/usr/lib/jvm/java-8-openjdk-amd64/include/ \
   -I/usr/lib/jvm/java-8-openjdk-amd64/include/linux \
   -L/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/ \
-  -ljvm jni-fuzzer.cc -o jni-fuzzer
+  -ljvm graphicsfuzz/examples/libFuzzer-integration/jni_fuzzer.cc -o fuzzer
 
 ```
 
@@ -327,7 +97,7 @@ export GRAPHICSFUZZ_JAR_PATH=<path>
 export LD_LIBRARY_PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/
 # Disable leak detection because the fuzzer leaks memory
 export ASAN_OPTIONS=detect_leaks=0
-./jni-fuzzer -max_total_time=10 -print_final_stats=1
+./fuzzer -max_total_time=10 -print_final_stats=1
 INFO: Seed: 4061094416
 INFO: Loaded 1 modules   (50 inline 8-bit counters): 50 [0x78e320, 0x78e352),
 INFO: Loaded 1 PC tables (50 PCs): 50 [0x56b4a8,0x56b7c8),

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -37,11 +37,12 @@ cat << EOF > fuzzer.cc
 #include <iostream>
 #include <string>
 
-#define CHECK(COND, MSG) \
-  if (!(COND)) {         \
-    perror(MSG);         \
-    exit(EXIT_FAILURE);  \
-  }
+void CHECK(bool condition, const char* message) {
+  if (condition)
+    return;
+  perror(message);
+  exit(EXIT_FAILURE);
+}
 
 static int sock;
 

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -176,6 +176,7 @@ void main(void)
 ...
 ```
 
+You should also see log messages from the GraphicsFuzz CustomMutatorServer.
 Note that it may appear as though libFuzzer is "stuck" on an invalid input and
 repeatedly asks GraphicsFuzz to mutate it. libFuzzer is not actually stuck it
 should progress within 30 seconds.

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -31,11 +31,9 @@ cat << EOF > fuzzer.cc
 #include <unistd.h>
 
 #include <algorithm>
-#include <cstring>
 #include <cerrno>
+#include <cstring>
 #include <fstream>
-#include <iostream>
-
 #include <iostream>
 #include <string>
 

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -1,10 +1,179 @@
 # LibFuzzer Integration
 
 *** note
-**Note:** The libFuzzer integration is experimental.
+**Note:** The libFuzzer integration is actively being developed and is
+experimental.
 ***
 
 GraphicsFuzz can be used with [libFuzzer](http://llvm.org/docs/LibFuzzer.html)
-using libFuzzer's [custom mutators](https://cs.chromium.org/chromium/src/third_party/libFuzzer/src/FuzzerInterface.h)
+as a [custom mutator](https://cs.chromium.org/chromium/src/third_party/libFuzzer/src/FuzzerInterface.h)
 for fuzzing that is both coverage-guided and [structure-aware](https://github.com/google/fuzzer-test-suite/blob/master/tutorial/structure-aware-fuzzing.md).
 
+## Using the Integration
+
+1. Build GraphicsFuzz.
+
+2. Start the GraphicsFuzz CustomMutatorServer with the following command:
+
+```bash
+java -ea -cp graphicsfuzz/target/graphicsfuzz/jar/tool-1.0.jar com.graphicsfuzz.generator.tool.CustomMutatorServer
+Listening on port: 8666
+```
+
+3. Build a fuzz target (in a new shell, since the previous example won't
+   terminate). An example is provided below:
+
+```bash
+cat << EOF > fuzzer.cc
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstring>
+#include <cerrno>
+#include <fstream>
+#include <iostream>
+
+#include <iostream>
+#include <string>
+
+#define CHECK(COND, MSG) \
+  if (!(COND)) {         \
+    perror(MSG);         \
+    exit(EXIT_FAILURE);  \
+  }
+
+static int sock;
+
+void ReadBuffer(uint8_t* data, size_t size) {
+  size_t bytes_read = 0;
+  while (bytes_read < size) {
+    void* buf = data + bytes_read;
+    size_t count = size - bytes_read;
+    ssize_t result = TEMP_FAILURE_RETRY(read(sock, buf, count));
+    CHECK(result >= 1, "short read");
+    bytes_read += static_cast<size_t>(result);
+  }
+}
+
+void Discard(size_t total_bytes_to_discard) {
+  if (!total_bytes_to_discard) return;
+
+  static const size_t discard_buffer_size = 1024;
+  static uint8_t discard_buffer[discard_buffer_size];
+
+  size_t num_discarded = 0;
+  while (num_discarded < total_bytes_to_discard) {
+    size_t num_to_discard =
+        std::min(total_bytes_to_discard - num_discarded, discard_buffer_size);
+    ReadBuffer(discard_buffer, num_to_discard);
+    num_discarded += num_to_discard;
+  }
+}
+
+struct __attribute__((packed)) MutateRequestHeader {
+  uint64_t size;
+  uint32_t seed;
+  uint8_t is_fragment;
+};
+
+static struct sockaddr_in serv_addr;
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
+                                          size_t max_size, unsigned int seed) {
+  if (size <= 1) {
+    // Handle common invalid testcases gracefully.
+    static const std::string basic_shader = "void main(void) { }";
+    if (basic_shader.size() < max_size) {
+      memcpy(reinterpret_cast<char*>(data), basic_shader.c_str(),
+             basic_shader.size());
+      return basic_shader.size();
+    }
+  }
+
+  // Open a connection to the CustomMutatorServer.
+  if (!sock) {
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    CHECK(sock >= 0, "Could not create socket");
+    static struct sockaddr_in serv_addr;
+    serv_addr.sin_family = AF_INET;
+    static const int port = 8666;
+    serv_addr.sin_port = htons(port);
+    CHECK(inet_pton(AF_INET, "0.0.0.0", &serv_addr.sin_addr) != -1,
+          "invalid address");
+
+    CHECK(connect(sock, reinterpret_cast<const struct sockaddr*>(&serv_addr),
+                  sizeof(serv_addr)) >= 0,
+          "connection failed");
+  }
+
+  static MutateRequestHeader request_header;
+  request_header.size = size;
+  request_header.seed = seed;
+  // In this example we only start with a fragment shader, so every shader must
+  // be a fragment shader.
+  request_header.is_fragment = true;
+  static int flags = 0;
+  // Send the mutation request.
+  ssize_t num_bytes_sent =
+      send(sock, reinterpret_cast<const void*>(&request_header),
+           sizeof(request_header), 0);
+  CHECK(num_bytes_sent == sizeof(request_header), "short write");
+  // Send the shader.
+  num_bytes_sent = send(sock, reinterpret_cast<const void*>(data), size, flags);
+  CHECK(static_cast<size_t>(num_bytes_sent) == size, "short write");
+
+  // Read the response shader size and contents.
+  uint8_t mutated_size_bytes[sizeof(size_t)];
+  ReadBuffer(mutated_size_bytes, sizeof(size_t));
+  size_t mutated_buf_length = *(reinterpret_cast<size_t*>(mutated_size_bytes));
+  if (mutated_buf_length > max_size) {
+    Discard(mutated_buf_length);
+    std::cout << "discard" << std::endl;
+    return size;
+  }
+  size_t read_size = std::min(max_size, mutated_buf_length);
+  ReadBuffer(data, read_size);
+  return read_size;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  std::string shader(reinterpret_cast<const char*>(data), size);
+  std::cout << shader << std::endl;
+  return 0;
+}
+EOF
+
+# Must use clang-6.0 or greater (sudo apt install clang-6.0 && clang-6.0 ...).
+clang++ -g -fsanitize=fuzzer,address fuzzer.cc -o fuzzer
+```
+
+4. Run the fuzz target (using a corpus is optional with the example above, but
+   is recommended):
+
+```bash
+./fuzzer
+INFO: Seed: 1327188846
+INFO: Loaded 1 modules   (33 inline 8-bit counters): 33 [0x78d460, 0x78d481),
+INFO: Loaded 1 PC tables (33 PCs): 33 [0x56a438,0x56a648),
+INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
+
+INFO: A corpus is not provided, starting from an empty corpus
+
+
+#2      INITED cov: 3 ft: 3 corp: 1/1b exec/s: 0 rss: 50Mb
+void main(void) { }
+void main(void)
+{
+ if(_GLF_DEAD(false))
+  {
+   gl_FragColor = vec4(-3.0, -4.7, -3.1, 11.74);
+  }
+}
+...
+```
+
+Note that it may appear as though libFuzzer is "stuck" on an invalid input and
+repeatedly asks GraphicsFuzz to mutate it. libFuzzer is not actually stuck it
+should progress within 30 seconds.

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -1,6 +1,6 @@
 # LibFuzzer Integration
 
-*** note
+***note
 **Note:** The libFuzzer integration is actively being developed and is
 experimental.
 ***

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -90,7 +90,8 @@ clang++ -g -fsanitize=fuzzer,address \
 ```
 
 3. Run the fuzzer, setting the appropriate environment variables (including
-   GRAPHICSFUZZ_JAR_PATH which you must set yourself) and options:
+   GRAPHICSFUZZ_JAR_PATH which you must set to `tool-1.0.jar` yourself) and
+   options:
 
 ```bash
 export GRAPHICSFUZZ_JAR_PATH=<path>

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -1,0 +1,10 @@
+# LibFuzzer Integration
+
+*** note
+**Note:** The libFuzzer integration is experimental.
+***
+
+GraphicsFuzz can be used with [libFuzzer](http://llvm.org/docs/LibFuzzer.html)
+using libFuzzer's [custom mutators](https://cs.chromium.org/chromium/src/third_party/libFuzzer/src/FuzzerInterface.h)
+for fuzzing that is both coverage-guided and [structure-aware](https://github.com/google/fuzzer-test-suite/blob/master/tutorial/structure-aware-fuzzing.md).
+

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -176,7 +176,9 @@ void main(void)
 ...
 ```
 
-You should also see log messages from the GraphicsFuzz CustomMutatorServer.
+You should also see log messages from the server.
+For now the server can only accept one connection per life time. So if you quit
+out of libFuzzer or it dies on its own you must restart the server.
 Note that it may appear as though libFuzzer is "stuck" on an invalid input and
 repeatedly asks GraphicsFuzz to mutate it. libFuzzer is not actually stuck it
 should progress within 30 seconds.

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -1,9 +1,7 @@
 # LibFuzzer Integration
 
-***note
 **Note:** The libFuzzer integration is actively being developed and is
 experimental.
-***
 
 GraphicsFuzz can be used with [libFuzzer](http://llvm.org/docs/LibFuzzer.html)
 as a [custom mutator](https://cs.chromium.org/chromium/src/third_party/libFuzzer/src/FuzzerInterface.h)

--- a/docs/libFuzzer-integration.md
+++ b/docs/libFuzzer-integration.md
@@ -118,7 +118,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
   // Send the mutation request.
   ssize_t num_bytes_sent =
       send(sock, reinterpret_cast<const void*>(&request_header),
-           sizeof(request_header), 0);
+           sizeof(request_header), flags);
   CHECK(num_bytes_sent == sizeof(request_header), "short write");
   // Send the shader.
   num_bytes_sent = send(sock, reinterpret_cast<const void*>(data), size, flags);

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -54,6 +54,7 @@ public class CustomMutatorServer {
 
   private static void runServer(int port)
       throws IOException, ParseTimeoutException, InterruptedException {
+    System.out.println("Listening on port: " + port);
     final ServerSocket serverSocket = new ServerSocket(port);
     final Socket socket = serverSocket.accept();
     final InputStream inputStream = socket.getInputStream();

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The GraphicsFuzz Project Authors
+ * Copyright 2019 The GraphicsFuzz Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -69,10 +69,6 @@ public class CustomMutatorServer {
     final int headerSize = Long.BYTES + Integer.BYTES + Byte.BYTES;
     final byte[] headerBuff = new byte[headerSize];
     while (true) {
-      // TODO(381): Figure out a better way to handle waiting for the header to arrive.
-      while (inputStream.available() < headerBuff.length) {
-        ;
-      }
       inputStream.read(headerBuff, 0, headerBuff.length);
       final ByteBuffer headerByteBuffer = ByteBuffer.wrap(headerBuff);
       headerByteBuffer.order(ByteOrder.LITTLE_ENDIAN);

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -41,11 +41,14 @@ import java.util.Optional;
  * Server that can accept shaders from a libFuzzer custom mutator and send back a mutated shader.
  */
 public class CustomMutatorServer {
+  private static final int INDENTATION_WIDTH = 0;
+  private static final int DEFAULT_PORT = 8666;
+
   public static void main(String[] args) {
     try {
       // TODO(381): If we don't switch from TCP, allow this to be configured from the command
       // line.
-      runServer(8666);
+      runServer(DEFAULT_PORT);
     } catch (IOException | ParseTimeoutException | InterruptedException exception) {
       exception.printStackTrace();
       System.exit(1);
@@ -100,13 +103,14 @@ public class CustomMutatorServer {
               tu,
               Optional.empty(),
               stream,
-              PrettyPrinterVisitor.DEFAULT_INDENTATION_WIDTH,
+              INDENTATION_WIDTH,
               PrettyPrinterVisitor.DEFAULT_NEWLINE_SUPPLIER,
               false);
           final String outputShader =
               new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
 
-          // Get shader size as a little endian uint64_t then write it to the socket.
+          // Get shader size as a little endian uint64_t then write it to the socket so libFuzzer
+          // knows what to expect.
           final ByteBuffer lengthByteBuffer = ByteBuffer.allocate(Long.BYTES);
           lengthByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
           lengthByteBuffer.putLong((long) outputShader.length());

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 /**
  * Server that can accept shaders from a libFuzzer custom mutator and send back a mutated shader.
  */
-public class CustomMutatorSever {
+public class CustomMutatorServer {
   public static void main(String[] args) {
     try {
       // TODO(381): If we don't switch from TCP, allow this to be configured from the command

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -36,11 +36,15 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Server that can accept shaders from a libFuzzer custom mutator and send back a mutated shader.
  */
 public class CustomMutatorServer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CustomMutatorServer.class);
   private static final int INDENTATION_WIDTH = 0;
   private static final int DEFAULT_PORT = 8666;
 
@@ -50,13 +54,13 @@ public class CustomMutatorServer {
       // line.
       runServer(DEFAULT_PORT);
     } catch (IOException exception) {
-      exception.printStackTrace();
+      LOGGER.error("Failed to listen on port: " + DEFAULT_PORT, exception);
       System.exit(1);
     }
   }
 
   private static void runServer(int port) throws IOException {
-    System.out.println("Listening on port: " + port);
+    LOGGER.info("Listening on port: " + port);
     final ServerSocket serverSocket = new ServerSocket(port);
     final Socket socket = serverSocket.accept();
     final InputStream inputStream = socket.getInputStream();
@@ -70,7 +74,7 @@ public class CustomMutatorServer {
     while (true) {
       int bytesRead = inputStream.read(headerBuff, 0, headerBuff.length);
       if (bytesRead == -1) {
-        System.out.println("Client closed connection");
+        LOGGER.info("Client closed connection");
         break;
       }
       final ByteBuffer headerByteBuffer = ByteBuffer.wrap(headerBuff);
@@ -139,7 +143,7 @@ public class CustomMutatorServer {
         | IOException
         | InterruptedException exception) {
       exception.printStackTrace();
-      System.out.println(inputShader);
+      LOGGER.error("Failed to mutate:\n" + inputShader, exception);
       return null;
     }
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorServer.java
@@ -68,7 +68,11 @@ public class CustomMutatorServer {
     final int headerSize = Long.BYTES + Integer.BYTES + Byte.BYTES;
     final byte[] headerBuff = new byte[headerSize];
     while (true) {
-      inputStream.read(headerBuff, 0, headerBuff.length);
+      int bytesRead = inputStream.read(headerBuff, 0, headerBuff.length);
+      if (bytesRead == -1) {
+        System.out.println("Client closed connection");
+        break;
+      }
       final ByteBuffer headerByteBuffer = ByteBuffer.wrap(headerBuff);
       headerByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -116,7 +116,8 @@ public class CustomMutatorSever {
 
           outputStream.write(outputShader.getBytes());
         }
-      } catch (GlslParserException | FuzzedIntoACornerException
+      } catch (GlslParserException
+          | FuzzedIntoACornerException
           | DuplicateVariableException exception) {
         exception.printStackTrace();
         System.out.println(new String(inputShaderBuff));

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -59,7 +59,8 @@ public class CustomMutatorSever {
     OutputStream outputStream = socket.getOutputStream();
     while (true) {
       // TODO(metzman) Figure out a better way to handle waiting for the header to arrive.
-      while (inputStream.available() < headerBuff.length) {;
+      while (inputStream.available() < headerBuff.length) {
+        ;
       }
       inputStream.read(headerBuff, 0, headerBuff.length);
       ByteBuffer headerByteBuffer = ByteBuffer.wrap(headerBuff);

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -68,7 +68,7 @@ public class CustomMutatorSever {
       headerByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
       long size1 = headerByteBuffer.getLong();
-      // Support two sizes for now so that one message format can be used between CustomMutate and
+      // Support two sizes for now so that one message format can be used for both CustomMutate and
       // CustomCrossOver.
       long size2 = headerByteBuffer.getLong();
       assert size2 == 0;

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.generator.tool;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.util.GlslParserException;
+import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.ParseTimeoutException;
+import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.ShaderKind;
+import com.graphicsfuzz.generator.fuzzer.FuzzedIntoACornerException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Server that can accept shaders from a libFuzzer custom mutator and send back a mutated shader.
+ */
+public class CustomMutatorSever {
+  public static void main(String[] args) {
+    try {
+      // TODO(metzman): If we don't switch from TCP, allow this to be configurable.
+      runServer(8666);
+    } catch (IOException | ParseTimeoutException | InterruptedException exception) {
+      exception.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  private static void runServer(int port)
+      throws IOException, ParseTimeoutException, InterruptedException {
+    byte[] headerBuff = new byte[28];
+    ServerSocket serverSocket = new ServerSocket(port);
+    Socket socket = serverSocket.accept();
+    InputStream inputStream = socket.getInputStream();
+    OutputStream outputStream = socket.getOutputStream();
+    while (true) {
+      // TODO(metzman) Figure out a better way to handle waiting for the header to arrive.
+      while (inputStream.available() < headerBuff.length) {;
+      }
+      inputStream.read(headerBuff, 0, headerBuff.length);
+      ByteBuffer headerByteBuffer = ByteBuffer.wrap(headerBuff);
+      headerByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+
+      long size1 = headerByteBuffer.getLong();
+      // Support two sizes for now so that one message format can be used between CustomMutate and
+      // CustomCrossOver.
+      long size2 = headerByteBuffer.getLong();
+      assert size2 == 0;
+
+      // Java won't allow us to create an array with a "long" size. Therefore, we must convert it to
+      // int before creating the array. This is probably a non-issue because libFuzzer is unlikely
+      // to ever give us a shader larger than Integer.MAX_VALUE (e.g. ~2G).
+      assert size1 <= Integer.MAX_VALUE && size2 <= Integer.MAX_VALUE;
+
+      // GraphicsFuzz can't do anything with this unfortunately.
+      long maxOutSize = headerByteBuffer.getLong();
+
+      int libfuzzerSeed = headerByteBuffer.getInt();
+
+      // Read the Shader.
+      byte[] inputShaderBuff = new byte[((int) size1) + ((int) size2)];
+      socket.getInputStream().read(inputShaderBuff, 0, inputShaderBuff.length);
+      String inputShader = new String(inputShaderBuff);
+
+      try {
+        // Now mutate the shader.
+        TranslationUnit tu = ParseHelper.parse(inputShader, ShaderKind.FRAGMENT);
+        Mutate.mutate(tu, new RandomWrapper(libfuzzerSeed));
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (PrintStream stream = new PrintStream(byteArrayOutputStream, true, "UTF-8")) {
+          PrettyPrinterVisitor.emitShader(
+              tu,
+              Optional.empty(),
+              stream,
+              PrettyPrinterVisitor.DEFAULT_INDENTATION_WIDTH,
+              PrettyPrinterVisitor.DEFAULT_NEWLINE_SUPPLIER,
+              false);
+          String outputShader =
+              new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
+
+          // Get shader size as a little endian uint64_t.
+          ByteBuffer lengthByteBuffer = ByteBuffer.allocate(Long.BYTES);
+          lengthByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+          lengthByteBuffer.putLong((long) outputShader.length());
+          byte[] length = new byte[Long.BYTES];
+          lengthByteBuffer.position(0);
+          lengthByteBuffer.get(length);
+          outputStream.write(length);
+
+          outputStream.write(outputShader.getBytes());
+        }
+      } catch (GlslParserException | FuzzedIntoACornerException exception) {
+        exception.printStackTrace();
+        System.out.println(new String(inputShaderBuff));
+        // Tell libFuzzer we will "send" it a 0-length shader.
+        for (int idx = 0; idx < Long.BYTES; idx++) {
+          outputStream.write(0);
+        }
+      }
+    }
+  }
+}

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -115,8 +115,8 @@ public class CustomMutatorSever {
 
           outputStream.write(outputShader.getBytes());
         }
-      } catch (GlslParserException | FuzzedIntoACornerException |
-          DuplicateVariableException exception) {
+      } catch (GlslParserException | FuzzedIntoACornerException
+          | DuplicateVariableException exception) {
         exception.printStackTrace();
         System.out.println(new String(inputShaderBuff));
         // Tell libFuzzer we will "send" it a 0-length shader.

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.generator.tool;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
+import com.graphicsfuzz.common.typing.DuplicateVariableException;
 import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -114,7 +115,8 @@ public class CustomMutatorSever {
 
           outputStream.write(outputShader.getBytes());
         }
-      } catch (GlslParserException | FuzzedIntoACornerException exception) {
+      } catch (GlslParserException | FuzzedIntoACornerException |
+          DuplicateVariableException exception) {
         exception.printStackTrace();
         System.out.println(new String(inputShaderBuff));
         // Tell libFuzzer we will "send" it a 0-length shader.

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/CustomMutatorSever.java
@@ -59,7 +59,7 @@ public class CustomMutatorSever {
     InputStream inputStream = socket.getInputStream();
     OutputStream outputStream = socket.getOutputStream();
     while (true) {
-      // TODO(metzman) Figure out a better way to handle waiting for the header to arrive.
+      // TODO(metzman): Figure out a better way to handle waiting for the header to arrive.
       while (inputStream.available() < headerBuff.length) {
         ;
       }

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Mutate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Mutate.java
@@ -144,7 +144,7 @@ public class Mutate {
 
   }
 
-  private static void mutate(TranslationUnit tu, IRandom random) {
+  public static void mutate(TranslationUnit tu, IRandom random) {
     final int maxTries = 10;
 
     List<? extends Mutation> mutations;

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
@@ -1,0 +1,109 @@
+// TODO(381): Fix memory leaks.
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+#include <string>
+
+#include <jni.h>
+
+class JVM {
+ private:
+  std::string kCustomMutatorServerClassName =
+      "com/graphicsfuzz/generator/tool/CustomMutatorServer";
+  std::string kMutateMethodName = "mutate";
+  std::string kMutateMethodSignature =
+      "(Ljava/lang/String;IZ)Ljava/lang/String;";
+  std::string kClassPathOption = "-Djava.class.path=";
+  char* option_c_str;
+
+  JavaVM* java_vm;
+  JavaVMInitArgs vm_args;
+  JavaVMOption vm_options;
+
+ public:
+  JNIEnv* jni_env;
+  jclass server_class;
+  jmethodID mutate_method;
+
+  JVM() {
+    vm_args.version = JNI_VERSION_1_6;
+    vm_args.nOptions = 1;
+
+    const char* jar_path = getenv("GRAPHICSFUZZ_JAR_PATH");
+    if (!jar_path) {
+      std::cout << "GRAPHICSFUZZ_JAR_PATH not Specified" << std::endl;
+      exit(1);
+    }
+    size_t option_size = strlen(jar_path) + 1 + kClassPathOption.size();
+    option_c_str = new char[option_size];
+    std::string option_string = kClassPathOption.append(jar_path);
+    memcpy(option_c_str, option_string.c_str(), option_string.size() + 1);
+    vm_options.optionString = option_c_str;
+    vm_args.options = &vm_options;
+    int result = JNI_CreateJavaVM(&java_vm, reinterpret_cast<void**>(&jni_env),
+                                  &vm_args);
+    if (!jni_env || result < 0) {
+      fprintf(stderr, "Failed to create JVM\n");
+      exit(1);
+    }
+    server_class = jni_env->FindClass(kCustomMutatorServerClassName.c_str());
+    mutate_method =
+        jni_env->GetStaticMethodID(server_class, kMutateMethodName.c_str(),
+                                   kMutateMethodSignature.c_str());
+  }
+
+  // TODO(381): Figure out how to do this without crashing.
+  // ~JVM() { java_vm->DestroyJavaVM(); }
+};
+
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
+                                          size_t max_size, unsigned int seed) {
+  static JVM jvm;
+
+  if (size <= 1) {
+    // Handle common invalid testcases gracefully.
+    static const std::string basic_shader = "void main(void) { }";
+    if (basic_shader.size() < max_size) {
+      memcpy(reinterpret_cast<char*>(data), basic_shader.c_str(),
+             basic_shader.size());
+      return basic_shader.size();
+    }
+  }
+
+  jint j_seed = seed;
+
+  // TODO(381): Allow use of vertex shaders. This might break if someone uses a
+  // corpus with fragment shaders.
+  jboolean is_fragment = true;
+
+  // Convert data to a Java string, call mutate and then free it.
+  std::string shader_string =
+      std::string(reinterpret_cast<char*>(data), size);
+  jstring input_shader = jvm.jni_env->NewStringUTF(shader_string.c_str());
+  jstring j_mutated_shader = reinterpret_cast<jstring>(
+      jvm.jni_env->CallStaticObjectMethod(jvm.server_class, jvm.mutate_method,
+                                          input_shader, j_seed, is_fragment));
+  if (!j_mutated_shader) {
+    return size;
+  }
+
+  jboolean is_copy;
+  const char* mutated_shader =
+      jvm.jni_env->GetStringUTFChars(j_mutated_shader, &is_copy);
+  size_t mutated_size = jvm.jni_env->GetStringUTFLength(j_mutated_shader);
+  if (mutated_size > max_size) return size;
+  memcpy(reinterpret_cast<char*>(data), mutated_shader, mutated_size);
+  if (is_copy) {
+    jvm.jni_env->ReleaseStringUTFChars(j_mutated_shader, mutated_shader);
+  }
+  return mutated_size;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  std::string shader(reinterpret_cast<const char*>(data), size);
+  std::cout << shader << std::endl;
+  return 0;
+}

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
@@ -1,5 +1,5 @@
 // TODO(381): Fix memory leaks.
-#include <unistd.h>
+#include <jni.h>
 
 #include <cerrno>
 #include <cstdlib>
@@ -7,8 +7,6 @@
 #include <cstring>
 #include <iostream>
 #include <string>
-
-#include <jni.h>
 
 class JVM {
  private:

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
@@ -1,3 +1,18 @@
+// Copyright 2019 The GraphicsFuzz Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
 // TODO(381): Fix memory leaks.
 #include <jni.h>
 

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
@@ -2,8 +2,9 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstdlib>
+#include <cstdint>
 #include <cstring>
-#include <ctime>
 #include <iostream>
 #include <string>
 

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/jni_fuzzer.cc
@@ -80,8 +80,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
   jboolean is_fragment = true;
 
   // Convert data to a Java string, call mutate and then free it.
-  std::string shader_string =
-      std::string(reinterpret_cast<char*>(data), size);
+  std::string shader_string = std::string(reinterpret_cast<char*>(data), size);
   jstring input_shader = jvm.jni_env->NewStringUTF(shader_string.c_str());
   jstring j_mutated_shader = reinterpret_cast<jstring>(
       jvm.jni_env->CallStaticObjectMethod(jvm.server_class, jvm.mutate_method,

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/tcp_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/tcp_fuzzer.cc
@@ -1,3 +1,17 @@
+// Copyright 2019 The GraphicsFuzz Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/tcp_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/tcp_fuzzer.cc
@@ -11,8 +11,7 @@
 #include <string>
 
 void CHECK(bool condition, const char* message) {
-  if (condition)
-    return;
+  if (condition) return;
   perror(message);
   exit(EXIT_FAILURE);
 }

--- a/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/tcp_fuzzer.cc
+++ b/graphicsfuzz/src/main/scripts/examples/libFuzzer-integration/tcp_fuzzer.cc
@@ -1,0 +1,118 @@
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+void CHECK(bool condition, const char* message) {
+  if (condition)
+    return;
+  perror(message);
+  exit(EXIT_FAILURE);
+}
+
+static int sock;
+
+void ReadBuffer(uint8_t* data, size_t size) {
+  size_t bytes_read = 0;
+  while (bytes_read < size) {
+    void* buf = data + bytes_read;
+    size_t count = size - bytes_read;
+    ssize_t result = TEMP_FAILURE_RETRY(read(sock, buf, count));
+    CHECK(result >= 1, "short read");
+    bytes_read += static_cast<size_t>(result);
+  }
+}
+
+void Discard(size_t total_bytes_to_discard) {
+  if (!total_bytes_to_discard) return;
+
+  static const size_t discard_buffer_size = 1024;
+  static uint8_t discard_buffer[discard_buffer_size];
+
+  size_t num_discarded = 0;
+  while (num_discarded < total_bytes_to_discard) {
+    size_t num_to_discard =
+        std::min(total_bytes_to_discard - num_discarded, discard_buffer_size);
+    ReadBuffer(discard_buffer, num_to_discard);
+    num_discarded += num_to_discard;
+  }
+}
+
+struct __attribute__((packed)) MutateRequestHeader {
+  uint64_t size;
+  uint32_t seed;
+  uint8_t is_fragment;
+};
+
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t* data, size_t size,
+                                          size_t max_size, unsigned int seed) {
+  if (size <= 1) {
+    // Handle common invalid testcases gracefully.
+    static const std::string basic_shader = "void main(void) { }";
+    if (basic_shader.size() < max_size) {
+      memcpy(reinterpret_cast<char*>(data), basic_shader.c_str(),
+             basic_shader.size());
+      return basic_shader.size();
+    }
+  }
+
+  // Open a connection to the CustomMutatorServer.
+  if (!sock) {
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    CHECK(sock >= 0, "Could not create socket");
+    static struct sockaddr_in serv_addr;
+    serv_addr.sin_family = AF_INET;
+    static const int port = 8666;
+    serv_addr.sin_port = htons(port);
+    CHECK(inet_pton(AF_INET, "0.0.0.0", &serv_addr.sin_addr) != -1,
+          "invalid address");
+
+    CHECK(connect(sock, reinterpret_cast<const struct sockaddr*>(&serv_addr),
+                  sizeof(serv_addr)) >= 0,
+          "connection failed");
+  }
+
+  static MutateRequestHeader request_header;
+  request_header.size = size;
+  request_header.seed = seed;
+  // In this example we only start with a fragment shader, so every shader must
+  // be a fragment shader.
+  request_header.is_fragment = true;
+  static int flags = 0;
+  // Send the mutation request.
+  ssize_t num_bytes_sent =
+      send(sock, reinterpret_cast<const void*>(&request_header),
+           sizeof(request_header), flags);
+  CHECK(num_bytes_sent == sizeof(request_header), "short write");
+  // Send the shader.
+  num_bytes_sent = send(sock, reinterpret_cast<const void*>(data), size, flags);
+  CHECK(static_cast<size_t>(num_bytes_sent) == size, "short write");
+
+  // Read the response shader size and contents.
+  uint8_t mutated_size_bytes[sizeof(size_t)];
+  ReadBuffer(mutated_size_bytes, sizeof(size_t));
+  size_t mutated_buf_length = *(reinterpret_cast<size_t*>(mutated_size_bytes));
+  if (mutated_buf_length > max_size) {
+    Discard(mutated_buf_length);
+    std::cout << "discard" << std::endl;
+    return size;
+  }
+  size_t read_size = std::min(max_size, mutated_buf_length);
+  ReadBuffer(data, read_size);
+  return read_size;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  std::string shader(reinterpret_cast<const char*>(data), size);
+  // Give the user some feedback since the coverage won't grow much in an empty
+  // fuzzer.
+  std::cout << shader << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This adds a working server that can accept shaders over TCP from a libFuzzer custom mutator and returns a mutated shader.

I've confirmed this works by modifying [ANGLE's translator fuzzer](https://cs.chromium.org/chromium/src/testing/libfuzzer/fuzzers/BUILD.gn?type=cs&q=angle_translator_fuzzer&sq=package:chromium&g=0&l=340) to use this server instead of using libFuzzer's standard mutations.
I still need to figure out how those changes will be upstreamed to ANGLE (I want to do it in a way that doesn't mess things up on ClusterFuzz).

This implementation may be replaced with something faster (e.g. shared memory).

Other details of the implementation will probably change, these include: 
* Currently the server listens on port `8666` and can only accept one connection. This doesn't allow parallel use of libFuzzer and other libFuzzer features.
* Whether we even try to support libFuzzer's custom crossover
* How we handle sizes on 32 bit platforms. Currently we treat sizes as 64 bits (`long`) because we use `size_t` (64 bits on x86_64 but 32 on x86) on the libFuzzer side.