### PR TITLE
Represent 1 as length of normalized vector

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -170,7 +170,10 @@ public final class OpaqueExpressionGenerator {
                 newDepth, fuzzer));
         case 3:
           // represent 1 as the length of normalized vector
-          if (!BasicType.allGenTypes().contains(type) || isZero) {
+          if (isZero) {
+            continue; // length(normalize(opaque)) only provides a means of representing 1, not 0
+          }
+          if (!BasicType.allGenTypes().contains(type)) {
             continue; // normalize doesn't operate on non-gen types.
           }
           Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueZeroOrOne(isZero,

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -132,25 +132,7 @@ public final class OpaqueExpressionGenerator {
 
   public Expr makeOpaqueOne(BasicType type, boolean constContext, final int depth,
         Fuzzer fuzzer) {
-    final int newDepth = depth + 1;
-    while (true) {
-      final int numTypesOfOne = 2;
-      switch (generator.nextInt(numTypesOfOne)) {
-        case 0:
-          return makeOpaqueZeroOrOne(false, type, constContext, newDepth, fuzzer);
-        case 1:
-          // length(normalize(opaque))
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue;
-          }
-          Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueZeroOrOne(false, type,
-              constContext, newDepth, fuzzer));
-          Expr lengthExpr = new FunctionCallExpr("length", normalizedExpr);
-          return new TypeConstructorExpr(type.toString(), lengthExpr);
-        default:
-          throw new RuntimeException();
-      }
-    }
+    return makeOpaqueZeroOrOne(false, type, constContext, depth, fuzzer);
   }
 
   private Expr makeOpaqueZeroOrOne(boolean isZero, BasicType type, boolean constContext,
@@ -163,7 +145,7 @@ public final class OpaqueExpressionGenerator {
     }
     final int newDepth = depth + 1;
     while (true) {
-      final int numTypesOfZeroOrOne = 3;
+      final int numTypesOfZeroOrOne = 4;
       switch (generator.nextInt(numTypesOfZeroOrOne)) {
         case 0:
           // Make an opaque value recursively and apply an identity function to it
@@ -186,10 +168,51 @@ public final class OpaqueExpressionGenerator {
           }
           return new FunctionCallExpr("sqrt", makeOpaqueZeroOrOne(isZero, type, constContext,
                 newDepth, fuzzer));
+        case 3:
+          return makeOpaqueZeroOrOneFromBuiltInFunctions(isZero, type, constContext, newDepth,
+              fuzzer);
         default:
           throw new RuntimeException();
       }
     }
+  }
+
+  private Expr makeOpaqueZeroOrOneFromBuiltInFunctions(boolean isZero, BasicType type,
+                                                       boolean constContext, int depth,
+                                                       Fuzzer fuzzer) {
+    return isZero ? makeOpaqueZeroFromBuiltInFunctions(true, type, constContext, depth, fuzzer)
+        : makeOpaqueOneFromBuiltInFunctions(false, type, constContext, depth, fuzzer);
+  }
+
+  private Expr makeOpaqueOneFromBuiltInFunctions(boolean isZero, BasicType type,
+                                                 boolean constContext, int depth,
+                                                 Fuzzer fuzzer) {
+    // TODO: add another built-in functions generating zero
+    final int newDepth = depth + 1;
+    while (true) {
+      final int numTypesOfOne = 2;
+      switch (generator.nextInt(numTypesOfOne)) {
+        case 0:
+          return makeOpaqueZeroOrOne(isZero, type, constContext, depth, fuzzer);
+        case 1:
+          // length(normalize(opaque))
+          if (!BasicType.allGenTypes().contains(type)) {
+            continue;
+          }
+          Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueZeroOrOne(false,
+              type, constContext, newDepth, fuzzer));
+          return new FunctionCallExpr("length", normalizedExpr);
+        default:
+          throw new RuntimeException();
+      }
+    }
+  }
+
+  private Expr makeOpaqueZeroFromBuiltInFunctions(boolean isZero, BasicType type,
+                                                  boolean constContext, int depth,
+                                                  Fuzzer fuzzer) {
+    // TODO: implement built-in functions generating zero
+    return makeOpaqueZeroOrOne(isZero, type, constContext, depth, fuzzer);
   }
 
   private Expr makeOpaqueZeroOrOneFromInjectionSwitch(boolean isZero, BasicType type) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -132,7 +132,25 @@ public final class OpaqueExpressionGenerator {
 
   public Expr makeOpaqueOne(BasicType type, boolean constContext, final int depth,
         Fuzzer fuzzer) {
-    return makeOpaqueZeroOrOne(false, type, constContext, depth, fuzzer);
+    final int newDepth = depth + 1;
+    while (true) {
+      final int numTypesOfOne = 2;
+      switch (generator.nextInt(numTypesOfOne)) {
+        case 0:
+          return makeOpaqueZeroOrOne(false, type, constContext, newDepth, fuzzer);
+        case 1:
+          // length(normalize(opaque))
+          if (!BasicType.allGenTypes().contains(type)) {
+            continue;
+          }
+          Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueZeroOrOne(false, type,
+              constContext, newDepth, fuzzer));
+          Expr lengthExpr = new FunctionCallExpr("length", normalizedExpr);
+          return new TypeConstructorExpr(type.toString(), lengthExpr);
+        default:
+          throw new RuntimeException();
+      }
+    }
   }
 
   private Expr makeOpaqueZeroOrOne(boolean isZero, BasicType type, boolean constContext,

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -169,50 +169,17 @@ public final class OpaqueExpressionGenerator {
           return new FunctionCallExpr("sqrt", makeOpaqueZeroOrOne(isZero, type, constContext,
                 newDepth, fuzzer));
         case 3:
-          return makeOpaqueZeroOrOneFromBuiltInFunctions(isZero, type, constContext, newDepth,
-              fuzzer);
-        default:
-          throw new RuntimeException();
-      }
-    }
-  }
-
-  private Expr makeOpaqueZeroOrOneFromBuiltInFunctions(boolean isZero, BasicType type,
-                                                       boolean constContext, int depth,
-                                                       Fuzzer fuzzer) {
-    return isZero ? makeOpaqueZeroFromBuiltInFunctions(true, type, constContext, depth, fuzzer)
-        : makeOpaqueOneFromBuiltInFunctions(false, type, constContext, depth, fuzzer);
-  }
-
-  private Expr makeOpaqueOneFromBuiltInFunctions(boolean isZero, BasicType type,
-                                                 boolean constContext, int depth,
-                                                 Fuzzer fuzzer) {
-    // TODO: add another built-in functions generating zero
-    final int newDepth = depth + 1;
-    while (true) {
-      final int numTypesOfOne = 2;
-      switch (generator.nextInt(numTypesOfOne)) {
-        case 0:
-          return makeOpaqueZeroOrOne(isZero, type, constContext, depth, fuzzer);
-        case 1:
-          // length(normalize(opaque))
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue;
+          // represent 1 as the length of normalized vector
+          if (!BasicType.allGenTypes().contains(type) || isZero) {
+            continue; // normalize doesn't operate on non-gen types.
           }
-          Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueZeroOrOne(false,
+          Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueZeroOrOne(isZero,
               type, constContext, newDepth, fuzzer));
           return new FunctionCallExpr("length", normalizedExpr);
         default:
           throw new RuntimeException();
       }
     }
-  }
-
-  private Expr makeOpaqueZeroFromBuiltInFunctions(boolean isZero, BasicType type,
-                                                  boolean constContext, int depth,
-                                                  Fuzzer fuzzer) {
-    // TODO: implement built-in functions generating zero
-    return makeOpaqueZeroOrOne(isZero, type, constContext, depth, fuzzer);
   }
 
   private Expr makeOpaqueZeroOrOneFromInjectionSwitch(boolean isZero, BasicType type) {


### PR DESCRIPTION
Implemented #398, add a new case in makeOpaqueZeroOrOne to generate 1 as the length of the normalized vector.