### PR TITLE
Add built-in function support for GLES 3.20 Fragment Processing Functions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -74,6 +74,11 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   }
 
   @Override
+  public boolean supportedDerivativeFunctions() {
+    return prototype.supportedDerivativeFunctions();
+  }
+
+  @Override
   public boolean supportedDeterminant() {
     return prototype.supportedDeterminant();
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -84,6 +84,11 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   }
 
   @Override
+  public boolean supportedExplicitDerivativeFunctions() {
+    return prototype.supportedExplicitDerivativeFunctions();
+  }
+
+  @Override
   public boolean supportedFloatBitsToInt() {
     return prototype.supportedFloatBitsToInt();
   }
@@ -111,6 +116,11 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   @Override
   public boolean supportedIntegerFunctions() {
     return prototype.supportedIntegerFunctions();
+  }
+
+  @Override
+  public boolean supportedInterpolationFunctions() {
+    return prototype.supportedInterpolationFunctions();
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -75,6 +75,11 @@ final class Essl100 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedDerivativeFunctions() {
+    return false;
+  }
+
+  @Override
   public boolean supportedDeterminant() {
     return false;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -85,6 +85,11 @@ final class Essl100 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedExplicitDerivativeFunctions() {
+    return false;
+  }
+
+  @Override
   public boolean supportedFloatBitsToInt() {
     return false;
   }
@@ -111,6 +116,11 @@ final class Essl100 implements ShadingLanguageVersion {
 
   @Override
   public boolean supportedIntegerFunctions() {
+    return false;
+  }
+
+  @Override
+  public boolean supportedInterpolationFunctions() {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
@@ -56,6 +56,11 @@ final class Essl300 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedDerivativeFunctions() {
+    return true;
+  }
+
+  @Override
   public boolean supportedDeterminant() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl320.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl320.java
@@ -30,4 +30,9 @@ final class Essl320 extends CompositeShadingLanguageVersion {
     return "320 es";
   }
 
+  @Override
+  public boolean supportedInterpolationFunctions() {
+    return true;
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -75,6 +75,11 @@ final class Glsl110 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedDerivativeFunctions() {
+    return true;
+  }
+
+  @Override
   public boolean supportedDeterminant() {
     return false;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -85,6 +85,11 @@ final class Glsl110 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedExplicitDerivativeFunctions() {
+    return false;
+  }
+
+  @Override
   public boolean supportedFloatBitsToInt() {
     return false;
   }
@@ -111,6 +116,11 @@ final class Glsl110 implements ShadingLanguageVersion {
 
   @Override
   public boolean supportedIntegerFunctions() {
+    return false;
+  }
+
+  @Override
+  public boolean supportedInterpolationFunctions() {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl400.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl400.java
@@ -41,6 +41,11 @@ final class Glsl400 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedInterpolationFunctions() {
+    return true;
+  }
+
+  @Override
   public boolean supportedPackSnorm4x8() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl450.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl450.java
@@ -31,6 +31,11 @@ final class Glsl450 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedExplicitDerivativeFunctions() {
+    return true;
+  }
+
+  @Override
   public boolean supportedMixNonfloatBool() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -163,15 +163,23 @@ public interface ShadingLanguageVersion {
 
   boolean supportedClampUint();
 
+  /**
+   * Derivative Functions are a subset of fragment processing functions that compute
+   * the rate of change between pixels in a given fragment.
+   * GLSL versions 1.1+ and ESSL versions 3.0+ support these functions.
+   *
+   * @return true if explicit derivative functions are supported - false otherwise.
+   */
+  boolean supportedDerivativeFunctions();
+
   boolean supportedDeterminant();
 
   boolean supportedDoStmt();
 
   /**
-   * Derivative Functions are a subset of fragment processing functions that compute
-   * the rate of change between pixels in a given fragment. In recent GLSL specifications,
-   * new derivative functions were added that allow a user to specify how much precision
-   * the user wants in the calculation, instead of leaving the choice to the compiler.
+   * In recent GLSL specifications, new derivative functions were added that allow a user to
+   * specify how much precision the user wants in the calculation, instead of leaving the choice
+   * to the compiler.
    * GLSL versions 4.5+ support these explicit derivative functions.
    *
    * @return true if explicit derivative functions are supported - false otherwise.

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -167,6 +167,17 @@ public interface ShadingLanguageVersion {
 
   boolean supportedDoStmt();
 
+  /**
+   * Derivative Functions are a subset of fragment processing functions that compute
+   * the rate of change between pixels in a given fragment. In recent GLSL specifications,
+   * new derivative functions were added that allow a user to specify how much precision
+   * the user wants in the calculation, instead of leaving the choice to the compiler.
+   * GLSL versions 4.5+ support these explicit derivative functions.
+   *
+   * @return true if explicit derivative functions are supported - false otherwise.
+   */
+  boolean supportedExplicitDerivativeFunctions();
+
   boolean supportedFloatBitsToInt();
 
   boolean supportedFloatBitsToUint();
@@ -186,6 +197,15 @@ public interface ShadingLanguageVersion {
    * @return true if Integer Functions are supported - false otherwise.
    */
   boolean supportedIntegerFunctions();
+
+  /**
+   * Interpolation Functions are a subset of fragment processing functions that
+   * compute an interpolated value of a fragment shader input variable at a specific location.
+   * GLSL versions 4.0+ and ESSL versions 3.2+ support these functions.
+   *
+   * @return true if Interpolation Functions are supported - false otherwise.
+   */
+  boolean supportedInterpolationFunctions();
 
   boolean supportedInverse();
 

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -1156,28 +1156,7 @@ public final class TyperHelper {
     }
 
     // 8.14.2 Interpolation Functions
-    if (shadingLanguageVersion.supportedInterpolationFunctions()) {
-      {
-        final String name = "interpolateAtCentroid";
-        for (Type t : genType()) {
-          addBuiltin(builtinsForVersion, name, t, t);
-        }
-      }
-
-      {
-        final String name = "interpolateAtSample";
-        for (Type t : genType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT);
-        }
-      }
-
-      {
-        final String name = "interpolateAtOffset";
-        for (Type t : genType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.VEC2);
-        }
-      }
-    }
+    // TODO(550): Support functions that take non-uniform shader input variables as parameters.
   }
 
   private static void addBuiltin(Map<String, List<FunctionPrototype>> builtinsForVersion,

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -852,7 +852,7 @@ public final class TyperHelper {
 
     // 8.13: Fragment Processing Functions (only available in fragment shaders)
 
-    if(shadingLanguageVersion.supportedDerivativeFunctions()) {
+    if (shadingLanguageVersion.supportedDerivativeFunctions()) {
       getBuiltinsForGlslVersionFragmentProcessing(builtinsForVersion, shadingLanguageVersion);
     }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -852,6 +852,10 @@ public final class TyperHelper {
 
     // 8.13: Fragment Processing Functions (only available in fragment shaders)
 
+    if(shadingLanguageVersion.supportedDerivativeFunctions()) {
+      getBuiltinsForGlslVersionFragmentProcessing(builtinsForVersion, shadingLanguageVersion);
+    }
+
     // 8.14: Noise Functions - deprecated, so we do not consider them
 
     return builtinsForVersion;
@@ -1071,6 +1075,107 @@ public final class TyperHelper {
       for (int i = 0; i < igenType().size(); i++) {
         addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
         addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      }
+    }
+  }
+
+  /**
+   * Helper function to register built-in function prototypes for Fragment Processing Functions,
+   * as specified in section 8.14 of the GLSL 4.6 and ESSL 3.2 specifications.
+   *
+   * @param builtinsForVersion the list of builtins to add prototypes to
+   * @param shadingLanguageVersion the version of GLSL in use
+   */
+  private static void getBuiltinsForGlslVersionFragmentProcessing(
+      Map<String, List<FunctionPrototype>> builtinsForVersion,
+      ShadingLanguageVersion shadingLanguageVersion) {
+    // 8.14.1 Derivative Functions
+    {
+      final String name = "dFdx";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    {
+      final String name = "dFdy";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    {
+      final String name = "fwidth";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    if (shadingLanguageVersion.supportedExplicitDerivativeFunctions()) {
+      {
+        final String name = "dFdxFine";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "dFdxCoarse";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "dFdyFine";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "dFdyCoarse";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "fwidthFine";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "fwidthCoarse";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+    }
+
+    // 8.14.2 Interpolation Functions
+    if (shadingLanguageVersion.supportedInterpolationFunctions()) {
+      {
+        final String name = "interpolateAtCentroid";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "interpolateAtSample";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT);
+        }
+      }
+
+      {
+        final String name = "interpolateAtOffset";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.VEC2);
+        }
       }
     }
   }


### PR DESCRIPTION
Implements #468.

Basic derivative functions (dFdx, dFdy, fwidth) are supported by GLSL 1.1+ and ESSL 3.0+.

Extended derivative functions (coarse and fine versions of the above functions) are supported by GLSL versions 4.5+.

Interpolation functions are supported by GLSL 4.0+ and ESSL 3.2+. I ran into a snag involving these functions that I detailed in issue #550. For now, I've removed them from this PR.