### PR TITLE
Add e test for function call macro parentheses removal

### DIFF
--- a/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/util/SimplifyTest.java
@@ -142,4 +142,18 @@ public class SimplifyTest {
     final TranslationUnit simplifiedTu = Simplify.simplify(tu);
     CompareAsts.assertEqualAsts(expected, simplifiedTu);
   }
+
+  @Ignore
+  @Test
+  public void testFunctionCallParenthesesRemoved() throws Exception {
+    final TranslationUnit tu = ParseHelper.parse("void main() {"
+        + "foo(_GLF_IDENTITY(1 + 2, 1 + 2));"
+        + "}"
+    );
+    final String expected = "void main() {"
+        + " foo(1 + 2);"
+        + "}";
+    final TranslationUnit simplifiedTu = Simplify.simplify(tu);
+    CompareAsts.assertEqualAsts(expected, simplifiedTu);
+  }
 }


### PR DESCRIPTION
Related issue: #110

As this [comment](https://github.com/google/graphicsfuzz/pull/489/files#r287494701) addressed, this PR added a test case for checking parentheses removal for the function call expression.
