### PR TITLE
Renaming of 'shaderset' to 'shader family'

### DIFF
--- a/server/src/main/java/com/graphicsfuzz/server/webui/WebUiConstants.java
+++ b/server/src/main/java/com/graphicsfuzz/server/webui/WebUiConstants.java
@@ -24,7 +24,7 @@ public final class WebUiConstants {
 
   static final String FILE_ROUTE = "file";
   static final String WORKER_DIR = "processing";
-  static final String SHADERSET_DIR = "shaderfamilies";
+  static final String SHADER_FAMILIES_DIR = "shaderfamilies";
   static final String WORKER_INFO_FILE = "client.json";
   static final String COMPUTE_SHADER_DOC_URL =
       "https://github.com/google/graphicsfuzz/blob/master/docs/glsl-fuzz-walkthrough"


### PR DESCRIPTION
In preparation for some work on the WebUI, here is a bit of renaming of the legacy term 'shaderset' to the more up-to-date term 'shader family'.

The renaming has only been applied to Java classes and variables, comments, and messages in the WebUI.  It has not been applied to the web logic of the WebUI itself.