### PR TITLE
Handle SSBO with several types

### DIFF
--- a/python/src/main/python/test_scripts/test_runspv/README.md
+++ b/python/src/main/python/test_scripts/test_runspv/README.md
@@ -5,16 +5,23 @@ The tests assume that you are working under Linux and that an Android device is 
 
 They require Python 3, pathlib2, Pillow, and PyTest.
 
+## Using PyCharm
+
 If you are using PyCharm these can all be installed by pressing Alt+Return on the errors about unknown imports and
 following the instructions thereafter.
 
-Alternatively, pytest can be installed as follows:
-
-```
-sudo apt-get install python3-pip
-pip3 install pytest pathlib2 Pillow
-```
-
-(The other dependencies should be similar).
-
 If using PyCharm you need to [configure it to use PyTest for tests](https://www.jetbrains.com/help/pycharm/pytest.html).
+
+## Using the command line
+
+Alternatively, pytest and dependencies can be installed as follows:
+
+```
+python3 -m pip install pytest pathlib2 Pillow
+```
+
+To run the tests from the command line:
+
+```
+python3 -m pytest ./runspv_tests.py
+```


### PR DESCRIPTION
Amber does not support more than one type. Promote bools when
feasible.