### PR TITLE
Generate ternary identities for nonscalar types

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -694,7 +694,7 @@ public final class OpaqueExpressionGenerator {
 
             List<Expr> vectorEntryList = new ArrayList<Expr>();
             for (int i = 0; i < numColumns; i++) {
-              vectorEntryList.add(new ArrayIndexExpr(expr,
+              vectorEntryList.add(new ArrayIndexExpr(expr.clone(),
                   new IntConstantExpr(String.valueOf(i))));
             }
             vectorEntryList.set(indexToApplyIdentities,

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -663,7 +663,7 @@ public final class OpaqueExpressionGenerator {
   private class IdentityTernary extends AbstractIdentityTransformation {
 
     private IdentityTernary() {
-      super(BasicType.allBasicTypes(), false);
+      super(BasicType.allNumericTypes(), false);
     }
 
     @Override
@@ -673,9 +673,11 @@ public final class OpaqueExpressionGenerator {
       // or
       // (true  ? expr : whatever)
 
+      assert BasicType.allNumericTypes().contains(type);
       // If we generate identities for all entries in a non-scalar type, a huge amount of
       // identities are applied. To solve that, we only fuzz one entry at random in a vector,
       // and one column at random in a matrix.
+
       Expr exprWithIdentityApplied;
       if (!BasicType.allScalarTypes().contains(type)) {
         final int numColumns;

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -676,7 +676,7 @@ public final class OpaqueExpressionGenerator {
       Expr exprWithIdentityApplied = applyIdentityFunction(expr, type, constContext, depth, fuzzer);
       // We have to make sure that the LHS and RHS of the ternary expression evaluate to the same
       // type, so we set constContext to true to ensure no side effects.
-      Expr something = fuzzedConstructor(fuzzer.fuzzExpr(type, false, true, depth));
+      Expr something = fuzzedConstructor(fuzzer.fuzzExpr(type, false, constContext, depth));
       if (generator.nextBoolean()) {
         return identityConstructor(expr,
             ternary(makeOpaqueBoolean(false, BasicType.BOOL, constContext, depth, fuzzer),

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -692,8 +692,8 @@ public final class OpaqueExpressionGenerator {
         if (expr instanceof VariableIdentifierExpr) {
 
           final int numColumns =
-              (BasicType.allVectorTypes().contains(type) ?
-              type.getNumElements() : type.getNumColumns());
+              (BasicType.allVectorTypes().contains(type)
+                  ? type.getNumElements() : type.getNumColumns());
 
           final int indexToApplyIdentities = generator.nextInt(numColumns);
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -674,8 +674,6 @@ public final class OpaqueExpressionGenerator {
       // (true  ? expr : whatever)
       assert BasicType.allNumericTypes().contains(type);
       Expr exprWithIdentityApplied = applyIdentityFunction(expr, type, constContext, depth, fuzzer);
-      // We have to make sure that the LHS and RHS of the ternary expression evaluate to the same
-      // type, so we set constContext to true to ensure no side effects.
       Expr something = fuzzedConstructor(fuzzer.fuzzExpr(type, false, constContext, depth));
       if (generator.nextBoolean()) {
         return identityConstructor(expr,


### PR DESCRIPTION
As discussed in #254.

The idea behind this is that I only want to generate identities for specific entries in a vector/matrix, and not enclose the whole nonscalar with identities.

To do this;

`v -> (true ? vecX(..., identity(v[Y]), ...) : _)`

`v -> (false ? _ : vecX(..., identity(v[Y]), ...))`

where v is a vector of size X, y is the random entry in v we want to apply
identities to, and ... is the other entries in v that we don't change. The form is the same for matrices, but instead of applying identities to one entry, we'd apply them to one column of the matrix (the syntax is similar).

However, I'm currently running into issues with GenerateShaderFamily tests failing because of aliasing on the AST.

From what I understand of the full stacktrace and through debugging, the test fails while trying to visit an entry in the constructor expression, but I can't tell much more than that. Which argument of the constructor seems to vary, so my guess is that it's failing on whichever one is being fuzzed with identities.

The full stacktrace looks something like this:

`java.lang.AssertionError: There should be no aliasing in the AST with the exception of types; found multiple parents for 'com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr@503556cb' which has class class com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr.

	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:55)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitArrayIndexExpr(StandardVisitor.java:325)
	at com.graphicsfuzz.common.ast.expr.ArrayIndexExpr.accept(ArrayIndexExpr.java:53)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitTypeConstructorExpr(StandardVisitor.java:235)
	at com.graphicsfuzz.common.ast.expr.TypeConstructorExpr.accept(TypeConstructorExpr.java:86)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitTernaryExpr(StandardVisitor.java:296)
	at com.graphicsfuzz.common.ast.expr.TernaryExpr.accept(TernaryExpr.java:54)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitParenExpr(StandardVisitor.java:183)
	at com.graphicsfuzz.common.ast.expr.ParenExpr.accept(ParenExpr.java:36)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitFunctionCallExpr(StandardVisitor.java:222)
	at com.graphicsfuzz.common.ast.expr.FunctionCallExpr.accept(FunctionCallExpr.java:73)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitFunctionCallExpr(StandardVisitor.java:222)
	at com.graphicsfuzz.common.ast.expr.FunctionCallExpr.accept(FunctionCallExpr.java:73)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitFunctionCallExpr(StandardVisitor.java:222)
	at com.graphicsfuzz.common.ast.expr.FunctionCallExpr.accept(FunctionCallExpr.java:73)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitMemberLookupExpr(StandardVisitor.java:197)
	at com.graphicsfuzz.common.ast.expr.MemberLookupExpr.accept(MemberLookupExpr.java:53)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitBinaryExpr(StandardVisitor.java:177)
	at com.graphicsfuzz.common.ast.expr.BinaryExpr.accept(BinaryExpr.java:65)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitBinaryExpr(StandardVisitor.java:178)
	at com.graphicsfuzz.common.ast.expr.BinaryExpr.accept(BinaryExpr.java:65)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitTernaryExpr(StandardVisitor.java:295)
	at com.graphicsfuzz.common.ast.expr.TernaryExpr.accept(TernaryExpr.java:54)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitReturnStmt(StandardVisitor.java:215)
	at com.graphicsfuzz.common.ast.stmt.ReturnStmt.accept(ReturnStmt.java:57)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:419)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitBlockStmt(StandardVisitor.java:132)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitFunctionDefinition(StandardVisitor.java:106)
	at com.graphicsfuzz.common.ast.decl.FunctionDefinition.accept(FunctionDefinition.java:42)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitChildFromParent(StandardVisitor.java:415)
	at com.graphicsfuzz.common.ast.ParentMap.visitChildFromParent(ParentMap.java:48)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visitTranslationUnit(StandardVisitor.java:113)
	at com.graphicsfuzz.common.ast.TranslationUnit.accept(TranslationUnit.java:123)
	at com.graphicsfuzz.common.ast.visitors.StandardVisitor.visit(StandardVisitor.java:98)
	at com.graphicsfuzz.common.ast.ParentMap.<init>(ParentMap.java:32)
	at com.graphicsfuzz.common.ast.IParentMap.createParentMap(IParentMap.java:26)
	at com.graphicsfuzz.generator.mutateapi.Expr2ExprMutationFinder.<init>(Expr2ExprMutationFinder.java:32)
	at com.graphicsfuzz.generator.semanticspreserving.IdentityMutationFinder.<init>(IdentityMutationFinder.java:61)
	at com.graphicsfuzz.generator.transformation.IdentityTransformation.apply(IdentityTransformation.java:37)
	at com.graphicsfuzz.generator.tool.Generate.applyTransformationsMultiPass(Generate.java:429)
	at com.graphicsfuzz.generator.tool.Generate.transformShader(Generate.java:291)
	at com.graphicsfuzz.generator.tool.Generate.generateVariant(Generate.java:184)
	at com.graphicsfuzz.generator.tool.Generate.generateVariant(Generate.java:233)
	at com.graphicsfuzz.generator.tool.GenerateShaderFamily.mainHelper(GenerateShaderFamily.java:228)
	at com.graphicsfuzz.generator.tool.GenerateShaderFamilyTest.checkShaderFamilyGeneration(GenerateShaderFamilyTest.java:251)
	at com.graphicsfuzz.generator.tool.GenerateShaderFamilyTest.checkShaderFamilyGeneration(GenerateShaderFamilyTest.java:231)
	at com.graphicsfuzz.generator.tool.GenerateShaderFamilyTest.testGenerateSmall100ShaderFamilyMultiPass(GenerateShaderFamilyTest.java:100)
`

Any assistance would be appreciated.