### PR TITLE
Ensure bitwise shift opaque one shifts left/right by same value

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -228,8 +228,6 @@ public final class OpaqueExpressionGenerator {
                   operator)));
     } else {
       // We're going to shift twice in opposite directions by the same value.
-      final Expr shiftBackValue = generator.nextBoolean() ? shiftValue.clone()
-          : makeClampedFuzzedExpr(type, constContext, depth, fuzzer, maxValue);
       return Optional.of(
           new ParenExpr(
               new BinaryExpr(
@@ -238,7 +236,7 @@ public final class OpaqueExpressionGenerator {
                           makeOpaqueOne(type, constContext, depth, fuzzer),
                           shiftValue,
                           BinOp.SHL)),
-                  shiftBackValue,
+                  shiftValue.clone(),
                   BinOp.SHR)));
     }
   }


### PR DESCRIPTION
Fixes #579.
While this didn't get caught by the validation tests, it causes undefined/non-determinant behavior when rendering shaders.

This is an example of what was generated:
```
1 << clamp(- 25010, int((injectionSwitch.x)), int(4)) >> clamp(2949, 0, int(4));
```
injectionSwitch.x = 0, so the statement becomes

(1 << 0) >> 4

which is not our intention for producing this opaque one.

I opted to remove the chance to generate a second clamp expression because we don't have any control over what kind of fuzzed value comes out, so we can't safely ensure it'll always evaluate to the same number.