### PR TITLE
Seperate functions making opaque 1 and 0

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -99,8 +99,8 @@ public final class OpaqueExpressionGenerator {
 
   private List<OpaqueZeroOneFactory> waysToMakeZero() {
     if (opaqueZeroFactories.isEmpty()) {
-      opaqueZeroFactories.add(this::opaqueZeroOrOneSquareRoot);
       opaqueZeroFactories.add(this::opaqueZeroOrOneFromInjectionSwitch);
+      opaqueZeroFactories.add(this::opaqueZeroOrOneSquareRoot);
       opaqueZeroFactories.add(this::opaqueZeroOrOneFromIdentityFunction);
       opaqueZeroFactories.add(this::opaqueZeroSin);
       opaqueZeroFactories.add(this::opaqueZeroLogarithm);
@@ -110,24 +110,14 @@ public final class OpaqueExpressionGenerator {
 
   private List<OpaqueZeroOneFactory> waysToMakeOne() {
     if (opaqueOneFactories.isEmpty()) {
-      opaqueOneFactories.add(this::opaqueZeroOrOneSquareRoot);
       opaqueOneFactories.add(this::opaqueZeroOrOneFromInjectionSwitch);
+      opaqueOneFactories.add(this::opaqueZeroOrOneSquareRoot);
       opaqueOneFactories.add(this::opaqueZeroOrOneFromIdentityFunction);
       opaqueOneFactories.add(this::opaqueOneExponential);
       opaqueOneFactories.add(this::opaqueOneCosine);
       opaqueOneFactories.add(this::opaqueOneNormalizedVectorLength);
     }
     return opaqueOneFactories;
-  }
-
-  private Optional opaqueZeroOrOneSquareRoot(BasicType type, boolean constContext, final int depth,
-                                             Fuzzer fuzzer, boolean isZero) {
-    // sqrt (opaque)
-    if (!BasicType.allGenTypes().contains(type)) {
-      return Optional.empty();
-    }
-    return Optional.of(new FunctionCallExpr("sqrt", makeOpaqueZeroOrOne(isZero, type, constContext,
-        depth, fuzzer)));
   }
 
   private Optional opaqueZeroOrOneFromInjectionSwitch(BasicType type, boolean constContext,
@@ -138,6 +128,16 @@ public final class OpaqueExpressionGenerator {
       return Optional.empty();
     }
     return Optional.of(makeOpaqueZeroOrOneFromInjectionSwitch(isZero, type));
+  }
+
+  private Optional opaqueZeroOrOneSquareRoot(BasicType type, boolean constContext, final int depth,
+                                             Fuzzer fuzzer, boolean isZero) {
+    // sqrt (opaque)
+    if (!BasicType.allGenTypes().contains(type)) {
+      return Optional.empty();
+    }
+    return Optional.of(new FunctionCallExpr("sqrt", makeOpaqueZeroOrOne(isZero, type, constContext,
+        depth, fuzzer)));
   }
 
   private Optional opaqueZeroOrOneFromIdentityFunction(BasicType type, boolean constContext,

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -261,74 +261,13 @@ public final class OpaqueExpressionGenerator {
   }
 
   public Expr makeOpaqueZero(BasicType type, boolean constContext, final int depth,
-        Fuzzer fuzzer) {
-    if (isTooDeep(depth)) {
-      return makeLiteralZeroOrOne(true, type);
-    }
-    final int newDepth = depth + 1;
-    while (true) {
-      final int numTypesOfZero = 3;
-      switch (generator.nextInt(numTypesOfZero)) {
-        case 0:
-          // represent 0 as the natural logarithm of opaqueOne, e.g. log(1.0)
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue; // log doesn't operate on non-gen types.
-          }
-          return new FunctionCallExpr("log", makeOpaqueOne(type, constContext, newDepth,
-              fuzzer));
-        case 1:
-          // represent 0 as sin(opaqueZero) function, e.g. sin(0.0)
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue; // sin doesn't operate on non-gen types.
-          }
-          return new FunctionCallExpr("sin", makeOpaqueZero(type, constContext, newDepth,
-              fuzzer));
-        case 2:
-          return makeOpaqueZeroOrOne(true, type, constContext, newDepth, fuzzer);
-        default:
-          throw new RuntimeException();
-      }
-    }
+                             Fuzzer fuzzer) {
+    return makeOpaqueZeroOrOne(true, type, constContext, depth, fuzzer);
   }
 
   public Expr makeOpaqueOne(BasicType type, boolean constContext, final int depth,
-        Fuzzer fuzzer) {
-
-    if (isTooDeep(depth)) {
-      return makeLiteralZeroOrOne(false, type);
-    }
-    final int newDepth = depth + 1;
-    while (true) {
-      final int numTypesOfOne = 4;
-      switch (generator.nextInt(numTypesOfOne)) {
-        case 0:
-          // represent 1 as the length of normalized non-zero vector
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue; // normalize doesn't operate on non-gen types.
-          }
-          Expr normalizedExpr = new FunctionCallExpr("normalize", makeOpaqueOne(
-              type, constContext, newDepth, fuzzer));
-          return new FunctionCallExpr("length", normalizedExpr);
-        case 1:
-          // represent 1 as cos(opaqueZero) function, e.g. cos(0.0)
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue; // cos doesn't operate on non-gen types.
-          }
-          return new FunctionCallExpr("cos", makeOpaqueZero(type, constContext, newDepth,
-              fuzzer));
-        case 2:
-          // represent 1 as the exponential function of opaqueZero, e.g. exp(0.0)
-          if (!BasicType.allGenTypes().contains(type)) {
-            continue; // exp doesn't operate on non-gen types.
-          }
-          return new FunctionCallExpr("exp", makeOpaqueZero(type, constContext, newDepth,
-              fuzzer));
-        case 3:
-          return makeOpaqueZeroOrOne(false, type, constContext, newDepth, fuzzer);
-        default:
-          throw new RuntimeException();
-      }
-    }
+                            Fuzzer fuzzer) {
+    return makeOpaqueZeroOrOne(false, type, constContext, depth, fuzzer);
   }
 
   private Expr makeOpaqueZeroOrOne(boolean isZero, BasicType type, boolean constContext,

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -99,9 +99,9 @@ public final class OpaqueExpressionGenerator {
 
   private List<OpaqueZeroOneFactory> waysToMakeZero() {
     if (opaqueZeroFactories.isEmpty()) {
+      opaqueZeroFactories.add(this::opaqueZeroOrOneFromIdentityFunction);
       opaqueZeroFactories.add(this::opaqueZeroOrOneFromInjectionSwitch);
       opaqueZeroFactories.add(this::opaqueZeroOrOneSquareRoot);
-      opaqueZeroFactories.add(this::opaqueZeroOrOneFromIdentityFunction);
       opaqueZeroFactories.add(this::opaqueZeroSin);
       opaqueZeroFactories.add(this::opaqueZeroLogarithm);
     }
@@ -110,14 +110,26 @@ public final class OpaqueExpressionGenerator {
 
   private List<OpaqueZeroOneFactory> waysToMakeOne() {
     if (opaqueOneFactories.isEmpty()) {
+      opaqueOneFactories.add(this::opaqueZeroOrOneFromIdentityFunction);
       opaqueOneFactories.add(this::opaqueZeroOrOneFromInjectionSwitch);
       opaqueOneFactories.add(this::opaqueZeroOrOneSquareRoot);
-      opaqueOneFactories.add(this::opaqueZeroOrOneFromIdentityFunction);
       opaqueOneFactories.add(this::opaqueOneExponential);
       opaqueOneFactories.add(this::opaqueOneCosine);
       opaqueOneFactories.add(this::opaqueOneNormalizedVectorLength);
     }
     return opaqueOneFactories;
+  }
+
+  private Optional opaqueZeroOrOneFromIdentityFunction(BasicType type, boolean constContext,
+                                                       final int depth,
+                                                       Fuzzer fuzzer, boolean isZero) {
+    // Make an opaque value recursively and apply an identity function to it
+    return Optional.of(applyIdentityFunction(makeOpaqueZeroOrOne(isZero, type, constContext,
+        depth, fuzzer),
+        type,
+        constContext,
+        depth,
+        fuzzer));
   }
 
   private Optional opaqueZeroOrOneFromInjectionSwitch(BasicType type, boolean constContext,
@@ -139,19 +151,7 @@ public final class OpaqueExpressionGenerator {
     return Optional.of(new FunctionCallExpr("sqrt", makeOpaqueZeroOrOne(isZero, type, constContext,
         depth, fuzzer)));
   }
-
-  private Optional opaqueZeroOrOneFromIdentityFunction(BasicType type, boolean constContext,
-                                                       final int depth,
-                                                       Fuzzer fuzzer, boolean isZero) {
-    // Make an opaque value recursively and apply an identity function to it
-    return Optional.of(applyIdentityFunction(makeOpaqueZeroOrOne(isZero, type, constContext,
-        depth, fuzzer),
-        type,
-        constContext,
-        depth,
-        fuzzer));
-  }
-
+  
   private Optional opaqueZeroSin(BasicType type, boolean constContext, final int depth,
                                  Fuzzer fuzzer, boolean isZero) {
     // represent 0 as sin(opaqueZero) function, e.g. sin(0.0)

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueZeroOneFactory.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueZeroOneFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.graphicsfuzz.generator.fuzzer;
 
 import com.graphicsfuzz.common.ast.expr.Expr;

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueZeroOneFactory.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueZeroOneFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The GraphicsFuzz Project Authors
+ * Copyright 2019 The GraphicsFuzz Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueZeroOneFactory.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueZeroOneFactory.java
@@ -1,0 +1,11 @@
+package com.graphicsfuzz.generator.fuzzer;
+
+import com.graphicsfuzz.common.ast.expr.Expr;
+import com.graphicsfuzz.common.ast.type.BasicType;
+import java.util.Optional;
+
+@FunctionalInterface
+public interface OpaqueZeroOneFactory {
+  Optional<Expr> tryMakeOpaque(BasicType type, boolean constContext, final int depth,
+                               Fuzzer fuzzer, boolean isZero);
+}


### PR DESCRIPTION
Related issue #427, built-in functions used to generate opaque zero and one expressions are now separated into the different methods.