### PR TITLE
Added more tests for removing uniforms

### DIFF
--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
@@ -24,6 +24,7 @@ import com.graphicsfuzz.common.util.CompareAsts;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.PipelineInfo;
 import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.ShaderKind;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -69,6 +70,41 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
   // TODO(478): enable this test once the issue is addressed.
   @Ignore
   @Test
+  public void testRemoveUnusedNameShadowing() throws Exception {
+    // Checks for the case where a uniform declared in the pipeline state is not used, but another
+    // variable shadows its name.
+    final String minimalShader = "void main() { int shadow; }";
+    final PipelineInfo pipelineInfo = new PipelineInfo();
+    pipelineInfo.addUniform("shadow", BasicType.FLOAT, Optional.empty(),
+        Collections.singletonList(10.0));
+    final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(),
+        pipelineInfo, ParseHelper.parse(minimalShader));
+    // The pipeline info has an unused uniform named 'shadow', and the shader declares an unrelated
+    // variable called 'shadow'.  We would like the uniform to be removed from the pipeline info,
+    // as it is not used.
+    assertEquals(1, shaderJob.getPipelineInfo().getNumUniforms());
+
+    // There should be exactly one opportunity to remove a piece of unused pipeline state.
+    // TODO(478): remove the Assert.fail(), and un-comment the lines that follow it.
+    Assert.fail();
+    //List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
+    //    RemoveRedundantUniformMetadataReductionOpportunities
+    //        .findOpportunities(shaderJob,
+    //            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+    //            null,
+    //            true));
+    //assertEquals(1, ops.size());
+    //ops.get(0).applyReduction();
+
+    // Check that after applying the reduction opportunity there are no uniforms in the pipeline
+    // state and that the shader has not changed.
+    CompareAsts.assertEqualAsts(minimalShader, shaderJob.getFragmentShader().get());
+    assertEquals(0, shaderJob.getPipelineInfo().getNumUniforms());
+  }
+
+  // TODO(478): enable this test once the issue is addressed.
+  @Ignore
+  @Test
   public void testDoNotRemoveUsed() throws Exception {
     // Make a shader job with a simple fragment shader that declares (but does not use)
     // a uniform.  We don't want the metadata for this uniform to get removed; the declaration
@@ -89,6 +125,40 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     //    .findOpportunities(shaderJob,
     //        new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), null,
     //            true));
+    //assertEquals(0, ops.size());
+  }
+
+  // TODO(478): enable this test once the issue is addressed.
+  @Ignore
+  @Test
+  public void testDoNotRemoveUsedMultipleShaders() throws Exception {
+    // A shader job with a vertex shader and fragment shader that each use a different
+    // uniform (but that do not use a uniform in common).  Neither uniform should be removed
+    // from the pipeline state.
+    final String minimalVertexShader = "uniform float used_in_vertex_only; void main() { "
+        + "used_in_vertex_only; }";
+    final String minimalFragmentShader = "uniform float used_in_fragment_only; void main() { "
+        + "used_in_fragment_only; }";
+    final PipelineInfo pipelineInfo = new PipelineInfo();
+    pipelineInfo.addUniform("used_in_vertex_only", BasicType.FLOAT, Optional.empty(),
+        Collections.singletonList(10.0));
+    pipelineInfo.addUniform("used_in_fragment_only", BasicType.FLOAT, Optional.empty(),
+        Collections.singletonList(20.0));
+    final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(),
+        pipelineInfo, ParseHelper.parse(minimalVertexShader, ShaderKind.VERTEX),
+        ParseHelper.parse(minimalVertexShader, ShaderKind.FRAGMENT));
+    // Check that initially there are indeed two uniforms in the pipeline state.
+    assertEquals(2, shaderJob.getPipelineInfo().getNumUniforms());
+
+    // There should be no opportunities to remove a piece of unused pipeline state, since both
+    // uniforms are referenced.
+    // TODO(478): remove the Assert.fail(), and un-comment the lines that follow it.
+    Assert.fail();
+    //List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
+    //    RemoveRedundantUniformMetadataReductionOpportunities
+    //        .findOpportunities(shaderJob,
+    //            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+    //            null, true));
     //assertEquals(0, ops.size());
   }
 


### PR DESCRIPTION
The tests check the cases where (a) a uniform is truly unused, but
there is a use of a shadowing variable with the same name, and (b) a
uniform is used in a fragment shader but not vertex shader, and vice
versa.