### PR TITLE
Refactor code to use isType functions when possible

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
@@ -353,7 +353,7 @@ public class BasicType extends BuiltinType {
    *     (numElements < 0, numElements > 4)
    */
   public static BasicType makeVectorType(BasicType elementType, int numElements) {
-    if (!allScalarTypes().contains(elementType)) {
+    if (!elementType.isScalar()) {
       throw new UnsupportedOperationException(
           "Cannot make vector type from element type " + elementType);
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/SupportedTypes.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/SupportedTypes.java
@@ -26,8 +26,7 @@ public class SupportedTypes {
         && !shadingLanguageVersion.supportedUnsigned()) {
       return false;
     }
-    if (BasicType.allMatrixTypes().contains(type)
-        && !BasicType.allSquareMatrixTypes().contains(type)
+    if (type.isMatrix() && !BasicType.allSquareMatrixTypes().contains(type)
         && !shadingLanguageVersion.supportedNonSquareMatrices()) {
       return false;
     }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -807,7 +807,7 @@ public final class OpaqueExpressionGenerator {
     private IdentityRewriteComposite() {
       // all non-boolean vector/matrix types
       super(BasicType.allNumericTypes().stream().filter(
-          item -> !BasicType.allScalarTypes().contains(item)).collect(Collectors.toList()),
+          item -> !item.isScalar()).collect(Collectors.toList()),
           false);
     }
 
@@ -824,8 +824,7 @@ public final class OpaqueExpressionGenerator {
       assert expr instanceof VariableIdentifierExpr;
 
       final int numColumns =
-          (BasicType.allVectorTypes().contains(type)
-          ? type.getNumElements() : type.getNumColumns());
+          (type.isVector() ? type.getNumElements() : type.getNumColumns());
       final int columnToFurtherTransform = generator.nextInt(numColumns);
       final List<Expr> typeConstructorArguments = new ArrayList<>();
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -823,8 +823,7 @@ public final class OpaqueExpressionGenerator {
       assert type.isVector() || type.isMatrix();
       assert expr instanceof VariableIdentifierExpr;
 
-      final int numColumns =
-          (type.isVector() ? type.getNumElements() : type.getNumColumns());
+      final int numColumns = type.isVector() ? type.getNumElements() : type.getNumColumns();
       final int columnToFurtherTransform = generator.nextInt(numColumns);
       final List<Expr> typeConstructorArguments = new ArrayList<>();
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/SwizzleExprTemplate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/SwizzleExprTemplate.java
@@ -32,9 +32,8 @@ public class SwizzleExprTemplate extends AbstractExprTemplate {
   private final boolean isLValue;
 
   public SwizzleExprTemplate(BasicType argType, BasicType resultType, boolean isLValue) {
-    assert BasicType.allVectorTypes().contains(argType);
-    assert BasicType.allVectorTypes().contains(resultType) || BasicType.allScalarTypes()
-          .contains(resultType);
+    assert argType.isVector();
+    assert resultType.isVector() || resultType.isScalar();
     if (isLValue) {
       assert resultType.getNumElements() <= argType.getNumElements();
     }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/VectorMatrixIndexExprTemplate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/templates/VectorMatrixIndexExprTemplate.java
@@ -33,8 +33,7 @@ public class VectorMatrixIndexExprTemplate extends AbstractExprTemplate {
   private final boolean isLValue;
 
   public VectorMatrixIndexExprTemplate(BasicType argType, boolean isLValue) {
-    assert BasicType.allVectorTypes().contains(argType) || BasicType.allMatrixTypes()
-          .contains(argType);
+    assert argType.isVector() || argType.isMatrix();
     this.argType = argType;
     this.isLValue = isLValue;
   }
@@ -44,10 +43,10 @@ public class VectorMatrixIndexExprTemplate extends AbstractExprTemplate {
     assert args.length == getNumArguments();
 
     int index;
-    if (BasicType.allVectorTypes().contains(argType)) {
+    if (argType.isVector()) {
       index = generator.nextInt(argType.getNumElements());
     } else {
-      assert BasicType.allMatrixTypes().contains(argType);
+      assert argType.isMatrix();
       index = generator.nextInt(argType.getNumColumns());
     }
     return new ArrayIndexExpr(args[0], new IntConstantExpr(String.valueOf(index)));

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/IdentityMutationFinder.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/IdentityMutationFinder.java
@@ -83,8 +83,7 @@ public class IdentityMutationFinder extends Expr2ExprMutationFinder {
         iterators.forEach(clonedScope::remove);
       }
     }
-    if (BasicType.allScalarTypes().contains(basicType)
-        || BasicType.allVectorTypes().contains(basicType)
+    if (basicType.isScalar() || basicType.isVector()
         || BasicType.allSquareMatrixTypes().contains(basicType)) {
       // TODO: add support for non-square matrices.
       addMutation(new Expr2ExprMutation(parentMap.getParent(expr),

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunities.java
@@ -223,7 +223,7 @@ public final class FoldConstantReductionOpportunities extends SimplifyExprReduct
       return;
     }
     final BasicType basicType = (BasicType) structureType;
-    if (!BasicType.allVectorTypes().contains(basicType)) {
+    if (!basicType.isVector()) {
       return;
     }
     if (basicType.getNumElements() != tce.getNumArgs()) {


### PR DESCRIPTION
Fixes #536.

This PR makes the distinction that the isScalar/isVector/isMatrix functions are used whenever we know for certain that the type in question is a BasicType (and can use those methods). Whenever we work with a Type instead of a BasicType (in more general cases, and in most lambda expressions), we can't use those functions.