### PR TITLE
Add support for angle and trigonometric built-in functions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -278,4 +278,13 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
     return prototype.supportedUnsigned();
   }
 
+  @Override
+  public boolean supportedAngleAndTrigonometricFunctions() {
+    return prototype.supportedAngleAndTrigonometricFunctions();
+  }
+
+  @Override
+  public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
+    return prototype.supportedHyperbolicAngleAndTrigonometricFunctions();
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -278,4 +278,14 @@ final class Essl100 implements ShadingLanguageVersion {
   public boolean supportedUnsigned() {
     return false;
   }
+
+  @Override
+  public boolean supportedAngleAndTrigonometricFunctions() {
+    return true;
+  }
+
+  @Override
+  public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
+    return false;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
@@ -215,4 +215,8 @@ final class Essl300 extends CompositeShadingLanguageVersion {
     return true;
   }
 
+  @Override
+  public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
+    return true;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -281,4 +281,14 @@ final class Glsl110 implements ShadingLanguageVersion {
   public boolean supportedUnsigned() {
     return false;
   }
+
+  @Override
+  public boolean supportedAngleAndTrigonometricFunctions() {
+    return true;
+  }
+
+  @Override
+  public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
+    return false;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl130.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl130.java
@@ -115,4 +115,8 @@ final class Glsl130 extends CompositeShadingLanguageVersion {
     return true;
   }
 
+  @Override
+  public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
+    return true;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -275,4 +275,22 @@ public interface ShadingLanguageVersion {
 
   boolean supportedUnsigned();
 
+  /**
+   * Angle and Trigonometric Functions are a set of built-in functions related to the calculation
+   * of an angle. For example, sin(angle) - computes the sine value of the angle provided.
+   * GLSL versions 1.1+ and ESSL versions 1.0+ support these functions.
+   *
+   * @return true if Angle and Trigonometric Functions are supported - false otherwise.
+   */
+  boolean supportedAngleAndTrigonometricFunctions();
+
+  /**
+   * Hyperbolic Angle and Trigonometric Functions are a set of built-in functions that
+   * computes the hyperbolic trigonometric functions. For example, sinh() - calculate the
+   * hyperbolic sine function of the given value.
+   * GLSL versions 1.3+ and ESSL versions 3.0+ support these functions.
+   *
+   * @return true if Hyperbolic Angle and Trigonometric Functions are supported - false otherwise.
+   */
+  boolean supportedHyperbolicAngleAndTrigonometricFunctions();
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -285,7 +285,7 @@ public final class TyperHelper {
   }
 
   public static Map<String, List<FunctionPrototype>> getBuiltins(ShadingLanguageVersion
-                                                                     shadingLanguageVersion) {
+      shadingLanguageVersion) {
     if (!builtins.containsKey(shadingLanguageVersion)) {
       builtins.putIfAbsent(shadingLanguageVersion,
           getBuiltinsForGlslVersion(shadingLanguageVersion));
@@ -1151,7 +1151,7 @@ public final class TyperHelper {
    * Helper function to register built-in function prototypes for Fragment Processing Functions,
    * as specified in section 8.14 of the GLSL 4.6 and ESSL 3.2 specifications.
    *
-   * @param builtinsForVersion     the list of builtins to add prototypes to
+   * @param builtinsForVersion the list of builtins to add prototypes to
    * @param shadingLanguageVersion the version of GLSL in use
    */
   private static void getBuiltinsForGlslVersionFragmentProcessing(
@@ -1228,7 +1228,7 @@ public final class TyperHelper {
   }
 
   private static void addBuiltin(Map<String, List<FunctionPrototype>> builtinsForVersion,
-                                 String name, Type resultType, Type... args) {
+      String name, Type resultType, Type... args) {
     if (!builtinsForVersion.containsKey(name)) {
       builtinsForVersion.put(name, new ArrayList<>());
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -807,21 +807,24 @@ public final class TyperHelper {
 
     // 8.8: Integer Functions
 
-    if (shadingLanguageVersion.supportedIntegerFunctions()) {
-      getBuiltinsForGlslVersionInteger(builtinsForVersion);
-    }
+    getBuiltinsForGlslVersionInteger(builtinsForVersion, shadingLanguageVersion);
 
     // 8.13: Fragment Processing Functions (only available in fragment shaders)
 
-    if (shadingLanguageVersion.supportedDerivativeFunctions()) {
-      getBuiltinsForGlslVersionFragmentProcessing(builtinsForVersion, shadingLanguageVersion);
-    }
+    getBuiltinsForGlslVersionFragmentProcessing(builtinsForVersion, shadingLanguageVersion);
 
     // 8.14: Noise Functions - deprecated, so we do not consider them
 
     return builtinsForVersion;
   }
 
+  /**
+   * Helper function to register built-in function prototypes for Angle and Trigonometric
+   * Functions, as specified in section 8.1 of the GLSL 4.6 and ESSL 3.2 specifications.
+   *
+   * @param builtinsForVersion the list of builtins to add prototypes to
+   * @param shadingLanguageVersion the version of GLSL in use
+   */
   private static void getBuiltinsForGlslVersionAngleAndTrigonometric(
       ShadingLanguageVersion shadingLanguageVersion,
       Map<String, List<FunctionPrototype>> builtinsForVersion) {
@@ -1054,95 +1057,106 @@ public final class TyperHelper {
     }
   }
 
+
+  /**
+   * Helper function to register built-in function prototypes for Integer Functions,
+   * as specified in section 8.8 of the GLSL 4.6 and ESSL 3.2 specifications.
+   *
+   * @param builtinsForVersion the list of builtins to add prototypes to
+   * @param shadingLanguageVersion the version of GLSL in use
+   */
   private static void getBuiltinsForGlslVersionInteger(
-      Map<String, List<FunctionPrototype>> builtinsForVersion) {
-    {
-      final String name = "uaddCarry";
-      for (Type t : ugenType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t, new QualifiedType(t,
-            Arrays.asList(TypeQualifier.OUT_PARAM)));
+      Map<String, List<FunctionPrototype>> builtinsForVersion,
+      ShadingLanguageVersion shadingLanguageVersion) {
+    if (shadingLanguageVersion.supportedIntegerFunctions()) {
+      {
+        final String name = "uaddCarry";
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, t, new QualifiedType(t,
+              Arrays.asList(TypeQualifier.OUT_PARAM)));
+        }
       }
-    }
 
-    {
-      final String name = "usubBorrow";
-      for (Type t : ugenType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t, new QualifiedType(t,
-            Arrays.asList(TypeQualifier.OUT_PARAM)));
+      {
+        final String name = "usubBorrow";
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, t, new QualifiedType(t,
+              Arrays.asList(TypeQualifier.OUT_PARAM)));
+        }
       }
-    }
 
-    {
-      final String name = "umulExtended";
-      for (Type t : ugenType()) {
-        addBuiltin(builtinsForVersion, name, VoidType.VOID, t, t,
-            new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)),
-            new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)));
+      {
+        final String name = "umulExtended";
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, VoidType.VOID, t, t,
+              new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)),
+              new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)));
+        }
       }
