### PR TITLE
Represent 0 as sin(0.0)

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -145,7 +145,7 @@ public final class OpaqueExpressionGenerator {
     }
     final int newDepth = depth + 1;
     while (true) {
-      final int numTypesOfZeroOrOne = 6;
+      final int numTypesOfZeroOrOne = 7;
       switch (generator.nextInt(numTypesOfZeroOrOne)) {
         case 0:
           // Make an opaque value recursively and apply an identity function to it
@@ -198,6 +198,16 @@ public final class OpaqueExpressionGenerator {
             continue; // exp doesn't operate on non-gen types.
           }
           return new FunctionCallExpr("exp", makeOpaqueZero(type, constContext, newDepth,
+              fuzzer));
+        case 6:
+          // represent 0 as sin(opaqueZero) function, e.g. sin(0.0)
+          if (!isZero) {
+            continue; // sin(opaqueZero) only provides a mean of representing 0, not 1
+          }
+          if (!BasicType.allGenTypes().contains(type)) {
+            continue; // sin doesn't operate on non-gen types.
+          }
+          return new FunctionCallExpr("sin", makeOpaqueZero(type, constContext, newDepth,
               fuzzer));
         default:
           throw new RuntimeException();


### PR DESCRIPTION
Fixes: #393 
Add a new way of representing 0 as sin(expression) where expression is guaranteed to be also zero.