### PR TITLE
Reducer opportunity to remove redundant uniform metadata

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -1011,7 +1011,14 @@ public class ShaderJobFileOperations {
     byte[] computeData = isFile(computeShaderFile)
         ? readFileToByteArray(computeShaderFile)
         : new byte[0];
-    byte[] combinedData = new byte[vertexData.length + fragmentData.length + computeData.length];
+    // This metadata is required since in the case of
+    // RemoveRedundantUniformMetadataReductionOpportunities
+    // only metadata in json is removed, not the shaders.
+    byte[] metaData = isFile(shaderJobFile)
+        ? readFileToByteArray(shaderJobFile)
+        : new byte[0];
+    byte[] combinedData =
+        new byte[vertexData.length + fragmentData.length + computeData.length + metaData.length ];
     System.arraycopy(
         vertexData,
         0,
@@ -1030,6 +1037,12 @@ public class ShaderJobFileOperations {
         combinedData,
         vertexData.length + fragmentData.length,
         computeData.length);
+    System.arraycopy(
+        metaData,
+        0,
+        combinedData,
+        vertexData.length + fragmentData.length + computeData.length,
+        metaData.length);
     return DigestUtils.md5Hex(combinedData);
   }
 

--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -1011,9 +1011,8 @@ public class ShaderJobFileOperations {
     byte[] computeData = isFile(computeShaderFile)
         ? readFileToByteArray(computeShaderFile)
         : new byte[0];
-    // This metadata is required since in the case of
-    // RemoveRedundantUniformMetadataReductionOpportunities
-    // only metadata in json is removed, not the shaders.
+    //  This metadata is required in order to distinguish between shader jobs
+    //  with identical shaders but different pipeline information.
     byte[] metaData = isFile(shaderJobFile)
         ? readFileToByteArray(shaderJobFile)
         : new byte[0];

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
@@ -297,7 +297,7 @@ public class ReductionDriver {
         context.getEmitGraphicsFuzzDefines()
     );
     if (requiresUniformBindings) {
-      assert state.hasUniformBindings();
+      assert state.getPipelineInfo().getNumUniforms() == 0 || state.hasUniformBindings();
       state.removeUniformBindings();
     }
   }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
@@ -90,6 +90,7 @@ public class ReductionDriver {
         IReductionOpportunityFinder.inlineFunctionFinder(),
         IReductionOpportunityFinder.unusedParamFinder(),
         IReductionOpportunityFinder.foldConstantFinder(),
+        IReductionOpportunityFinder.redundantUniformMetadataFinder()
     }) {
       cleanupPasses.add(new SystematicReductionPass(context,
           verbose,

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
@@ -476,7 +476,7 @@ public interface IReductionOpportunityFinder<T extends IReductionOpportunity> {
 
       @Override
       public String getName() {
-        return "unusedUniformMetadata";
+        return "redundantUniformMetadata";
       }
     };
   }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
@@ -462,4 +462,23 @@ public interface IReductionOpportunityFinder<T extends IReductionOpportunity> {
     };
   }
 
+  static IReductionOpportunityFinder<RemoveRedundantUniformMetadataReductionOpportunity>
+      redundantUniformMetadataFinder() {
+    return new IReductionOpportunityFinder<RemoveRedundantUniformMetadataReductionOpportunity>() {
+      @Override
+      public List<RemoveRedundantUniformMetadataReductionOpportunity> findOpportunities(
+          ShaderJob shaderJob,
+          ReducerContext context) {
+        return RemoveRedundantUniformMetadataReductionOpportunities.findOpportunities(
+            shaderJob,
+            context);
+      }
+
+      @Override
+      public String getName() {
+        return "unusedUniformMetadata";
+      }
+    };
+  }
+
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunities.java
@@ -65,7 +65,8 @@ public final class ReductionOpportunities {
         IReductionOpportunityFinder.liveFragColorWriteFinder(),
         IReductionOpportunityFinder.unusedParamFinder(),
         IReductionOpportunityFinder.foldConstantFinder(),
-        IReductionOpportunityFinder.inlineUniformFinder())) {
+        IReductionOpportunityFinder.inlineUniformFinder(),
+        IReductionOpportunityFinder.redundantUniformMetadataFinder())) {
       final List<? extends IReductionOpportunity> currentOpportunities = ros
             .findOpportunities(shaderJob, context);
       if (ReductionDriver.DEBUG_REDUCER) {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunities.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
+import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.ListConcat;
+import com.graphicsfuzz.common.util.PipelineInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RemoveRedundantUniformMetadataReductionOpportunities
+    extends ReductionOpportunitiesBase<RemoveRedundantUniformMetadataReductionOpportunity> {
+
+  private final PipelineInfo pipelineInfo;
+  private List<String> redundantUniformNames;
+
+  public RemoveRedundantUniformMetadataReductionOpportunities(TranslationUnit tu,
+                                                              ReducerContext context,
+                                                              PipelineInfo pipelineInfo) {
+    super(tu, context);
+    this.pipelineInfo = pipelineInfo;
+  }
+
+  static List<RemoveRedundantUniformMetadataReductionOpportunity> findOpportunities(
+      ShaderJob shaderJob,
+      ReducerContext context) {
+    return shaderJob.getShaders()
+        .stream()
+        .map(item -> findOpportunitiesForShader(item, context, shaderJob.getPipelineInfo()))
+        .reduce(Arrays.asList(), ListConcat::concatenate);
+  }
+
+  @Override
+  public void visitTranslationUnit(TranslationUnit translationUnit) {
+    redundantUniformNames = new ArrayList<>(pipelineInfo.getUniformNames());
+    super.visitTranslationUnit(translationUnit);
+
+    for (String uniformName : redundantUniformNames) {
+      addOpportunity(new RemoveRedundantUniformMetadataReductionOpportunity(uniformName,
+          pipelineInfo, getVistitationDepth()));
+    }
+  }
+
+  private static List<RemoveRedundantUniformMetadataReductionOpportunity>
+      findOpportunitiesForShader(TranslationUnit tu,
+                               ReducerContext context,
+                               PipelineInfo pipelineInfo) {
+    RemoveRedundantUniformMetadataReductionOpportunities finder =
+          new RemoveRedundantUniformMetadataReductionOpportunities(tu, context, pipelineInfo);
+    finder.visit(tu);
+    return finder.getOpportunities();
+  }
+
+  @Override
+  public void visitVariablesDeclaration(VariablesDeclaration variablesDeclaration) {
+    // This prevents removing a uniform declared but not used.
+    super.visitVariablesDeclaration(variablesDeclaration);
+    for (VariableDeclInfo vdi : variablesDeclaration.getDeclInfos()) {
+      removeRedundantUniformName(vdi.getName());
+    }
+  }
+
+  @Override
+  public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
+    super.visitVariableIdentifierExpr(variableIdentifierExpr);
+    final String name = variableIdentifierExpr.getName();
+    removeRedundantUniformName(name);
+  }
+
+  private void removeRedundantUniformName(String name) {
+    assert redundantUniformNames != null;
+    redundantUniformNames.remove(name);
+  }
+
+}

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunity.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.visitors.VisitationDepth;
+import com.graphicsfuzz.common.util.PipelineInfo;
+
+public class RemoveRedundantUniformMetadataReductionOpportunity
+    extends AbstractReductionOpportunity {
+
+  private final PipelineInfo pipelineInfo;
+  private final String uniformName;
+
+  RemoveRedundantUniformMetadataReductionOpportunity(String uniformName,
+                                                     PipelineInfo pipelineInfo,
+                                                     VisitationDepth depth) {
+    super(depth);
+    this.pipelineInfo = pipelineInfo;
+    this.uniformName = uniformName;
+  }
+
+  @Override
+  void applyReductionImpl() {
+    pipelineInfo.removeUniform(uniformName);
+  }
+
+  @Override
+  public boolean preconditionHolds() {
+    return pipelineInfo.getUniformNames().contains(uniformName);
+  }
+
+}

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
@@ -563,8 +563,6 @@ public class ReductionDriverTest {
 
   }
 
-  // TODO(478): Enable this test once the issue is fixed.
-  @Ignore
   @Test
   public void testReductionOfUnreferencedUniform() throws Exception {
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
@@ -27,16 +27,12 @@ import com.graphicsfuzz.common.util.RandomWrapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
 
-  // TODO(478): enable this test once the issue is addressed.
-  @Ignore
   @Test
   public void testRemoveUnused() throws Exception {
     // Make a shader job with an empty fragment shader, and declare one uniform in the pipeline
@@ -50,15 +46,13 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     assertEquals(1, shaderJob.getPipelineInfo().getNumUniforms());
 
     // There should be exactly one opportunity to remove a piece of unused pipeline state.
-    // TODO(478): remove the Assert.fail(), and un-comment the lines that follow it.
-    Assert.fail();
-    //List<RemoveRedundantUniformMetadatReductionOpportunity> ops =
-    //    RemoveRedundantUniformMetadatReductionOpportunities
-    //    .findOpportunities(shaderJob,
-    //        new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), null,
-    //            true));
-    //assertEquals(1, ops.size());
-    //ops.get(0).applyReduction();
+    List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
+        RemoveRedundantUniformMetadataReductionOpportunities
+        .findOpportunities(shaderJob,
+            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), null,
+                true));
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
 
     // Check that after applying the reduction opportunity there are no uniforms in the pipeline
     // state and that the shader has not changed.
@@ -66,8 +60,6 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     assertEquals(0, shaderJob.getPipelineInfo().getNumUniforms());
   }
 
