### PR TITLE
Do not generate GraphicsFuzz header when preparing a reference shader.

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
@@ -119,7 +119,7 @@ public final class PrepareReference {
         maxUniforms,
         generateUniformBindings);
 
-    fileOps.writeShaderJobFile(shaderJob, outputShaderJobFile);
+    fileOps.writeShaderJobFile(shaderJob, outputShaderJobFile, false);
   }
 
   public static void prepareReference(ShaderJob shaderJob,


### PR DESCRIPTION
The header is not needed, so it is pointless and misleading to
generate it.