### PR TITLE
Remove guard against shader_translator memory exhaustion error

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -1123,20 +1123,10 @@ public class ShaderJobFileOperations {
         shaderFile,
         ShaderTranslatorShadingLanguageVersionSupport
             .getShaderTranslatorArgument(shadingLanguageVersion));
-    if (isMemoryExhaustedError(shaderTranslatorResult)) {
-      return true;
-    }
     return checkValidationResult(
         shaderTranslatorResult,
         shaderFile.getName(),
         throwExceptionOnValidationError);
-  }
-
-  // TODO(171): This is a workaround for an issue where shader_translator reports memory exhaustion.
-  // If the issue in shader_translator can be fixed, we should get rid of this check.
-  private boolean isMemoryExhaustedError(ExecResult shaderTranslatorResult) {
-    return shaderTranslatorResult.res != 0
-        && shaderTranslatorResult.stdout.toString().contains("memory exhausted");
   }
 
   private boolean checkValidationResult(ExecResult res,


### PR DESCRIPTION
The problem has been fixed in shader_translator.