-  // TODO(478): enable this test once the issue is addressed.
-  @Ignore
   @Test
   public void testDoNotRemoveUsed() throws Exception {
     // Make a shader job with a simple fragment shader that declares (but does not use)
@@ -82,14 +74,12 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     assertEquals(1, shaderJob.getPipelineInfo().getNumUniforms());
 
     // There should be exactly one opportunity to remove a piece of unused pipeline state.
-    // TODO(478): remove the Assert.fail(), and un-comment the lines that follow it.
-    Assert.fail();
-    //List<RemoveRedundantUniformMetadatReductionOpportunity> ops =
-    //    RemoveRedundantUniformMetadatReductionOpportunities
-    //    .findOpportunities(shaderJob,
-    //        new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), null,
-    //            true));
-    //assertEquals(0, ops.size());
+    List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
+        RemoveRedundantUniformMetadataReductionOpportunities
+        .findOpportunities(shaderJob,
+            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), null,
+                true));
+    assertEquals(0, ops.size());
   }
 
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
@@ -77,16 +77,14 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     assertEquals(1, shaderJob.getPipelineInfo().getNumUniforms());
 
     // There should be exactly one opportunity to remove a piece of unused pipeline state.
-    // TODO(478): remove the Assert.fail(), and un-comment the lines that follow it.
-    Assert.fail();
-    //List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
-    //    RemoveRedundantUniformMetadataReductionOpportunities
-    //        .findOpportunities(shaderJob,
-    //            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
-    //            null,
-    //            true));
-    //assertEquals(1, ops.size());
-    //ops.get(0).applyReduction();
+    List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
+        RemoveRedundantUniformMetadataReductionOpportunities
+            .findOpportunities(shaderJob,
+                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                null,
+                true));
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
 
     // Check that after applying the reduction opportunity there are no uniforms in the pipeline
     // state and that the shader has not changed.
