### PR TITLE
Reducer: Add class skeleton and tests

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunities.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+
+public class GlobalVariableDeclToExprReductionOpportunities
+    extends ReductionOpportunitiesBase<GlobalVariableDeclToExprReductionOpportunity> {
+  public GlobalVariableDeclToExprReductionOpportunities(TranslationUnit tu,
+                                                        ReducerContext context) {
+    super(tu, context);
+  }
+}

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunities.java
@@ -17,11 +17,33 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.util.ListConcat;
+import java.util.Arrays;
+import java.util.List;
 
 public class GlobalVariableDeclToExprReductionOpportunities
     extends ReductionOpportunitiesBase<GlobalVariableDeclToExprReductionOpportunity> {
   public GlobalVariableDeclToExprReductionOpportunities(TranslationUnit tu,
                                                         ReducerContext context) {
     super(tu, context);
+  }
+
+  static List<GlobalVariableDeclToExprReductionOpportunity> findOpportunities(
+      ShaderJob shaderJob,
+      ReducerContext context) {
+    return shaderJob.getShaders()
+        .stream()
+        .map(item -> findOpportunitiesForShader(item, context))
+        .reduce(Arrays.asList(), ListConcat::concatenate);
+  }
+
+  private static List<GlobalVariableDeclToExprReductionOpportunity> findOpportunitiesForShader(
+      TranslationUnit tu,
+      ReducerContext context) {
+    GlobalVariableDeclToExprReductionOpportunities finder =
+        new GlobalVariableDeclToExprReductionOpportunities(tu, context);
+    finder.visit(tu);
+    return finder.getOpportunities();
   }
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.visitors.VisitationDepth;
+
+public class GlobalVariableDeclToExprReductionOpportunity extends AbstractReductionOpportunity {
+  GlobalVariableDeclToExprReductionOpportunity(VisitationDepth depth) {
+    super(depth);
+  }
+
+  @Override
+  void applyReductionImpl() {
+  }
+
+  @Override
+  public boolean preconditionHolds() {
+    return false;
+  }
+}

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunity.java
@@ -25,10 +25,11 @@ public class GlobalVariableDeclToExprReductionOpportunity extends AbstractReduct
 
   @Override
   void applyReductionImpl() {
+    throw new RuntimeException("Not implemented yet.");
   }
 
   @Override
   public boolean preconditionHolds() {
-    return false;
+    throw new RuntimeException("Not implemented yet.");
   }
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
@@ -105,8 +105,8 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
   public void testDoNotReplaceConst() throws Exception {
     final String original = "const int a = 1; void main() { }";
     final TranslationUnit tu = ParseHelper.parse(original);
-    final List<GlobalVariablesDeclarationReductionOpportunity> ops =
-        GlobalVariablesDeclarationReductionOpportunities
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
                 ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), null, true));

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
@@ -138,6 +138,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
+  @Ignore
   @Test
   public void testAssignVariableIdentifier() throws Exception {
     final String program = ""

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
@@ -46,6 +46,39 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
 
   @Ignore
   @Test
+  public void testZeroMethod() throws Exception {
+    final String original = "int a = 1;";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), null, true));
+    // Since the new assignment statement must be only inserted as the first statement of
+    // the main function, thus we have to ensure that main function exists.
+    // In this case, there is no method at all.
+    assertTrue(ops.isEmpty());
+  }
+
+  @Ignore
+  @Test
+  public void testNoMainMethod() throws Exception {
+    final String original = "int a = 1; void foo() { }";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), null, true));
+    // Since the new assignment statement must be only inserted as the first statement of
+    // the main function, thus we have to ensure that main function exists.
+    // In this case, there is one method but it is not main though so there should be no
+    // opportunities.
+    assertTrue(ops.isEmpty());
+  }
+
+  @Ignore
+  @Test
   public void testInsertAsFirstStatement() throws Exception {
     final String program = ""
         + "int a = 1;"

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
@@ -35,8 +35,8 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
   public void testDoNotReplace() throws Exception {
     final String original = "int a = 1; void main() { }";
     final TranslationUnit tu = ParseHelper.parse(original);
-    final List<VariableDeclToExprReductionOpportunity> ops =
-        VariableDeclToExprReductionOpportunities
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
                 ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), null, true));
@@ -61,12 +61,13 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
         + " int b = a;"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(program);
-    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
             ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), null, true));
     assertEquals(1, ops.size());
-    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
@@ -87,14 +88,15 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
         + " b = foo();"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(program);
-    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
             ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), null, true));
     // Only variable declarations a and b have the initializer.
     // Thus, we expect the reducer to find only 2 opportunities.
     assertEquals(2, ops.size());
