### PR TITLE
runspv: .shader_test files include GLSL as comment

### DIFF
--- a/python/src/main/python/drivers/runspv.py
+++ b/python/src/main/python/drivers/runspv.py
@@ -347,6 +347,7 @@ def filename_extension_suggests_glsl(file: str):
             or file.endswith('.vert')
             or file.endswith('.comp'))
 
+
 def prepare_shader(
     output_dir: str,
     shader: Optional[str],
@@ -860,7 +861,25 @@ def get_shader_as_comment(shader: str) -> str:
     return '\n'.join(lines)
 
 
-def amberscriptify_image(vert, frag, uniform_json, vert_original=None, frag_original=None):
+def get_spirv_opt_args_comment(spirv_args: Optional[List[str]]) -> str:
+    if spirv_args:
+        result = '# spirv-opt was used with the following arguments:\n'
+        args = ['# \'{}\''.format(arg) for arg in spirv_args]
+        result += '\n'.join(args)
+        result += '\n\n'
+        return result
+    else:
+        return ''
+
+
+def amberscriptify_image(
+    vert,
+    frag,
+    uniform_json,
+    vert_original,
+    frag_original,
+    spirv_args
+):
     """
     Generates Amberscript representation of an image test
     """
@@ -871,6 +890,8 @@ def amberscriptify_image(vert, frag, uniform_json, vert_original=None, frag_orig
 
     has_frag_glsl = frag_original and filename_extension_suggests_glsl(frag_original)
     has_vert_glsl = vert_original and filename_extension_suggests_glsl(vert_original)
+
+    result += get_spirv_opt_args_comment(spirv_args)
 
     if has_frag_glsl or has_vert_glsl:
         result += '# Derived from the following GLSL.\n\n'
@@ -936,9 +957,14 @@ def run_image_amber(
     device_image = ANDROID_DEVICE_GRAPHICSFUZZ_DIR + '/image_0.png'
 
     with open_helper(amberscript_file, 'w') as f:
-        f.write(
-            amberscriptify_image(
-                vert, frag, json_file, frag_original=frag_original, vert_original=vert_original))
+        f.write(amberscriptify_image(
+            vert,
+            frag,
+            json_file,
+            vert_original,
+            frag_original,
+            spirv_opt_args,
+        ))
 
     if is_android:
         prepare_device(force, using_legacy_worker=False)
@@ -1107,14 +1133,21 @@ def comp_json_to_amberscript(comp_json):
     return result
 
 
-def amberscriptify_comp(comp_spv: str, comp_json: str, comp_original=None):
+def amberscriptify_comp(
+    comp_spv: str,
+    comp_json: str,
+    comp_original: Optional[str],
+    spirv_args: Optional[List[str]]
+):
     """
     Generates an AmberScript representation of a compute test
     """
 
-    result = '# Generated\n'
+    result = '# Generated\n\n'
 
     result += '# A test for a bug found by GraphicsFuzz.\n\n'
+
+    result += get_spirv_opt_args_comment(spirv_args)
 
     if comp_original and filename_extension_suggests_glsl(comp_original):
         result += '# Derived from the following GLSL.\n\n'
@@ -1205,7 +1238,7 @@ def run_compute_amber(
     comp = prepare_shader(output_dir, comp_original, spirv_opt_args)
 
     with open_helper(amberscript_file, 'w') as f:
-        f.write(amberscriptify_comp(comp, json_file))
+        f.write(amberscriptify_comp(comp, json_file, comp_original, spirv_opt_args))
 
     # FIXME: in case of multiple SSBOs, we should pass the binding of the ones to be dumped
     ssbo_binding = str(get_ssbo_binding(json_file))


### PR DESCRIPTION
Fix #416

Also use '--raw-id' in spirv-dis to get consistent ids.