### PR TITLE
Add support for built-in GLES 3.20 Integer Functions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -109,6 +109,11 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   }
 
   @Override
+  public boolean supportedIntegerFunctions() {
+    return prototype.supportedIntegerFunctions();
+  }
+
+  @Override
   public boolean supportedInverse() {
     return prototype.supportedInverse();
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -110,6 +110,11 @@ final class Essl100 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedIntegerFunctions() {
+    return false;
+  }
+
+  @Override
   public boolean supportedInverse() {
     return false;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
@@ -31,6 +31,11 @@ final class Essl310 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedIntegerFunctions() {
+    return true;
+  }
+
+  @Override
   public boolean supportedMixNonfloatBool() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -110,6 +110,11 @@ final class Glsl110 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedIntegerFunctions() {
+    return false;
+  }
+
+  @Override
   public boolean supportedInverse() {
     return false;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl400.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl400.java
@@ -36,6 +36,11 @@ final class Glsl400 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedIntegerFunctions() {
+    return true;
+  }
+
+  @Override
   public boolean supportedPackSnorm4x8() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -177,6 +177,8 @@ public interface ShadingLanguageVersion {
 
   boolean supportedIntBitsToFloat();
 
+  boolean supportedIntegerFunctions();
+
   boolean supportedInverse();
 
   boolean supportedIsinf();

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -19,6 +19,7 @@ package com.graphicsfuzz.common.typing;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.ast.type.Type;
+import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -839,12 +840,102 @@ public final class TyperHelper {
     // 8.7: Vector Relational Functions
 
     // 8.8: Integer Functions
+    if (shadingLanguageVersion.supportedIntegerFunctions()) {
+      getBuiltinsForGlslVersionInteger(builtinsForVersion);
+    }
 
     // 8.13: Fragment Processing Functions (only available in fragment shaders)
 
     // 8.14: Noise Functions - deprecated, so we do not consider them
 
     return builtinsForVersion;
+  }
+
+  private static void getBuiltinsForGlslVersionInteger(
+      Map<String, List<FunctionPrototype>> builtinsForVersion) {
+    {
+      final String name = "uaddCarry";
+      for (Type t : ugenType()) {
+        addBuiltin(builtinsForVersion, name, t, t, t, t);
+      }
+    }
+
+    {
+      final String name = "usubBorrow";
+      for (Type t : ugenType()) {
+        addBuiltin(builtinsForVersion, name, t, t, t, t);
+      }
+    }
+
+    {
+      final String name = "umulExtended";
+      for (Type t : ugenType()) {
+        addBuiltin(builtinsForVersion, name, VoidType.VOID, t, t, t, t);
+      }
+    }
+
+    {
+      final String name = "imulExtended";
+      for (Type t : igenType()) {
+        addBuiltin(builtinsForVersion, name, VoidType.VOID, t, t, t, t);
+      }
+    }
+
+    {
+      final String name = "bitfieldExtract";
+      for (Type t : igenType()) {
+        addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
+      }
+      for (Type t : ugenType()) {
+        addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
+      }
+    }
+
+    {
+      final String name = "bitfieldInsert";
+      for (Type t : igenType()) {
+        addBuiltin(builtinsForVersion, name, t, t, t, BasicType.INT, BasicType.INT);
+      }
+      for (Type t : ugenType()) {
+        addBuiltin(builtinsForVersion, name, t, t, t, BasicType.INT, BasicType.INT);
+      }
+    }
+
+    {
+      final String name = "bitfieldReverse";
+      for (Type t : igenType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+      for (Type t : ugenType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    // we need to use both igen and ugen types of the same size for these builtins, so we need a
+    // counting loop instead of an iterator to access both lists at the same time.
+    {
+      final String name = "bitCount";
+      for (int i = 0; i < igenType().size(); i++) {
+        addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
+        addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      }
+    }
+
+    {
+      final String name = "findLSB";
+      for (int i = 0; i < igenType().size(); i++) {
+        addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
+        addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      }
+    }
+
+    {
+      final String name = "findMSB";
+      for (int i = 0; i < igenType().size(); i++) {
+        addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
+        addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      }
+    }
   }
 
   private static void addBuiltin(Map<String, List<FunctionPrototype>> builtinsForVersion,

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -44,6 +44,7 @@ import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.ast.type.QualifiedType;
 import com.graphicsfuzz.common.ast.type.TypeQualifier;
+import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
@@ -712,7 +713,11 @@ public class TyperTest {
           result.append(decl.getType() + " " + decl.getName());
         }
         result.append(") {\n");
-        result.append("  return " + fp.getName() + "(");
+        result.append("  ");
+        if (fp.getReturnType() != VoidType.VOID) {
+          result.append("return ");
+        }
+        result.append(fp.getName() + "(");
         first = true;
         for (ParameterDecl decl : fp.getParameters()) {
           if (!first) {


### PR DESCRIPTION
Implements #467. 

OpenGL versions including and above 3.1ES and 4.0 support integer functions. The function signatures do not change between versions, nor were any functions added after 3.1ES, so I went ahead and added to the ShadingLanguageVersion interface instead of manually checking all the versions in TyperHelper.

Regarding the change in TyperTest, the test was not set up to handle void-returning functions, producing statements like:

```
uint testwhatever()
{
   return imul(u0, u1, u2, u3);
}
```

when imul() is a void function. This would cause a validation error, so I added a void type check.