### PR TITLE
Add new ways to generate opaque zero/one from bitwise operations

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -236,7 +236,7 @@ public final class OpaqueExpressionGenerator {
                   new ParenExpr(
                       new BinaryExpr(
                           makeOpaqueOne(type, constContext, depth, fuzzer),
-                          shiftValue.clone(),
+                          shiftValue,
                           BinOp.SHL)),
                   shiftBackValue,
                   BinOp.SHR)));
@@ -252,10 +252,9 @@ public final class OpaqueExpressionGenerator {
    * to be generated depending on the precision and type of the integer.
    *
    * @param type - the type to make a clamped expression from.
-   * @param bound - the bound for the randomly generated number.
-   * @return an expression of a clamped value between 0 and m, inclusive:
-   *     clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(m)), and m is an integer
-   *     between 0 and maxValue, inclusive.
+   * @param bound - the upper bound for the clamped expression.
+   * @return an expression of a clamped value between 0 and bound, inclusive:
+   *     clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(bound)),
    */
   private Expr makeClampedFuzzedExpr(BasicType type, boolean constContext,
                                      final int depth, Fuzzer fuzzer, int bound) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -193,7 +193,7 @@ public final class OpaqueExpressionGenerator {
     final Expr shiftValue;
     if (isZero) {
       // We can't shift zero reliably if the number is signed because of sign bit extension, so
-      // we simply shift it zero.
+      // we simply shift it zero if it's signed.
       shiftValue = type.getElementType() == BasicType.INT
           ? new IntConstantExpr("0")
           : new UIntConstantExpr(generator.nextInt(1000) + "u");

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -167,10 +167,24 @@ public final class OpaqueExpressionGenerator {
   }
 
   /**
-   * Function to generate an opaque zero or one by bitwise shifting left or right by a value
-   * between 0 and 8 bits, inclusive. For example, we can transform an integer i -> i >> 0 or
-   * i << 0. Generates an opaque value if the type of zero to be generated is an integer and the
-   * shading language in use supports bitwise operations.
+   * Function to generate an opaque zero or one by bitwise shifting left or right by an amount of
+   * bits dependent on which opaque is being generated.
+   * The minimum precision for a lowp integer in GLSL is 9 bits, with one of those bits reserved as
+   * a sign bit if the integer is signed. The OpenGL specification does not define behavior for
+   * shifting an integer beyond its maximum size in bits.
+   * This influences the process of generating opaque values such that:
+   *     If we're generating an opaque zero, we don't have to worry about losing bits, so our
+   *     maximum shift value is 8 bits.
+   *     If we're generating an opaque one, we have to make sure that we don't lose our 1 bit.
+   *     This limits our maximum shift value to 7 bits (more on how we shift an opaque one below).
+   * Possibilities for generating an opaque zero include:
+   *     Shifting an opaque zero by n bits: (opaque zero) >> n or (opaque zero) << n, where n is
+   *     an expression of a clamped value between 0 and 8:
+   *     n = clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(8)).
+   * Possibilities for generating an opaque zero include:
+   *     Shifting an opaque one to the left by n bits, then shifting it to the right by n bits:
+   *     ((opaque one) << n) >> n, where n is an expression of a clamped value between 0 and 7,
+   *     inclusive: n = clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(7)).
    *
    * @param type - the base type of the opaque value being created.
    * @param constContext - true if we're in a constant expression context, false otherwise.
@@ -189,16 +203,21 @@ public final class OpaqueExpressionGenerator {
     if (!shadingLanguageVersion.supportedBitwiseOperations()) {
       return Optional.empty();
     }
-    final BinOp operator = generator.nextBoolean() ? BinOp.SHL : BinOp.SHR;
-    // The maximum safe value to shift zero without potentially causing undefined behavior is
-    // between zero and eight bits (as nine bits is the minimum precision of an integer in GLSL).
-    // If we're shifting one, we want to be able to shift backwards without losing information, and
-    // so our maximum shift value is seven bits.
-    final int bound = isZero ? 10 : 9;
-    final int maxValue = generator.nextInt(bound);
+    // The minimum precision for a lowp integer in GLSL is 9 bits (with one reserved for a sign
+    // bit if the integer is signed) - we don't have to worry about losing information if we're
+    // shifting zero, but shifting more than 8 bits may result in undefined behavior.
+    final int maxShiftForZero = 9;
+    // While we still have a hard maximum bits to shift of 8 bits, if we're shifting one, then
+    // we can potentially lose information because GLSL bit shifting is not circular. To remedy
+    // that, we make sure not to shift our 1 bit out of the integer by limiting our maximum shift
+    // to 7 bits.
+    final int maxShiftForOne = 8;
+    final int maxValue = generator.nextInt(isZero ? maxShiftForZero : maxShiftForOne);
+    // We pass true as constContext when fuzzing here because the expression will be evaluated,
+    // so we don't want any side effects.
     final Expr shiftValue = new FunctionCallExpr(
         "clamp",
-        fuzzer.fuzzExpr(type, false, constContext, depth),
+        fuzzer.fuzzExpr(type, false, true, depth),
         makeOpaqueZero(type, constContext, depth, fuzzer),
         applyIdentityFunction(
             new TypeConstructorExpr(
@@ -208,40 +227,37 @@ public final class OpaqueExpressionGenerator {
                     : new UIntConstantExpr(maxValue + "u")),
             type, constContext, depth, fuzzer));
     if (isZero) {
+      final BinOp operator = generator.nextBoolean() ? BinOp.SHL : BinOp.SHR;
       return Optional.of(
           new ParenExpr(
               new BinaryExpr(
                   makeOpaqueZero(type, constContext, depth, fuzzer),
-                  applyIdentityFunction(shiftValue, type, constContext, depth, fuzzer),
+                  shiftValue,
                   operator)));
     } else {
-      assert !isZero;
-      assert operator == BinOp.SHL || operator == BinOp.SHR;
       // We're going to shift twice in opposite directions by the same value.
-      final BinOp secondOp = operator == BinOp.SHL ? BinOp.SHR : BinOp.SHL;
       return Optional.of(
           new ParenExpr(
               new BinaryExpr(
                   new ParenExpr(
                       new BinaryExpr(
                           makeOpaqueOne(type, constContext, depth, fuzzer),
-                          applyIdentityFunction(shiftValue.clone(), type, constContext, depth,
-                              fuzzer),
-                          operator)),
-                  applyIdentityFunction(shiftValue.clone(), type, constContext, depth, fuzzer),
-                  secondOp)));
+                          shiftValue.clone(),
+                          BinOp.SHL)),
+                  shiftValue.clone(),
+                  BinOp.SHR)));
     }
   }
 
   /**
    * Function to generate an opaque value by performing a bitwise operation on an opaque zero or
    * an opaque one.
-   * Possibilities to create zero include:
+   * Possibilities for generating an opaque zero include:
    * Bitwise ANDing a fuzzed expression with an opaque zero: (fuzzedexpr) & (opaque zero)
    * Bitwise ORing an opaque zero with an opaque zero: (opaque zero) | (opaque zero)
    * Bitwise XORing an opaque zero with an opaque zero or an opaque one with an opaque one:
    *     (opaque zero) ^ (opaque zero) or (opaque one) ^ (opaque one)
-   * Possibilities to create one include:
+   * Possibilities for generating an opaque one include:
    * Bitwise ANDing an opaque one with an opaque one: (opaque one) & (opaque one)
    * Bitwise ORing an opaque one with an opaque zero or one: (opaque one) | (opaque zero or one)
    * Bitwise XORing an opaque zero with an opaque one or an opaque one with an opaque zero:
@@ -263,25 +279,23 @@ public final class OpaqueExpressionGenerator {
     if (!shadingLanguageVersion.supportedBitwiseOperations()) {
       return Optional.empty();
     }
-    final int operator = generator.nextInt(3);
+    final int numPossibleOperators = 3;
+    final int operator = generator.nextInt(numPossibleOperators);
     Optional<Expr> opaqueExpr;
     switch (operator) {
       case 0:
         // Bitwise AND
         if (isZero) {
+          // We pass true as constContext when fuzzing here because the expression will be
+          // evaluated, so we don't want any side effects.
+          final Expr fuzzedExpr = fuzzer.fuzzExpr(type, false, true, depth);
+          final Expr opaqueZero = makeOpaqueZero(type, constContext, depth, fuzzer);
           opaqueExpr = Optional.of(
               new ParenExpr(
                   generator.nextBoolean()
-                  ? new BinaryExpr(
-                      fuzzer.fuzzExpr(type, false, constContext, depth),
-                      makeOpaqueZero(type, constContext, depth, fuzzer),
-                      BinOp.BAND)
-                  : new BinaryExpr(
-                      makeOpaqueZero(type, constContext, depth, fuzzer),
-                      fuzzer.fuzzExpr(type, false, constContext, depth),
-                      BinOp.BAND)));
+                  ? new BinaryExpr(fuzzedExpr, opaqueZero, BinOp.BAND)
+                  : new BinaryExpr(opaqueZero, fuzzedExpr, BinOp.BAND)));
         } else {
-          assert !isZero;
           opaqueExpr = Optional.of(
               new ParenExpr(
                   new BinaryExpr(
@@ -300,25 +314,19 @@ public final class OpaqueExpressionGenerator {
                       makeOpaqueZero(type, constContext, depth, fuzzer),
                       BinOp.BOR)));
         } else {
-          assert !isZero;
+          final Expr opaqueOne = makeOpaqueOne(type, constContext, depth, fuzzer);
+          final Expr opaqueZeroOrOne = makeOpaqueZeroOrOne(generator.nextBoolean(), type,
+              constContext, depth, fuzzer);
           opaqueExpr = Optional.of(
               new ParenExpr(
                   generator.nextBoolean()
-                  ? new BinaryExpr(
-                      makeOpaqueOne(type, constContext, depth, fuzzer),
-                      makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
-                          fuzzer),
-                      BinOp.BOR)
-                  : new BinaryExpr(
-                      makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
-                          fuzzer),
-                      makeOpaqueOne(type, constContext, depth, fuzzer),
-                      BinOp.BOR)));
+                  ? new BinaryExpr(opaqueOne, opaqueZeroOrOne, BinOp.BOR)
+                  : new BinaryExpr(opaqueZeroOrOne, opaqueOne, BinOp.BOR)));
         }
         break;
       default:
         // Bitwise XOR
-        assert operator == 2;
+        assert operator == numPossibleOperators - 1;
         boolean useZeroOrOne = generator.nextBoolean();
         opaqueExpr = Optional.of(
             new ParenExpr(

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -235,8 +235,6 @@ public final class OpaqueExpressionGenerator {
     }
     final BinOp operator = generator.nextBoolean() ? BinOp.SHL : BinOp.SHR;
     // We need to make sure the LHS and RHS of the shift expression are based on the same type.
-    // GLSL resolves bit shift expressions as the type of the right side - expressions like
-    // 0 >> 944u + 1 will resolve to adding an unsigned and signed integer, which is disallowed.
     // Additionally, we can't shift zero reliably if the number is signed because of sign bit
     // extension, so we simply shift it zero.
     final Expr shiftValue = type.getElementType() == BasicType.INT

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -178,13 +178,15 @@ public final class OpaqueExpressionGenerator {
    *     If we're generating an opaque one, we have to make sure that we don't lose our 1 bit.
    *     This limits our maximum shift value to 7 bits (more on how we shift an opaque one below).
    * Possibilities for generating an opaque zero include:
-   *     Shifting an opaque zero by n bits: (opaque zero) >> n or (opaque zero) << n, where n is
-   *     an expression of a clamped value between 0 and 8:
-   *     n = clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(8)).
+   *     Shifting an opaque zero by m bits: (opaque zero) >> n or (opaque zero) << n, where n is
+   *     an expression of a clamped value between 0 and m, inclusive:
+   *     n = clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(m)), and m is an integer
+   *     between 0 and 8, inclusive.
    * Possibilities for generating an opaque zero include:
    *     Shifting an opaque one to the left by n bits, then shifting it to the right by n bits:
-   *     ((opaque one) << n) >> n, where n is an expression of a clamped value between 0 and 7,
-   *     inclusive: n = clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(7)).
+   *     ((opaque one) << n) >> n, where n is an expression of a clamped value between 0 and m,
+   *     inclusive: n = clamp(fuzzedexpr, (opaque zero), identity(typeconstructor(m)), and m is an
+   *     integer between 0 and 7, inclusive.
    *
    * @param type - the base type of the opaque value being created.
    * @param constContext - true if we're in a constant expression context, false otherwise.

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -247,21 +247,19 @@ public final class OpaqueExpressionGenerator {
       case 0:
         // Bitwise AND
         if (isZero) {
-          opaqueExpr = generator.nextBoolean()
-              ? Optional.of(
-                  new ParenExpr(
-                      new BinaryExpr(
-                          makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
-                              fuzzer),
-                          makeOpaqueZero(type, constContext, depth, fuzzer),
-                          BinOp.BAND)))
-              : Optional.of(
-                  new ParenExpr(
-                      new BinaryExpr(
-                          makeOpaqueZero(type, constContext, depth, fuzzer),
-                          makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
-                              fuzzer),
-                          BinOp.BAND)));
+          opaqueExpr = Optional.of(
+              new ParenExpr(
+                  generator.nextBoolean()
+                  ? new BinaryExpr(
+                      makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
+                          fuzzer),
+                      makeOpaqueZero(type, constContext, depth, fuzzer),
+                      BinOp.BAND)
+                  : new BinaryExpr(
+                      makeOpaqueZero(type, constContext, depth, fuzzer),
+                      makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
+                          fuzzer),
+                      BinOp.BAND)));
         } else {
           assert !isZero;
           opaqueExpr = Optional.of(
@@ -283,40 +281,36 @@ public final class OpaqueExpressionGenerator {
                       BinOp.BOR)));
         } else {
           assert !isZero;
-          opaqueExpr = generator.nextBoolean()
-              ? Optional.of(
-                  new ParenExpr(
-                      new BinaryExpr(
-                          makeOpaqueOne(type, constContext, depth, fuzzer),
-                          makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
-                              fuzzer),
-                          BinOp.BOR)))
-              : Optional.of(
-                  new ParenExpr(
-                      new BinaryExpr(
-                          makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
-                              fuzzer),
-                          makeOpaqueOne(type, constContext, depth, fuzzer),
-                          BinOp.BOR)));
+          opaqueExpr = Optional.of(
+              new ParenExpr(
+                  generator.nextBoolean()
+                  ? new BinaryExpr(
+                      makeOpaqueOne(type, constContext, depth, fuzzer),
+                      makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
+                          fuzzer),
+                      BinOp.BOR)
+                  : new BinaryExpr(
+                      makeOpaqueZeroOrOne(generator.nextBoolean(), type, constContext, depth,
+                          fuzzer),
+                      makeOpaqueOne(type, constContext, depth, fuzzer),
+                      BinOp.BOR)));
         }
         break;
       default:
         // Bitwise XOR
         assert operator == 2;
         boolean useZeroOrOne = generator.nextBoolean();
-        opaqueExpr = isZero
-            ? Optional.of(
-                new ParenExpr(
-                    new BinaryExpr(
-                        makeOpaqueZeroOrOne(useZeroOrOne, type, constContext, depth, fuzzer),
-                        makeOpaqueZeroOrOne(useZeroOrOne, type, constContext, depth, fuzzer),
-                        BinOp.BXOR)))
-            : Optional.of(
-                new ParenExpr(
-                    new BinaryExpr(
-                        makeOpaqueZeroOrOne(useZeroOrOne, type, constContext, depth, fuzzer),
-                        makeOpaqueZeroOrOne(!useZeroOrOne, type, constContext, depth, fuzzer),
-                        BinOp.BXOR)));
+        opaqueExpr = Optional.of(
+            new ParenExpr(
+                isZero
+                ? new BinaryExpr(
+                    makeOpaqueZeroOrOne(useZeroOrOne, type, constContext, depth, fuzzer),
+                    makeOpaqueZeroOrOne(useZeroOrOne, type, constContext, depth, fuzzer),
+                    BinOp.BXOR)
+                : new BinaryExpr(
+                    makeOpaqueZeroOrOne(useZeroOrOne, type, constContext, depth, fuzzer),
+                    makeOpaqueZeroOrOne(!useZeroOrOne, type, constContext, depth, fuzzer),
+                    BinOp.BXOR)));
     }
     return opaqueExpr;
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -189,7 +189,9 @@ public final class OpaqueExpressionGenerator {
       return Optional.empty();
     }
     final BinOp operator = generator.nextBoolean() ? BinOp.SHL : BinOp.SHR;
-    // We need to make sure the LHS and RHS of the shift expression are based on the same type.
+    // We need to make sure the LHS and RHS of the shift expression are based on the same type
+    // explicitly, so we can't generate opaque values to shift by as they will implicitly be
+    // considered signed integers, and both sides of the shift must be the same type.
     final Expr shiftValue;
     if (isZero) {
       // We can't shift zero reliably if the number is signed because of sign bit extension, so


### PR DESCRIPTION
Fixes #551.

Possibilities added for opaque zero generation:

(opaque zero) >> (0 if signed, otherwise a number between 0 and 1000)
(opaque zero) << (0 if signed, otherwise a number between 0 and 1000)
(opaque zero or one) & (opaque zero)
(opaque zero) & (opaque zero or one)
(opaque zero) | (opaque zero)
(opaque zero) ^ (opaque zero)
(opaque one) ^ (opaque one)

Possibilities added for opaque one generation:

(opaque one) >> 0
(opaque one) << 0
(opaque one) & (opaque one)
(opaque one) | (opaque zero or one)
(opaque zero or one) | (opaque one)
(opaque zero) ^ (opaque one)
(opaque one) ^ (opaque zero)
