### PR TITLE
Refactor BasicType with documentation and exception improvements

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
@@ -344,26 +344,44 @@ public class BasicType extends BuiltinType {
           BVEC4));
   }
 
+  /**
+   * Static version of getNumColumns(). Finds the number of columns in a matrix. Can only be
+   * invoked on a matrix type.
+   *
+   * @return the number of columns that the matrix type has.
+   * @throws UnsupportedOperationException if the type is not a matrix.
+   */
   public static int numColumns(BasicType basicType) {
-    assert allMatrixTypes().contains(basicType);
+    if (!allMatrixTypes().contains(basicType)) {
+      throw new UnsupportedOperationException(
+          "Type" + basicType.toString() + " does not have columns");
+    }
     if (Arrays.asList(MAT2X2, MAT2X3, MAT2X4).contains(basicType)) {
       return 2;
     }
     if (Arrays.asList(MAT3X2, MAT3X3, MAT3X4).contains(basicType)) {
       return 3;
     }
-    if (Arrays.asList(MAT4X2, MAT4X3, MAT4X4).contains(basicType)) {
-      return 4;
-    }
-    throw new RuntimeException("Camnnot get number of columns for " + basicType);
+    assert Arrays.asList(MAT4X2, MAT4X3, MAT4X4).contains(basicType);
+    return 4;
   }
 
+  /**
+   * Creates a vector type of a specified size from a scalar type.
+   *
+   * @return a vector type of numElements dimension, or the scalar type if numElements is 1.
+   * @throws UnsupportedOperationException if the specified base type is not a scalar, or
+   *     if numElements is outside the bounds of possible dimensions
+   *     (numElements < 0, numElements > 4)
+   */
   public static BasicType makeVectorType(BasicType elementType, int numElements) {
     if (!allScalarTypes().contains(elementType)) {
-      throw new RuntimeException("Cannot make vector type from element type " + elementType);
+      throw new UnsupportedOperationException(
+          "Cannot make vector type from element type " + elementType);
     }
     if (numElements < 0 || numElements > 4) {
-      throw new RuntimeException("Cannot make vector type with " + numElements + " elements");
+      throw new UnsupportedOperationException(
+          "Cannot make vector type with " + numElements + " elements");
     }
     if (elementType == FLOAT) {
       switch (numElements) {
@@ -433,8 +451,18 @@ public class BasicType extends BuiltinType {
     return allMatrixTypes().contains(this);
   }
 
+  /**
+   * Determines the vector type of the columns in the matrix. For example, accessing a column of a
+   * mat2x2 would give you a variable of type vec2. Can only be invoked on a matrix type.
+   *
+   * @return the type that represents that the matrix type has.
+   * @throws UnsupportedOperationException if the type is not a matrix.
+   */
   public BasicType getColumnType() {
-    assert allMatrixTypes().contains(this);
+    if (!this.isMatrix()) {
+      throw new UnsupportedOperationException(
+          "Type" + this.toString() + " does not have a column type");
+    }
     if (Arrays.asList(BasicType.MAT2X2, BasicType.MAT3X2, BasicType.MAT4X2).contains(this)) {
       return VEC2;
     }
@@ -445,8 +473,17 @@ public class BasicType extends BuiltinType {
     return VEC4;
   }
 
+  /**
+   * Finds the number of columns in a matrix. Can only be invoked on a matrix type.
+   *
+   * @return the number of columns that the matrix type has.
+   * @throws UnsupportedOperationException if the type is not a matrix.
+   */
   public int getNumColumns() {
-    assert allMatrixTypes().contains(this);
+    if (!this.isMatrix()) {
+      throw new UnsupportedOperationException(
+          "Type" + this.toString() + " does not have columns");
+    }
     if (Arrays.asList(BasicType.MAT2X2, BasicType.MAT2X3, BasicType.MAT2X4).contains(this)) {
       return 2;
     }
@@ -458,13 +495,16 @@ public class BasicType extends BuiltinType {
   }
 
   /**
-   * Finds the number of rows in a matrix type. Will cause an assertion failure if
-   * used with a non-matrix type.
+   * Finds the number of rows in a matrix. Can only be invoked on a matrix type.
    *
    * @return the number of rows that the matrix type has.
+   * @throws UnsupportedOperationException if the type is not a matrix.
    */
   public int getNumRows() {
-    assert allMatrixTypes().contains(this);
+    if (!this.isMatrix()) {
+      throw new UnsupportedOperationException(
+          "Type" + this.toString() + " does not have rows");
+    }
     if (Arrays.asList(BasicType.MAT2X2, BasicType.MAT3X2, BasicType.MAT4X2).contains(this)) {
       return 2;
     }


### PR DESCRIPTION
Fixes #531. 

This PR:

 - makes a distinction between usage of RuntimeException and UnsupportedOperationException - RuntimeException is still used in functions like toString(), where the type could possibly be in an invalid state. RuntimeException has been replaced by UnsupportedOperationException when the user can potentially (and realistically) misuse a function (sending invalid arguments or using an unintended type). Additionally, UnsupportedOperationException is thrown instead of asserting when an error state is realistically possible.

 - adds Javadoc comments to functions that throw UnsupportedOperationException.

 - replaces usage of static allTypes().contains(type) calls with the corresponding isType() call when the current scope is not static.