-    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
@@ -103,8 +105,8 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
   public void testDoNotReplaceConst() throws Exception {
     final String original = "const int a = 1; void main() { }";
     final TranslationUnit tu = ParseHelper.parse(original);
-    final List<VariableDeclToExprReductionOpportunity> ops =
-        VariableDeclToExprReductionOpportunities
+    final List<GlobalVariablesDeclarationReductionOpportunity> ops =
+        GlobalVariablesDeclarationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
                 ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), null, true));
@@ -129,12 +131,13 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
         + " f = bar();"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(program);
-    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
             ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), null, true));
     assertEquals(3, ops.size());
-    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
@@ -160,12 +163,13 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
         + " d = c;"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(program);
-    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+    final List<GlobalVariableDeclToExprReductionOpportunity> ops =
+        GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
             ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), null, true));
     assertEquals(4, ops.size());
-    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.RandomWrapper;
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GlobalVariableDeclToExprReductionOpportunitiesTest {
+
+  // TODO(519): Enable this test when the issue is solved.
+  @Ignore
+  @Test
+  public void testDoNotReplace() throws Exception {
+    final String original = "int a = 1; void main() { }";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<VariableDeclToExprReductionOpportunity> ops =
+        VariableDeclToExprReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), null, true));
+    // There should be no opportunities as the preserve semantics is enabled.
+    assertTrue(ops.isEmpty());
+  }
+
+  @Ignore
+  @Test
+  public void testInsertAsFirstStatement() throws Exception {
+    final String program = ""
+        + "int a = 1;"
+        + "void main() {"
+        + " int b = a; "
+        + "}";
+    // We have to ensure that the new assignment statements is inserted
+    // as the first statement in main() function.
+    final String expected = ""
+        + "int a;"
+        + "void main() {"
+        + " a = 1;"
+        + " int b = a;"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+            ShadingLanguageVersion.ESSL_100,
+            new RandomWrapper(0), null, true));
+    assertEquals(1, ops.size());
+    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Ignore
+  @Test
+  public void testMultipleDeclarations() throws Exception {
+    final String program = ""
+        + "int a = 1;"      // Initialized variable declaration.
+        + "int b = foo();"  // Initialized variable declaration.
+        + "int c;"          // Uninitialized variable declaration.
+        + "void main() { }";
+    final String expected = ""
+        + "int a;"
+        + "int b;"
+        + "int c;"          // Uninitialized variable declaration.
+        + "void main() {"
+        + " a = 1;"
+        + " b = foo();"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+            ShadingLanguageVersion.ESSL_100,
+            new RandomWrapper(0), null, true));
+    // Only variable declarations a and b have the initializer.
+    // Thus, we expect the reducer to find only 2 opportunities.
+    assertEquals(2, ops.size());
+    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Ignore
+  @Test
+  public void testDoNotReplaceConst() throws Exception {
+    final String original = "const int a = 1; void main() { }";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<VariableDeclToExprReductionOpportunity> ops =
+        VariableDeclToExprReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+                ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), null, true));
+    // There should be no opportunities as it is invalid to declare constant variable
+    // without an initial value.
+    assertTrue(ops.isEmpty());
+  }
+
+  @Ignore
+  @Test
+  public void testMultipleLineDeclarationsOneLine() throws Exception {
+    final String program = ""
+        + "int b = 1, c, d = foo(), e, f = bar();"  // This variable declaration has many
+                                                    // declaration infos but we consider only
+                                                    // the one that has initializer (b, d, and f).
+        + "void main() { }";
+    final String expected = ""
+        + "int b, c, d, e, f;"
+        + "void main() {"
+        + " b = 1;"
+        + " d = foo();"
+        + " f = bar();"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+            ShadingLanguageVersion.ESSL_100,
+            new RandomWrapper(0), null, true));
+    assertEquals(3, ops.size());
+    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testAssignVariableIdentifier() throws Exception {
+    final String program = ""
+        + "int a = 1;"
+        + "int b = a, c = b;"   // b depends on a and c depends on b.
+        + "int d = c;"          // d depends on c.
+        + "void main() { }";
+    // As here we have the variable identifier as the initializer, we need to
+    // make sure that new expressions generated by the reducer are added
+    // in the correct order.
+    final String expected = ""
+        + "int a;"
+        + "int b, c;"
+        + "int d;"
+        + "void main() {"
+        + " a = 1;"
+        + " b = a;"
+        + " c = b;"
+        + " d = c;"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+            ShadingLanguageVersion.ESSL_100,
+            new RandomWrapper(0), null, true));
+    assertEquals(4, ops.size());
+    ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+}


### PR DESCRIPTION
Related issue: #519

Added class skeleton and tests for the reducer to reduce global initializers with the assignment statements.