### PR TITLE
Check for side effects with lvalue parameters of built-in functions

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
@@ -17,6 +17,8 @@
 package com.graphicsfuzz.common.util;
 
 import com.graphicsfuzz.common.ast.IAstNode;
+import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
+import com.graphicsfuzz.common.ast.decl.ParameterDecl;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
@@ -28,6 +30,7 @@ import com.graphicsfuzz.common.ast.stmt.DiscardStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprCaseLabel;
 import com.graphicsfuzz.common.ast.stmt.ReturnStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
+import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.typing.TyperHelper;
@@ -44,6 +47,17 @@ public class SideEffectChecker {
             .containsKey(functionCallExpr.getCallee())) {
           // Assume that any call to a non-builtin might have a side-effect.
           predicateHolds();
+        }
+        for (FunctionPrototype p :
+            TyperHelper.getBuiltins(shadingLanguageVersion).get(functionCallExpr.getCallee())) {
+          // We check each argument of the built-in's prototypes to see if they require lvalues -
+          // if so, they can cause side effects.
+          for (ParameterDecl param : p.getParameters()) {
+            if (param.getType().hasQualifier(TypeQualifier.OUT_PARAM)
+                || param.getType().hasQualifier(TypeQualifier.INOUT_PARAM)) {
+              predicateHolds();
+            }
+          }
         }
         super.visitFunctionCallExpr(functionCallExpr);
       }

--- a/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
@@ -52,6 +52,8 @@ public class SideEffectChecker {
             TyperHelper.getBuiltins(shadingLanguageVersion).get(functionCallExpr.getCallee())) {
           // We check each argument of the built-in's prototypes to see if they require lvalues -
           // if so, they can cause side effects.
+          // We could be more precise here by finding the specific overload of the function rather
+          // than checking every possible prototype for lvalue parameters.
           for (ParameterDecl param : p.getParameters()) {
             if (param.getType().hasQualifier(TypeQualifier.OUT_PARAM)
                 || param.getType().hasQualifier(TypeQualifier.INOUT_PARAM)) {

--- a/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.common.util;
 
+import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
@@ -26,15 +27,20 @@ import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
+import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
-import java.util.ArrayList;
 import java.util.Collections;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.*;
 
 public class SideEffectCheckerTest {
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
 
   @Test
   public void testAssignmentHasSideEffects() throws Exception {
@@ -65,12 +71,30 @@ public class SideEffectCheckerTest {
         ShadingLanguageVersion.ESSL_310));
   }
 
-  // TODO: Unignore when #521 is ready to merge.
+  // TODO(521): Unignore when #521 is ready to merge.
   @Ignore
   @Test
   public void testOutParamHasSideEffects() throws Exception {
-    assertFalse(SideEffectChecker.isSideEffectFree(new FunctionCallExpr(
-        "uaddCarry", new ArrayList<>()),
-        ShadingLanguageVersion.ESSL_310));
+    final String shader = "void main { "
+        + "   uint out1;"
+        + "   uvec2 out2;"
+        + "   uvec3 out3;"
+        + "   uvec4 out4;"
+        + "   uaddCarry(uint(0), uint(0), out1);"
+        + "   uaddCarry(uvec2(0, 0), uvec2(0, 0), out2);"
+        + "   uaddCarry(uvec3(0, 0, 0), uvec3(0, 0, 0), out3);"
+        + "   uaddCarry(uvec4(0, 0, 0, 0), uvec4(0, 0, 0, 0), out4);"
+        + "}";
+
+    final TranslationUnit tu = ParseHelper.parse(shader, ShaderKind.FRAGMENT);
+    tu.setShadingLanguageVersion(ShadingLanguageVersion.ESSL_310);
+
+    assertFalse(new CheckPredicateVisitor() {
+      @Override
+      public void visitFunctionCallExpr(FunctionCallExpr expr) {
+        assertTrue(expr.getCallee().equals("uaddCarry"));
+        assertFalse(SideEffectChecker.isSideEffectFree(expr, ShadingLanguageVersion.ESSL_310));
+      }
+    }.test(tu));
   }
 }

--- a/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.util;
 
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
+import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
 import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
 import com.graphicsfuzz.common.ast.expr.UnOp;
 import com.graphicsfuzz.common.ast.expr.UnaryExpr;
@@ -26,7 +27,9 @@ import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import java.util.ArrayList;
 import java.util.Collections;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -62,4 +65,12 @@ public class SideEffectCheckerTest {
         ShadingLanguageVersion.ESSL_310));
   }
 
+  // TODO: Unignore when #521 is ready to merge.
+  @Ignore
+  @Test
+  public void testOutParamHasSideEffects() throws Exception {
+    assertFalse(SideEffectChecker.isSideEffectFree(new FunctionCallExpr(
+        "uaddCarry", new ArrayList<>()),
+        ShadingLanguageVersion.ESSL_310));
+  }
 }

--- a/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
@@ -28,6 +28,7 @@ import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
+import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import java.util.Collections;
 import org.junit.Ignore;
@@ -89,12 +90,12 @@ public class SideEffectCheckerTest {
     final TranslationUnit tu = ParseHelper.parse(shader, ShaderKind.FRAGMENT);
     tu.setShadingLanguageVersion(ShadingLanguageVersion.ESSL_310);
 
-    assertFalse(new CheckPredicateVisitor() {
+    new StandardVisitor() {
       @Override
       public void visitFunctionCallExpr(FunctionCallExpr expr) {
         assertTrue(expr.getCallee().equals("uaddCarry"));
         assertFalse(SideEffectChecker.isSideEffectFree(expr, ShadingLanguageVersion.ESSL_310));
       }
-    }.test(tu));
+    }.visit(tu);
   }
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/FunctionCallExprTemplate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/FunctionCallExprTemplate.java
@@ -21,6 +21,7 @@ import com.graphicsfuzz.common.ast.decl.ParameterDecl;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
 import com.graphicsfuzz.common.ast.type.Type;
+import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.util.IRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,7 +63,8 @@ public class FunctionCallExprTemplate extends AbstractExprTemplate {
   @Override
   public boolean requiresLValueForArgument(int index) {
     assert index >= 0 && index < getNumArguments();
-    return false;
+    return argTypes.get(index).hasQualifier(TypeQualifier.OUT_PARAM)
+        || argTypes.get(index).hasQualifier(TypeQualifier.INOUT_PARAM);
   }
 
   @Override


### PR DESCRIPTION
Fixes #522 and #524. I made sure to test this outside of the IDE by readding built-ins (specifically the integer ones) with out parameters and generating hundreds of variants, then grepping for the offending functions to see if they were being used properly.

