### PR TITLE
Represent 0 using log(1.0)

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -202,7 +202,7 @@ public final class OpaqueExpressionGenerator {
         case 6:
           // represent 0 as the natural logarithm of opaqueOne, e.g. log(1.0)
           if (!isZero) {
-            continue; // log(opaqueZero) only provides a means of representing 0, not 1
+            continue; // log(opaqueOne) only provides a means of representing 0, not 1
           }
           if (!BasicType.allGenTypes().contains(type)) {
             continue; // log doesn't operate on non-gen types.

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -145,7 +145,7 @@ public final class OpaqueExpressionGenerator {
     }
     final int newDepth = depth + 1;
     while (true) {
-      final int numTypesOfZeroOrOne = 6;
+      final int numTypesOfZeroOrOne = 7;
       switch (generator.nextInt(numTypesOfZeroOrOne)) {
         case 0:
           // Make an opaque value recursively and apply an identity function to it
@@ -198,6 +198,16 @@ public final class OpaqueExpressionGenerator {
             continue; // exp doesn't operate on non-gen types.
           }
           return new FunctionCallExpr("exp", makeOpaqueZero(type, constContext, newDepth,
+              fuzzer));
+        case 6:
+          // represent 0 as the natural logarithm of opaqueOne, e.g. log(1.0)
+          if (!isZero) {
+            continue; // log(opaqueZero) only provides a means of representing 0, not 1
+          }
+          if (!BasicType.allGenTypes().contains(type)) {
+            continue; // log doesn't operate on non-gen types.
+          }
+          return new FunctionCallExpr("log", makeOpaqueOne(type, constContext, newDepth,
               fuzzer));
         default:
           throw new RuntimeException();


### PR DESCRIPTION
Related issue: #426 

Add a new case to represent 0 as the log() function of the opaque one expression.