### PR TITLE
Refined the reducer's facilities for unwrapping block statements.  It…

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunities.java
@@ -56,18 +56,13 @@ public class LiveOutputVariableWriteReductionOpportunities
   }
 
   @Override
-  protected void visitChildOfBlock(BlockStmt block, int index) {
-
-    final Stmt child = block.getStmt(index);
-
-    if (!(child instanceof BlockStmt)) {
-      return;
-    }
-    final Optional<String> backupName = containsOutVariableBackup((BlockStmt) child);
+  public void visitBlockStmt(BlockStmt block) {
+    super.visitBlockStmt(block);
+    final Optional<String> backupName = containsOutVariableBackup(block);
     if (backupName.isPresent()) {
-      addOpportunity(new LiveOutputVariableWriteReductionOpportunity((BlockStmt) child,
-            backupName.get(),
-            getVistitationDepth()));
+      addOpportunity(new LiveOutputVariableWriteReductionOpportunity(block,
+          backupName.get(),
+          getVistitationDepth()));
     }
   }
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunities.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
 import com.graphicsfuzz.common.ast.stmt.DoStmt;
@@ -27,7 +28,11 @@ import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.util.ListConcat;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class UnwrapReductionOpportunities
       extends ReductionOpportunitiesBase<UnwrapReductionOpportunity> {
@@ -98,23 +103,32 @@ public class UnwrapReductionOpportunities
   }
 
   @Override
-  protected void visitChildOfBlock(BlockStmt block, int index) {
-    final Stmt child = block.getStmt(index);
-    if (isNonEmptyBlockStmtWithoutTopLevelDeclaration(child)) {
+  protected void visitChildOfBlock(BlockStmt block, Stmt child) {
+    if (!(child instanceof BlockStmt)) {
+      return;
+    }
+    final BlockStmt childAsBlock = (BlockStmt) child;
+    if (childAsBlock.getNumStmts() == 0) {
+      // We do not unwrap an empty block statement, as there would be nothing to unwrap.
+      // Other reductions take responsibility for removing a redundant { }.
+      return;
+    }
+    // If unwrapping the child block may lead to name collisions then it cannot be done.
+    // A collision can be with a variable name already in scope, or a variable name that will come
+    // into scope later in the parent block.
+    final Set<String> namesDeclaredDirectlyByParentOrInScopeAlready = new HashSet<>();
+    namesDeclaredDirectlyByParentOrInScopeAlready.addAll(
+        UnwrapReductionOpportunity.getNamesDeclaredDirectlyByBlock(block));
+    namesDeclaredDirectlyByParentOrInScopeAlready.addAll(currentScope.namesOfAllVariablesInScope());
+    final Set<String> namesDeclaredDirectlyByChild =
+        UnwrapReductionOpportunity.getNamesDeclaredDirectlyByBlock(childAsBlock);
+    if (Collections.disjoint(namesDeclaredDirectlyByParentOrInScopeAlready,
+        namesDeclaredDirectlyByChild)) {
       addOpportunity(
-            new UnwrapReductionOpportunity(child, ((BlockStmt) child).getStmts(),
-                  parentMap,
-                  getVistitationDepth()));
+          new UnwrapReductionOpportunity(child, childAsBlock.getStmts(),
+              parentMap,
+              getVistitationDepth()));
     }
-  }
-
-  private boolean isNonEmptyBlockStmtWithoutTopLevelDeclaration(Stmt stmt) {
-    if (!(stmt instanceof BlockStmt)) {
-      return false;
-    }
-    final BlockStmt blockStmt = (BlockStmt) stmt;
-    return blockStmt.getNumStmts() > 0 && blockStmt.getStmts().stream()
-          .noneMatch(item -> item instanceof DeclarationStmt);
   }
 
   private boolean isUnwrappable(LoopStmt loop) {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunities.java
@@ -103,7 +103,8 @@ public class UnwrapReductionOpportunities
   }
 
   @Override
-  protected void visitChildOfBlock(BlockStmt block, Stmt child) {
+  protected void visitChildOfBlock(BlockStmt block, int childIndex) {
+    final Stmt child = block.getStmt(childIndex);
     if (!(child instanceof BlockStmt)) {
       return;
     }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunity.java
@@ -92,7 +92,9 @@ public final class UnwrapReductionOpportunity extends AbstractReductionOpportuni
     }
     if (parentOfWrapper instanceof BlockStmt) {
       // We need to make sure it is still the case that applying the unwrap will not lead to name
-      // clashes.
+      // clashes.  We only need to check the names declared directly by the parent block against
+      // the names declared inside the block being unwrapped, because it is only these sets of names
+      // that can have been affected by applying other reduction opportunities.
       if (!Collections.disjoint(getNamesDeclaredDirectlyByBlock((BlockStmt) parentOfWrapper),
           getNamesDeclaredByStmtList(wrapees))) {
         return false;

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunitiesTest.java
@@ -51,8 +51,28 @@ public class LiveOutputVariableWriteReductionOpportunitiesTest {
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false, null, null, null, true));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
-    assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(reducedProgram)),
-          PrettyPrinterVisitor.prettyPrintAsString(tu));
+    CompareAsts.assertEqualAsts(reducedProgram, tu);
+  }
+
+  @Test
+  public void testLiveGLFragColorWriteOpportunityAtRootOfMain() throws Exception {
+    // Checks that we can eliminate a live color write if it is at the root of a function, i.e.
+    // not enclosed in any additional block.
+    final String backupName = Constants.GLF_OUT_VAR_BACKUP_PREFIX + OpenGlConstants.GL_FRAG_COLOR;
+    final String program = "void main() {"
+        + "  vec4 " + backupName + ";"
+        + "  " + backupName + " = " + OpenGlConstants.GL_FRAG_COLOR + ";"
+        + "  " + OpenGlConstants.GL_FRAG_COLOR + " = " + backupName + ";"
+        + "}";
+    final String reducedProgram = "void main() {"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    List<LiveOutputVariableWriteReductionOpportunity> ops =
+        LiveOutputVariableWriteReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false, null, null, null, true));
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
+    CompareAsts.assertEqualAsts(reducedProgram, tu);
   }
 
   @Test


### PR DESCRIPTION
… did not previously unwrap a statement that contained declaration statements.  Now it does, so long as doing so will not introduce name clashes.  This had some small knock-on effects on the reduction of live color writes, which can now get unwrapped so that they appear in the outer-most block of a function.