@@ -94,8 +92,6 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     assertEquals(0, shaderJob.getPipelineInfo().getNumUniforms());
   }
 
-  // TODO(478): enable this test once the issue is addressed.
-  @Ignore
   @Test
   public void testDoNotRemoveUsed() throws Exception {
     // Make a shader job with a simple fragment shader that declares (but does not use)
@@ -109,7 +105,7 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     // Check that initially there is indeed one uniform in the pipeline state.
     assertEquals(1, shaderJob.getPipelineInfo().getNumUniforms());
 
-    // There should be exactly one opportunity to remove a piece of unused pipeline state.
+    // There should be no opportunities to remove a piece of unused pipeline state.
     List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
         RemoveRedundantUniformMetadataReductionOpportunities
         .findOpportunities(shaderJob,
@@ -118,8 +114,6 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     assertEquals(0, ops.size());
   }
 
-  // TODO(478): enable this test once the issue is addressed.
-  @Ignore
   @Test
   public void testDoNotRemoveUsedMultipleShaders() throws Exception {
     // A shader job with a vertex shader and fragment shader that each use a different
@@ -142,14 +136,12 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
 
     // There should be no opportunities to remove a piece of unused pipeline state, since both
     // uniforms are referenced.
-    // TODO(478): remove the Assert.fail(), and un-comment the lines that follow it.
-    Assert.fail();
-    //List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
-    //    RemoveRedundantUniformMetadataReductionOpportunities
-    //        .findOpportunities(shaderJob,
-    //            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
-    //            null, true));
-    //assertEquals(0, ops.size());
+    List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
+        RemoveRedundantUniformMetadataReductionOpportunities
+            .findOpportunities(shaderJob,
+                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                null, true));
+    assertEquals(0, ops.size());
   }
 
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
@@ -130,7 +130,7 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
         Collections.singletonList(20.0));
     final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(),
         pipelineInfo, ParseHelper.parse(minimalVertexShader, ShaderKind.VERTEX),
-        ParseHelper.parse(minimalVertexShader, ShaderKind.FRAGMENT));
+        ParseHelper.parse(minimalFragmentShader, ShaderKind.FRAGMENT));
     // Check that initially there are indeed two uniforms in the pipeline state.
     assertEquals(2, shaderJob.getPipelineInfo().getNumUniforms());
 


### PR DESCRIPTION
Related issue: #478

Added a new reducer opportunity which removes all redundant uniforms metadata in JSON except for the uniforms that are declared but not used.