### PR TITLE
Generate one from the length of normalized built-in function #398

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -173,8 +173,7 @@ public final class OpaqueExpressionGenerator {
   private Expr makeOpaqueZeroOrOneFromBuiltInFunctions(boolean isZero, BasicType type,
                                                        boolean constContext, int depth,
                                                        Fuzzer fuzzer) {
-    return isZero ?
-        makeOpaqueZeroFromBuiltInFunctions(true, type, constContext, depth, fuzzer)
+    return isZero ? makeOpaqueZeroFromBuiltInFunctions(true, type, constContext, depth, fuzzer)
         : makeOpaqueOneFromBuiltInFunctions(false, type, constContext, depth, fuzzer);
   }
 


### PR DESCRIPTION
Implemented #398, add a new case in makeOpaqueZeroOrOne to make opaque zero or one from built-in GLSL functions and add a new method to generate 1 from the length of the normalized expression.