-    }
 
-    {
-      final String name = "imulExtended";
-      for (Type t : igenType()) {
-        addBuiltin(builtinsForVersion, name, VoidType.VOID, t, t,
-            new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)),
-            new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)));
+      {
+        final String name = "imulExtended";
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, VoidType.VOID, t, t,
+              new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)),
+              new QualifiedType(t, Arrays.asList(TypeQualifier.OUT_PARAM)));
+        }
       }
-    }
 
-    {
-      final String name = "bitfieldExtract";
-      for (Type t : igenType()) {
-        addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
+      {
+        final String name = "bitfieldExtract";
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
+        }
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
+        }
       }
-      for (Type t : ugenType()) {
-        addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
-      }
-    }
 
-    {
-      final String name = "bitfieldInsert";
-      for (Type t : igenType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t, BasicType.INT, BasicType.INT);
+      {
+        final String name = "bitfieldInsert";
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, t, BasicType.INT, BasicType.INT);
+        }
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, t, BasicType.INT, BasicType.INT);
+        }
       }
-      for (Type t : ugenType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t, BasicType.INT, BasicType.INT);
-      }
-    }
 
-    {
-      final String name = "bitfieldReverse";
-      for (Type t : igenType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
+      {
+        final String name = "bitfieldReverse";
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
       }
-      for (Type t : ugenType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
 
-    // We need to use both igen and ugen types of the same size for these builtins, so we need a
-    // counting loop instead of an iterator to access both lists at the same time.
-    {
-      final String name = "bitCount";
-      for (int i = 0; i < igenType().size(); i++) {
-        addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
-        addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      // We need to use both igen and ugen types of the same size for these builtins, so we need a
+      // counting loop instead of an iterator to access both lists at the same time.
+      {
+        final String name = "bitCount";
+        for (int i = 0; i < igenType().size(); i++) {
+          addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
+          addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+        }
       }
-    }
 
-    {
-      final String name = "findLSB";
-      for (int i = 0; i < igenType().size(); i++) {
-        addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
-        addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      {
+        final String name = "findLSB";
+        for (int i = 0; i < igenType().size(); i++) {
+          addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
+          addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+        }
       }
-    }
 
-    {
-      final String name = "findMSB";
-      for (int i = 0; i < igenType().size(); i++) {
-        addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
-        addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+      {
+        final String name = "findMSB";
+        for (int i = 0; i < igenType().size(); i++) {
+          addBuiltin(builtinsForVersion, name, igenType().get(i), igenType().get(i));
+          addBuiltin(builtinsForVersion, name, igenType().get(i), ugenType().get(i));
+        }
       }
     }
   }
@@ -1158,24 +1172,26 @@ public final class TyperHelper {
       Map<String, List<FunctionPrototype>> builtinsForVersion,
       ShadingLanguageVersion shadingLanguageVersion) {
     // 8.14.1 Derivative Functions
-    {
-      final String name = "dFdx";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
+    if (shadingLanguageVersion.supportedDerivativeFunctions()) {
+      {
+        final String name = "dFdx";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
       }
-    }
 
-    {
-      final String name = "dFdy";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
+      {
+        final String name = "dFdy";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
       }
-    }
 
-    {
-      final String name = "fwidth";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
+      {
+        final String name = "fwidth";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
       }
     }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -631,13 +631,13 @@ public final class TyperHelper {
     }
 
     {
-      @SuppressWarnings("unused") 
+      @SuppressWarnings("unused")
       final String name = "frexp";
       // TODO: genType frexp(genType, out genIType)
     }
 
     {
-      @SuppressWarnings("unused") 
+      @SuppressWarnings("unused")
       final String name = "ldexp";
       // TODO: genType frexp(genType, in genIType)
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -285,7 +285,7 @@ public final class TyperHelper {
   }
 
   public static Map<String, List<FunctionPrototype>> getBuiltins(ShadingLanguageVersion
-      shadingLanguageVersion) {
+                                                                     shadingLanguageVersion) {
     if (!builtins.containsKey(shadingLanguageVersion)) {
       builtins.putIfAbsent(shadingLanguageVersion,
           getBuiltinsForGlslVersion(shadingLanguageVersion));
@@ -297,49 +297,10 @@ public final class TyperHelper {
       ShadingLanguageVersion shadingLanguageVersion) {
     Map<String, List<FunctionPrototype>> builtinsForVersion = new HashMap<>();
 
-    // Trigonometric Functions
-    {
-      final String name = "sin";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-    {
-      final String name = "cos";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-    {
-      final String name = "asin";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-    {
-      final String name = "acos";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-    {
-      final String name = "tan";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-    {
-      final String name = "atan";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-    {
-      final String name = "atan";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t);
-      }
-    }
+    // 8.1: Angle and Trigonometric Functions
+
+    getBuiltinsForGlslVersionAngleAndTrigonometric(shadingLanguageVersion,
+        builtinsForVersion);
 
     //Exponential Functions
 
@@ -670,13 +631,13 @@ public final class TyperHelper {
     }
 
     {
-      @SuppressWarnings("unused")
+      @SuppressWarnings("unused") 
       final String name = "frexp";
       // TODO: genType frexp(genType, out genIType)
     }
 
     {
-      @SuppressWarnings("unused")
+      @SuppressWarnings("unused") 
       final String name = "ldexp";
       // TODO: genType frexp(genType, in genIType)
     }
@@ -859,6 +820,113 @@ public final class TyperHelper {
     // 8.14: Noise Functions - deprecated, so we do not consider them
 
     return builtinsForVersion;
+  }
+
+  private static void getBuiltinsForGlslVersionAngleAndTrigonometric(
+      ShadingLanguageVersion shadingLanguageVersion,
+      Map<String, List<FunctionPrototype>> builtinsForVersion) {
+    if (shadingLanguageVersion.supportedAngleAndTrigonometricFunctions()) {
+      {
+        final String name = "radians";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "degrees";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "sin";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "cos";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "tan";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "asin";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "acos";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "atan";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+          addBuiltin(builtinsForVersion, name, t, t, t);
+        }
+      }
+    }
+
+    if (shadingLanguageVersion.supportedHyperbolicAngleAndTrigonometricFunctions()) {
+      {
+        final String name = "sinh";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "cosh";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "tanh";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "asinh";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "acosh";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+
+      {
+        final String name = "atanh";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+    }
   }
 
   private static void getBuiltinsForGlslVersionVectorRelational(
@@ -1083,7 +1151,7 @@ public final class TyperHelper {
    * Helper function to register built-in function prototypes for Fragment Processing Functions,
    * as specified in section 8.14 of the GLSL 4.6 and ESSL 3.2 specifications.
    *
-   * @param builtinsForVersion the list of builtins to add prototypes to
+   * @param builtinsForVersion     the list of builtins to add prototypes to
    * @param shadingLanguageVersion the version of GLSL in use
    */
   private static void getBuiltinsForGlslVersionFragmentProcessing(
@@ -1160,7 +1228,7 @@ public final class TyperHelper {
   }
 
   private static void addBuiltin(Map<String, List<FunctionPrototype>> builtinsForVersion,
-      String name, Type resultType, Type... args) {
+                                 String name, Type resultType, Type... args) {
     if (!builtinsForVersion.containsKey(name)) {
       builtinsForVersion.put(name, new ArrayList<>());
     }


### PR DESCRIPTION
Related issue: #460

The implementation of the new set of the built-in function for Angle and Trigonometric Functions. Following are the GLSL supported version for the new built-in functions.


General trigonometric functions (sin, cos, tan, etc):
- GLSL 1.1+
- GLSL ES 1.0+

Hyperbolic trigonometric functions (sinh, cosh, asinh, etc):
- GLSL 1.3+
- GLSL ES 3.0+
