### PR TITLE
Generator fix: clone injected function prototypes

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -82,6 +82,11 @@ limitations under the License.
       <artifactId>compare-asts</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.graphicsfuzz</groupId>
+      <artifactId>server-thrift-gen</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.generator.transformation;
 
+import com.graphicsfuzz.common.ast.IParentMap;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
@@ -34,18 +35,23 @@ import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.typing.ScopeTreeBuilder;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.generator.transformation.donation.DonationContext;
 import com.graphicsfuzz.generator.transformation.injection.BlockInjectionPoint;
 import com.graphicsfuzz.generator.util.GenerationParams;
 import com.graphicsfuzz.generator.util.TransformationProbabilities;
+import com.graphicsfuzz.server.thrift.ImageJob;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -174,6 +180,152 @@ public class DonateLiveCodeTransformationTest {
             GenerationParams.large(ShaderKind.FRAGMENT, true)
       );
     }
+  }
+
+  @Test
+  public void checkFunctionDeclsUnique() throws Exception {
+    // This test injects live code from a donor into a reference, such that the reference contains
+    // an injected function prototype followed by the injected function definition. We then create a
+    // parent map for the modified reference to ensure that there is no aliasing. I.e. the
+    // function prototype object is not reused in the function definition.
+
+    final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
+
+    final File donors = testFolder.newFolder("donors");
+    final File referenceFile = testFolder.newFile("reference.json");
+    final File variantFile = testFolder.newFile("variant.json");
+
+    {
+      // A call to "bar", which calls "foo" via its prototype (i.e. "foo" is defined after "bar").
+      final String donorSource =
+          "#version 300 es\n"
+          + "\n"
+          + "int foo(int f);\n"
+          + "\n"
+          + "int bar(int b) {\n"
+          + "    return foo(b);\n"
+          + "}\n"
+          + "\n"
+          + "int foo(int f) {\n"
+          + "    return f + 1;\n"
+          + "}\n"
+          + "\n"
+          + "void main() {\n"
+          + "    bar(1);\n"
+          + "}\n";
+
+      fileOps.writeShaderJobFileFromImageJob(
+          new ImageJob()
+              .setFragmentSource(donorSource)
+              .setUniformsInfo("{}"),
+          new File(donors, "donor.json")
+      );
+    }
+
+    {
+      final String referenceSource = "#version 300 es\n"
+          + "void main() {"
+          + "  "
+          + "}";
+
+      fileOps.writeShaderJobFileFromImageJob(
+          new ImageJob()
+              .setFragmentSource(referenceSource)
+              .setUniformsInfo("{}"),
+          referenceFile
+
+      );
+    }
+
+    final ShaderJob referenceShaderJob = fileOps.readShaderJobFile(referenceFile);
+
+    DonateLiveCodeTransformation transformation =
+        new DonateLiveCodeTransformation(IRandom::nextBoolean, donors,
+        GenerationParams.normal(ShaderKind.FRAGMENT, true), false);
+
+    assert referenceShaderJob.getFragmentShader().isPresent();
+
+    boolean result = transformation.apply(
+        referenceShaderJob.getFragmentShader().get(),
+        TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
+        new RandomWrapper(0),
+        GenerationParams.normal(ShaderKind.FRAGMENT, true)
+    );
+
+    Assert.assertTrue(result);
+
+    fileOps.writeShaderJobFile(referenceShaderJob, variantFile);
+    fileOps.areShadersValid(variantFile, true);
+
+    // Creating a parent map checks that there is no aliasing in the AST.
+    IParentMap.createParentMap(referenceShaderJob.getFragmentShader().get());
+  }
+
+  @Test
+  public void verySimpleDonorAndSourceNoPrecision() throws Exception {
+    // This test injects live code from a donor into a reference. The donor and reference contain
+    // almost no code. The modified reference is output and validated. This caught an issue where
+    // shaders without precision qualifiers became invalid because the injected color and coord
+    // variables did not have precision qualifiers.
+
+    final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
+
+    final File donors = testFolder.newFolder("donors");
+    final File referenceFile = testFolder.newFile("reference.json");
+    final File variantFile = testFolder.newFile("variant.json");
+
+    {
+      final String donorSource =
+          "#version 300 es\n"
+              + "void main() {\n"
+              + "    1;\n"
+              + "}\n";
+
+      fileOps.writeShaderJobFileFromImageJob(
+          new ImageJob()
+              .setFragmentSource(donorSource)
+              .setUniformsInfo("{}"),
+          new File(donors, "donor.json")
+      );
+    }
+
+    {
+      final String referenceSource = "#version 300 es\n"
+          + "void main() {"
+          + "  "
+          + "}";
+
+      fileOps.writeShaderJobFileFromImageJob(
+          new ImageJob()
+              .setFragmentSource(referenceSource)
+              .setUniformsInfo("{}"),
+          referenceFile
+
+      );
+    }
+
+    final ShaderJob referenceShaderJob = fileOps.readShaderJobFile(referenceFile);
+
+    DonateLiveCodeTransformation transformation =
+        new DonateLiveCodeTransformation(IRandom::nextBoolean, donors,
+            GenerationParams.normal(ShaderKind.FRAGMENT, true), false);
+
+    assert referenceShaderJob.getFragmentShader().isPresent();
+
+    boolean result = transformation.apply(
+        referenceShaderJob.getFragmentShader().get(),
+        TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
+        new RandomWrapper(0),
+        GenerationParams.normal(ShaderKind.FRAGMENT, true)
+    );
+
+    Assert.assertTrue(result);
+
+    fileOps.writeShaderJobFile(referenceShaderJob, variantFile);
+    fileOps.areShadersValid(variantFile, true);
+
+    // Creating a parent map checks that there is no aliasing in the AST.
+    IParentMap.createParentMap(referenceShaderJob.getFragmentShader().get());
   }
 
 }


### PR DESCRIPTION
Fixes #446 : injected function prototypes are aliased with their definitions. 
Fixes #452 : donating code to a recipient can lead to an invalid shader if the recipient has no precision qualifiers; fixed by ensuring that the new "color" and "coord" global variables have explicit precision qualifiers. 

Added tests. 