### PR TITLE
Remove parentheses after eliminating macros

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/SwitchStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/SwitchStmt.java
@@ -34,10 +34,6 @@ public class SwitchStmt extends Stmt {
     return expr;
   }
 
-  public void setExpr(Expr expr) {
-    this.expr = expr;
-  }
-
   public BlockStmt getBody() {
     return body;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/SwitchStmt.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/stmt/SwitchStmt.java
@@ -34,6 +34,10 @@ public class SwitchStmt extends Stmt {
     return expr;
   }
 
+  public void setExpr(Expr expr) {
+    this.expr = expr;
+  }
+
   public BlockStmt getBody() {
     return body;
   }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
@@ -33,23 +33,23 @@ public class EliminateInjectionMacrosVisitor extends StandardVisitor {
   protected void visitChildFromParent(IAstNode child, IAstNode parent) {
     super.visitChildFromParent(child, parent);
     if (child instanceof FunctionCallExpr) {
-      Expr expr = (Expr) child;
-      if (MacroNames.isIdentity(expr)
-          || MacroNames.isZero(expr)
-          || MacroNames.isOne(expr)
-          || MacroNames.isFalse(expr)
-          || MacroNames.isTrue(expr)) {
+      final FunctionCallExpr functionCallExpr = (FunctionCallExpr) child;
+      if (MacroNames.isIdentity(functionCallExpr)
+          || MacroNames.isZero(functionCallExpr)
+          || MacroNames.isOne(functionCallExpr)
+          || MacroNames.isFalse(functionCallExpr)
+          || MacroNames.isTrue(functionCallExpr)) {
         parent.replaceChild(child,
-            addParenthesesIfNecessary(parent, ((FunctionCallExpr) child).getChild(1)));
-      } else if (MacroNames.isFuzzed(expr)
-          || MacroNames.isDeadByConstruction(expr)
-          || MacroNames.isSwitch(expr)
-          || MacroNames.isLoopWrapper(expr)
-          || MacroNames.isIfWrapperFalse(expr)
-          || MacroNames.isIfWrapperTrue(expr)
+            addParenthesesIfNecessary(parent, functionCallExpr.getChild(1)));
+      } else if (MacroNames.isFuzzed(functionCallExpr)
+          || MacroNames.isDeadByConstruction(functionCallExpr)
+          || MacroNames.isSwitch(functionCallExpr)
+          || MacroNames.isLoopWrapper(functionCallExpr)
+          || MacroNames.isIfWrapperFalse(functionCallExpr)
+          || MacroNames.isIfWrapperTrue(functionCallExpr)
       ) {
         parent.replaceChild(child,
-            addParenthesesIfNecessary(parent, ((FunctionCallExpr) child).getChild(0)));
+            addParenthesesIfNecessary(parent, functionCallExpr.getChild(0)));
       }
     }
   }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
@@ -209,7 +209,7 @@ public class EliminateInjectionMacrosVisitor extends StandardVisitor {
 
   private void replaceChildWithGrandchild(Expr parent, int childIndex, int grandchildIndex) {
     assert parent.getChild(childIndex).getNumChildren() > grandchildIndex;
-    parent.setChild(0, (Expr) addParenthesesIfNecessary(parent,
+    parent.setChild(childIndex, (Expr) addParenthesesIfNecessary(parent,
         parent.getChild(childIndex).getChild(grandchildIndex)));
   }
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
@@ -77,7 +77,10 @@ public class EliminateInjectionMacrosVisitor extends StandardVisitor {
     }
 
     if (parent instanceof FunctionCallExpr) {
-      // This ensures that the binary expression inside the function call is not a comma operator
+      // Parentheses is unnecessary if parent is a function call expression.
+      // For example, foo(_GLF_FUNCTION(a)).
+
+      // This asserts that the binary expression inside the function call is not a comma operator
       // as it is invalid to have a comma appear directly here, e.g. _GLF_IDENTITY(expr, a, b) is
       // not valid since a and b are treated as function arguments instead.
       assert (!(child instanceof BinaryExpr) || ((BinaryExpr) child).getOp() != BinOp.COMMA);

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/glslreducers/EliminateInjectionMacrosVisitor.java
@@ -17,115 +17,17 @@
 package com.graphicsfuzz.reducer.glslreducers;
 
 import com.graphicsfuzz.common.ast.IAstNode;
-import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.ConstantExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
-import com.graphicsfuzz.common.ast.expr.MemberLookupExpr;
 import com.graphicsfuzz.common.ast.expr.ParenExpr;
-import com.graphicsfuzz.common.ast.expr.TernaryExpr;
-import com.graphicsfuzz.common.ast.expr.TypeConstructorExpr;
-import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
-import com.graphicsfuzz.common.ast.stmt.DoStmt;
-import com.graphicsfuzz.common.ast.stmt.ForStmt;
-import com.graphicsfuzz.common.ast.stmt.IfStmt;
-import com.graphicsfuzz.common.ast.stmt.LoopStmt;
-import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
-import com.graphicsfuzz.common.ast.stmt.WhileStmt;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.reducer.reductionopportunities.MacroNames;
 
 public class EliminateInjectionMacrosVisitor extends StandardVisitor {
-
-  @Override
-  public void visitBinaryExpr(BinaryExpr binaryExpr) {
-    super.visitBinaryExpr(binaryExpr);
-    cleanUpMacros(binaryExpr);
-  }
-
-  @Override
-  public void visitUnaryExpr(UnaryExpr unaryExpr) {
-    super.visitUnaryExpr(unaryExpr);
-    cleanUpMacros(unaryExpr);
-  }
-
-  @Override
-  public void visitParenExpr(ParenExpr parenExpr) {
-    super.visitParenExpr(parenExpr);
-    cleanUpMacros(parenExpr);
-  }
-
-  @Override
-  public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
-    super.visitFunctionCallExpr(functionCallExpr);
-    cleanUpMacros(functionCallExpr);
-  }
-
-  public void visitArrayIndexExpr(ArrayIndexExpr arrayIndexExpr) {
-    super.visitArrayIndexExpr(arrayIndexExpr);
-    cleanUpMacros(arrayIndexExpr);
-  }
-
-  public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
-    super.visitMemberLookupExpr(memberLookupExpr);
-    cleanUpMacros(memberLookupExpr);
-  }
-
-  public void visitTernaryExpr(TernaryExpr ternaryExpr) {
-    super.visitTernaryExpr(ternaryExpr);
-    cleanUpMacros(ternaryExpr);
-  }
-
-  @Override
-  public void visitTypeConstructorExpr(TypeConstructorExpr typeConstructorExpr) {
-    super.visitTypeConstructorExpr(typeConstructorExpr);
-    cleanUpMacros(typeConstructorExpr);
-  }
-
-  @Override
-  public void visitIfStmt(IfStmt ifStmt) {
-    super.visitIfStmt(ifStmt);
-    if (MacroNames.isDeadByConstruction(ifStmt.getCondition())
-        || MacroNames.isIfWrapperFalse(ifStmt.getCondition())
-        || MacroNames.isIfWrapperTrue(ifStmt.getCondition())) {
-      ifStmt.setCondition(ifStmt.getCondition().getChild(0));
-    }
-  }
-
-  @Override
-  public void visitSwitchStmt(SwitchStmt switchStmt) {
-    super.visitSwitchStmt(switchStmt);
-    if (MacroNames.isSwitch(switchStmt.getExpr())) {
-      switchStmt.setExpr(switchStmt.getExpr().getChild(0));
-    }
-  }
-
-  @Override
-  public void visitWhileStmt(WhileStmt whileStmt) {
-    super.visitWhileStmt(whileStmt);
-    cleanupLoop(whileStmt);
-  }
-
-  private void cleanupLoop(LoopStmt loopStmt) {
-    if (MacroNames.isLoopWrapper(loopStmt.getCondition())) {
-      loopStmt.setCondition(loopStmt.getCondition().getChild(0));
-    }
-  }
-
-  @Override
-  public void visitDoStmt(DoStmt doStmt) {
-    super.visitDoStmt(doStmt);
-    cleanupLoop(doStmt);
-  }
-
-  @Override
-  public void visitForStmt(ForStmt forStmt) {
-    super.visitForStmt(forStmt);
-    cleanupLoop(forStmt);
-  }
 
   @Override
   protected void visitChildFromParent(IAstNode child, IAstNode parent) {
@@ -140,7 +42,12 @@ public class EliminateInjectionMacrosVisitor extends StandardVisitor {
         parent.replaceChild(child,
             addParenthesesIfNecessary(parent, ((FunctionCallExpr) child).getChild(1)));
       } else if (MacroNames.isFuzzed(expr)
-          || MacroNames.isDeadByConstruction(expr)) {
+          || MacroNames.isDeadByConstruction(expr)
+          || MacroNames.isSwitch(expr)
+          || MacroNames.isLoopWrapper(expr)
+          || MacroNames.isIfWrapperFalse(expr)
+          || MacroNames.isIfWrapperTrue(expr)
+      ) {
         parent.replaceChild(child,
             addParenthesesIfNecessary(parent, ((FunctionCallExpr) child).getChild(0)));
       }
@@ -189,27 +96,4 @@ public class EliminateInjectionMacrosVisitor extends StandardVisitor {
     return true;
   }
 
-  private void cleanUpMacros(Expr parent) {
-    for (int i = 0; i < parent.getNumChildren(); i++) {
-      Expr child = parent.getChild(i);
-      // Note: it would be redundant to have a special function reduction opportunity
-      // be classed also as a fuzzed expression reduction opportunity
-      if (MacroNames.isIdentity(child)
-          || MacroNames.isZero(child)
-          || MacroNames.isOne(child)
-          || MacroNames.isFalse(child)
-          || MacroNames.isTrue(child)) {
-        replaceChildWithGrandchild(parent, i, 1);
-      } else if (MacroNames.isFuzzed(child)
-          || MacroNames.isDeadByConstruction(child)) {
-        replaceChildWithGrandchild(parent, i, 0);
-      }
-    }
-  }
-
-  private void replaceChildWithGrandchild(Expr parent, int childIndex, int grandchildIndex) {
-    assert parent.getChild(childIndex).getNumChildren() > grandchildIndex;
-    parent.setChild(childIndex, (Expr) addParenthesesIfNecessary(parent,
-        parent.getChild(childIndex).getChild(grandchildIndex)));
-  }
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
@@ -133,7 +133,6 @@ public class SimplifyTest {
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  @Ignore
   @Test
   public void testFunctionCallParenthesesRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
@@ -114,8 +114,6 @@ public class SimplifyTest {
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  // TODO(491): Enable once issue 491 is fixed.
-  @Ignore
   @Test
   public void testIdentityNotNestedRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
@@ -19,13 +19,10 @@ package com.graphicsfuzz.reducer.util;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.util.CompareAsts;
 import com.graphicsfuzz.common.util.ParseHelper;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class SimplifyTest {
 
-  // TODO(110) - this test fails due to issue 110, and should be enabled once that issue is fixed.
-  @Ignore
   @Test
   public void testIfParenthesesRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"
@@ -40,11 +37,10 @@ public class SimplifyTest {
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  @Ignore
   @Test
   public void testWhileParenthesesRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"
-        + "  while (_GLF_DEAD(_GLF_FALSE(false, false))) {"
+        + "  while(_GLF_WRAPPED_LOOP(_GLF_FALSE(false ,_GLF_DEAD(_GLF_FALSE(false, false))))) {"
         + "  }"
         + "}");
     final String expected = "void main() {"
@@ -55,30 +51,28 @@ public class SimplifyTest {
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  @Ignore
   @Test
   public void testForParenthesesRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"
         + " for ("
-        + "   int i = _GLF_ONE(1, _GLF_IDENTITY(1, 1));"
+        + "   int i = int(_GLF_ONE(1.0, _GLF_IDENTITY(1.0, 1.0)));"
         + "   i > _GLF_IDENTITY(1, _GLF_FUZZED(1));"
         + "   i++)"
         + "   { }"
         + " }"
         + "}");
     final String expected = "void main() {"
-        + " for (int i = 1; i > 1; i++)"
+        + " for (int i = int(1.0); i > 1; i++)"
         + "   { }"
         + "}";
     final TranslationUnit simplifiedTu = Simplify.simplify(tu);
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  @Ignore
   @Test
   public void testSwitchParenthesesRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"
-        + " switch(_GLF_ZERO(0, _GLF_IDENTITY(0, 0)))"
+        + " switch(_GLF_SWITCH(_GLF_ZERO(0, _GLF_IDENTITY(0, 0))))"
         + "   {"
         + "   }"
         + "}");
@@ -91,11 +85,10 @@ public class SimplifyTest {
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  @Ignore
   @Test
   public void testDoWhileParenthesesRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"
-        + " do { } while (_GLF_DEAD(_GLF_FALSE(false, false)));"
+        + " do { } while (_GLF_WRAPPED_LOOP(_GLF_DEAD(_GLF_FALSE(false, false))));"
         + "}");
     final String expected = "void main() {"
         + " do { } while (false);"
@@ -104,7 +97,6 @@ public class SimplifyTest {
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
 
-  @Ignore
   @Test
   public void testMacroBlockRemoved() throws Exception {
     final TranslationUnit tu = ParseHelper.parse("void main() {"
@@ -113,7 +105,7 @@ public class SimplifyTest {
         + " int a = _GLF_IDENTITY(_GLF_FUZZED(1), 1);"
         + "}"
     );
-    final String expected = "void() {"
+    final String expected = "void main() {"
         + " 1;"
         + " 1;"
         + " int a = 1;"


### PR DESCRIPTION
Related issue: #110 

- Remove the unneeded parentheses that exist after the macros elimination
- Update statement in the test cases that previously do not have the wrapper