### PR TITLE
Keep shading language version in sync

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
@@ -52,6 +52,7 @@ import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.typing.Scope;
+import com.graphicsfuzz.common.typing.SupportedTypes;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.generator.fuzzer.templates.FunctionCallExprTemplate;
@@ -136,7 +137,7 @@ public class Fuzzer {
       return makeExpr(qualifiedType.getTargetType(), isLValue, constContext, depth);
     }
     if (targetType instanceof BasicType) {
-
+      assert SupportedTypes.supported((BasicType) targetType, shadingLanguageVersion);
       List<IExprTemplate> applicableTemplates = availableTemplatesFromContext()
             .filter(item -> item.getResultType().equals(targetType)).collect(Collectors.toList());
       if (isLValue) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Templates.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Templates.java
@@ -80,15 +80,12 @@ public class Templates {
     }
 
     // Constants
-    for (BasicType type : BasicType.allBasicTypes()) {
-      if (!SupportedTypes.supported(type, shadingLanguageVersion)) {
-        continue;
-      }
+    for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
       addTemplate(templates, new ConstantExprTemplate(type));
     }
 
     // Parentheses
-    for (BasicType type : BasicType.allBasicTypes()) {
+    for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
       addTemplate(templates, new ParenExprTemplate(type, true));
       addTemplate(templates, new ParenExprTemplate(type, false));
     }
@@ -646,7 +643,7 @@ public class Templates {
       the built-in functions equal and notEqual.
     */
 
-    for (BasicType type : BasicType.allBasicTypes()) {
+    for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
       addTemplate(templates, new BinaryExprTemplate(type, type, BasicType.BOOL, BinOp.EQ));
       addTemplate(templates, new BinaryExprTemplate(type, type, BasicType.BOOL, BinOp.NE));
     }
@@ -675,12 +672,10 @@ public class Templates {
       evaluated, in order, from left to right.
       */
     if (GenerationParams.COMMA_OPERATOR_ENABLED) {
-      for (BasicType type : BasicType.allBasicTypes()) {
-        if (!SupportedTypes.supported(type, shadingLanguageVersion)) {
-          continue;
-        }
+      for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
         addTemplate(templates,
-              new BinaryExprTemplate(BasicType.allBasicTypes(), type, type, BinOp.COMMA));
+              new BinaryExprTemplate(supportedBasicTypes(shadingLanguageVersion),
+                  type, type, BinOp.COMMA));
       }
     }
 
@@ -693,10 +688,7 @@ public class Templates {
       section 4.1.10 "Implicit Conversions" that can be applied to one of the expressions to make
       their types match. This resulting matching type is the type of the entire expression.
     */
-    for (BasicType type : BasicType.allBasicTypes()) {
-      if (!SupportedTypes.supported(type, shadingLanguageVersion)) {
-        continue;
-      }
+    for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
       addTemplate(templates, new TernaryExprTemplate(type));
     }
 
@@ -1086,7 +1078,15 @@ public class Templates {
 
   }
 
-  static void addTemplate(List<IExprTemplate> templates, IExprTemplate template) {
+  private static List<BasicType> supportedBasicTypes(
+      ShadingLanguageVersion shadingLanguageVersion) {
+    return BasicType.allBasicTypes()
+        .stream()
+        .filter(item -> SupportedTypes.supported(item, shadingLanguageVersion))
+        .collect(Collectors.toList());
+  }
+
+  private static void addTemplate(List<IExprTemplate> templates, IExprTemplate template) {
     if (isBannedType(template.getResultType())) {
       return;
     }

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
@@ -19,7 +19,6 @@ package com.graphicsfuzz.generator.transformation;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
-import com.graphicsfuzz.common.ast.decl.ParameterDecl;
 import com.graphicsfuzz.common.ast.decl.ScalarInitializer;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
@@ -40,10 +39,8 @@ import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.RandomWrapper;
 import com.graphicsfuzz.common.util.ShaderKind;
-import com.graphicsfuzz.generator.transformation.DonateLiveCodeTransformation;
 import com.graphicsfuzz.generator.transformation.donation.DonationContext;
 import com.graphicsfuzz.generator.transformation.injection.BlockInjectionPoint;
-import com.graphicsfuzz.generator.transformation.IdentityTransformation;
 import com.graphicsfuzz.generator.util.GenerationParams;
 import com.graphicsfuzz.generator.util.TransformationProbabilities;
 import java.util.ArrayList;
@@ -87,7 +84,8 @@ public class DonateLiveCodeTransformationTest {
     // This test aimed to expose an issue, but did not succeed.  It's been left
     // here in the spirit of "why delete a test?"
 
-    final String reference = "void main() {"
+    final String reference = "#version 300 es\n"
+          + "void main() {"
           + "  int t;"
           + "  {"
           + "  }"
@@ -95,8 +93,6 @@ public class DonateLiveCodeTransformationTest {
           + "}";
 
     final IRandom generator = new RandomWrapper(0);
-
-    final ShadingLanguageVersion shadingLanguageVersion = ShadingLanguageVersion.ESSL_300;
 
     for (int i = 0; i < 10; i++) {
 
@@ -163,10 +159,10 @@ public class DonateLiveCodeTransformationTest {
                   freeVariables,
                   new ArrayList<>(),
                   new FunctionDefinition(new FunctionPrototype("foo", VoidType.VOID,
-                        new ArrayList<ParameterDecl>()), null)),
+                        new ArrayList<>()), null)),
             TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
             generator,
-          shadingLanguageVersion);
+          referenceTu.getShadingLanguageVersion());
 
       blockInjectionPoint.inject(toDonate);
 


### PR DESCRIPTION
Makes sure that shading language version used during expression fuzzing does not deviate from the shading language version used by the shader.