### PR TITLE
Make available builtins aware of shader kind

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/Inliner.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/Inliner.java
@@ -71,7 +71,7 @@ public class Inliner {
     this.call = call;
     this.tu = tu;
     this.shadingLanguageVersion = shadingLanguageVersion;
-    this.typer = new Typer(tu, shadingLanguageVersion);
+    this.typer = new Typer(tu);
     this.parentMap = IParentMap.createParentMap(tu);
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -74,6 +74,11 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   }
 
   @Override
+  public boolean supportedComputeShaders() {
+    return prototype.supportedComputeShaders();
+  }
+
+  @Override
   public boolean supportedDerivativeFunctions() {
     return prototype.supportedDerivativeFunctions();
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -75,6 +75,11 @@ final class Essl100 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedComputeShaders() {
+    return false;
+  }
+
+  @Override
   public boolean supportedDerivativeFunctions() {
     return false;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
@@ -31,6 +31,11 @@ final class Essl310 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedComputeShaders() {
+    return true;
+  }
+
+  @Override
   public boolean supportedIntegerFunctions() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -75,6 +75,11 @@ final class Glsl110 implements ShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedComputeShaders() {
+    return false;
+  }
+
+  @Override
   public boolean supportedDerivativeFunctions() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl430.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl430.java
@@ -29,4 +29,10 @@ final class Glsl430 extends CompositeShadingLanguageVersion {
   public String getVersionString() {
     return "430";
   }
+
+  @Override
+  public boolean supportedComputeShaders() {
+    return true;
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -164,6 +164,12 @@ public interface ShadingLanguageVersion {
   boolean supportedClampUint();
 
   /**
+   * GLSL versions 4.3+ and ESSL versions 3.1+ support compute shaders.
+   * @return true if the shading language version allows compute shaders - false otherwise.
+   */
+  boolean supportedComputeShaders();
+
+  /**
    * Derivative Functions are a subset of fragment processing functions that compute
    * the rate of change between pixels in a given fragment.
    * GLSL versions 1.1+ and ESSL versions 3.0+ support these functions.

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -49,6 +49,7 @@ import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.util.GlslParserException;
+import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.util.ExecHelper.RedirectType;
 import com.graphicsfuzz.util.ExecResult;
 import com.graphicsfuzz.common.util.OpenGlConstants;
@@ -72,7 +73,8 @@ public class TyperTest {
   @Test
   public void visitMemberLookupExpr() throws Exception {
 
-    String prog = "struct S { float a; float b; };\n"
+    String prog = "#version 100\n"
+          + "struct S { float a; float b; };\n"
           + "struct T { S s; float c; };\n"
           + "void main() {\n"
           + "  T myT = T(S(1.0, 2.0), 3.0);\n"
@@ -82,7 +84,7 @@ public class TyperTest {
     TranslationUnit tu = ParseHelper.parse(prog);
 
     int actualCount =
-          new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_100) {
+          new NullCheckTyper(tu) {
 
             private int count;
 
@@ -105,7 +107,8 @@ public class TyperTest {
   @Test
   public void visitMemberLookupExprAnonymous() throws Exception {
 
-    String prog = "struct { float a; float b; } myStruct;\n"
+    String prog = "#version 100\n"
+        + "struct { float a; float b; } myStruct;\n"
         + "void main() {\n"
         + "  myStruct.a = 2.0;\n"
         + "  myStruct.b = 3.0;\n"
@@ -115,7 +118,7 @@ public class TyperTest {
     TranslationUnit tu = ParseHelper.parse(prog);
 
     int actualCount =
-        new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_100) {
+        new NullCheckTyper(tu) {
 
           private int count;
 
@@ -137,14 +140,15 @@ public class TyperTest {
 
   @Test
   public void testTypeOfScalarConstructors() throws Exception {
-    String program = "void main() { float(1); int(1); uint(1); bool(1); }";
+    String program = "#version 440\n"
+        + "void main() { float(1); int(1); uint(1); bool(1); }";
 
     for (BasicType b : Arrays.asList(BasicType.FLOAT, BasicType.INT, BasicType.UINT,
           BasicType.BOOL)) {
 
       try {
 
-        new NullCheckTyper(ParseHelper.parse(program), ShadingLanguageVersion.GLSL_440) {
+        new NullCheckTyper(ParseHelper.parse(program)) {
 
           @Override
           public void visitTypeConstructorExpr(TypeConstructorExpr typeConstructorExpr) {
@@ -171,14 +175,15 @@ public class TyperTest {
 
   @Test
   public void testMemberLookupTypeFloat() throws Exception {
-    final String program = "void main() { vec2 v2 = vec2(1.0);"
+    final String program = "#version 100\n"
+          + "void main() { vec2 v2 = vec2(1.0);"
           + " v2.x; v2.y;"
           + " vec3 v3 = vec3(1.0);"
           + " v3.x; v3.y; v3.z;"
           + " vec4 v4 = vec4(1.0);"
           + " v4.x; v4.y; v4.z; v4.w; }";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_100) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
         super.visitMemberLookupExpr(memberLookupExpr);
@@ -190,14 +195,15 @@ public class TyperTest {
 
   @Test
   public void testMemberLookupTypeInt() throws Exception {
-    final String program = "void main() { ivec2 v2 = ivec2(1);"
+    final String program = "#version 440\n"
+          + "void main() { ivec2 v2 = ivec2(1);"
           + " v2.x; v2.y;"
           + " ivec3 v3 = ivec3(1);"
           + " v3.x; v3.y; v3.z;"
           + " ivec4 v4 = ivec4(1);"
           + " v4.x; v4.y; v4.z; v4.w; }";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
         super.visitMemberLookupExpr(memberLookupExpr);
@@ -209,14 +215,15 @@ public class TyperTest {
 
   @Test
   public void testMemberLookupTypeUint() throws Exception {
-    final String program = "void main() { uvec2 v2 = uvec2(1u);"
+    final String program = "#version 440\n"
+          + "void main() { uvec2 v2 = uvec2(1u);"
           + " v2.x; v2.y;"
           + " uvec3 v3 = uvec3(1u);"
           + " v3.x; v3.y; v3.z;"
           + " uvec4 v4 = uvec4(1u);"
           + " v4.x; v4.y; v4.z; v4.w; }";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
         super.visitMemberLookupExpr(memberLookupExpr);
@@ -229,14 +236,15 @@ public class TyperTest {
 
   @Test
   public void testMemberLookupTypeBool() throws Exception {
-    final String program = "void main() { bvec2 v2 = bvec2(true);"
+    final String program = "#version 440\n"
+          + "void main() { bvec2 v2 = bvec2(true);"
           + " v2.x; v2.y;"
           + " bvec3 v3 = bvec3(true);"
           + " v3.x; v3.y; v3.z;"
           + " bvec4 v4 = bvec4(true);"
           + " v4.x; v4.y; v4.z; v4.w; }";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
         super.visitMemberLookupExpr(memberLookupExpr);
@@ -248,9 +256,10 @@ public class TyperTest {
 
   @Test
   public void testBooleanVectorType() throws Exception {
-    final String program = "void main() { vec3(1.0) > vec3(2.0); }";
+    final String program = "#version 440\n"
+        + "void main() { vec3(1.0) > vec3(2.0); }";
     TranslationUnit tu = ParseHelper.parse(program);
-    new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitBinaryExpr(BinaryExpr binaryExpr) {
         super.visitBinaryExpr(binaryExpr);
@@ -261,9 +270,10 @@ public class TyperTest {
 
   @Test
   public void testBooleanVectorType2() throws Exception {
-    final String program = "void main() { vec3(1.0) > 2.0; }";
+    final String program = "#version 440\n"
+        + "void main() { vec3(1.0) > 2.0; }";
     TranslationUnit tu = ParseHelper.parse(program);
-    new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitBinaryExpr(BinaryExpr binaryExpr) {
         super.visitBinaryExpr(binaryExpr);
@@ -275,7 +285,7 @@ public class TyperTest {
   @Test
   public void testSwizzleTyped() throws Exception {
     TranslationUnit tu = ParseHelper.parse("void main() { vec2 v; v.xy = v.yx; }");
-    Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_100);
+    Typer typer = new NullCheckTyper(tu);
     new StandardVisitor() {
       @Override
       public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
@@ -287,7 +297,8 @@ public class TyperTest {
 
   @Test
   public void testAssignTyped() throws Exception {
-    TranslationUnit tu = ParseHelper.parse("void main() {"
+    TranslationUnit tu = ParseHelper.parse("#version 440\n"
+          + "void main() {"
           + "int x;"
           + "x = 2;"
           + "float f;"
@@ -298,7 +309,7 @@ public class TyperTest {
           + "v3 /= v3;"
           + "ivec2 i2;"
           + "i2 -= i2; }");
-    Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440);
+    Typer typer = new NullCheckTyper(tu);
     new StandardVisitor() {
       @Override
       public void visitBinaryExpr(BinaryExpr binaryExpr) {
@@ -328,11 +339,12 @@ public class TyperTest {
 
   @Test
   public void testCommaTyped() throws Exception {
-    TranslationUnit tu = ParseHelper.parse("void main() {"
+    TranslationUnit tu = ParseHelper.parse("#version 440\n"
+        + "void main() {"
         + "int x;"
         + "int y;"
         + "x, y; }");
-    Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.GLSL_440);
+    Typer typer = new NullCheckTyper(tu);
     new StandardVisitor() {
       @Override
       public void visitBinaryExpr(BinaryExpr binaryExpr) {
@@ -345,8 +357,10 @@ public class TyperTest {
 
   @Test
   public void testGlPositionTyped() throws Exception {
-    TranslationUnit tu = ParseHelper.parse("void main() { gl_Position = vec4(0.0); }");
-    Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_300);
+    TranslationUnit tu = ParseHelper.parse("#version 300 es\n"
+        + "void main() { gl_Position = vec4(0.0)"
+        + "; }");
+    Typer typer = new NullCheckTyper(tu);
     new StandardVisitor() {
       @Override
       public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
@@ -361,8 +375,9 @@ public class TyperTest {
 
   @Test
   public void testGlPointSizeTyped() throws Exception {
-    TranslationUnit tu = ParseHelper.parse("void main() { gl_PointSize = 1.0; }");
-    Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_300);
+    TranslationUnit tu = ParseHelper.parse("#version 300 es\n"
+        + "void main() { gl_PointSize = 1.0; }");
+    Typer typer = new NullCheckTyper(tu);
     new StandardVisitor() {
       @Override
       public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
@@ -434,7 +449,7 @@ public class TyperTest {
         + "void main() {"
         + "  int x = 031;"
         + "}");
-    new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_300) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitScalarInitializer(ScalarInitializer scalarInitializer) {
         super.visitScalarInitializer(scalarInitializer);
@@ -449,7 +464,7 @@ public class TyperTest {
         + "void main() {"
         + "  int x = 0xA03B;"
         + "}");
-    new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_300) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitScalarInitializer(ScalarInitializer scalarInitializer) {
         super.visitScalarInitializer(scalarInitializer);
@@ -464,7 +479,7 @@ public class TyperTest {
         + "void main() {"
         + "  int x = 031u;"
         + "}");
-    new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_300) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitScalarInitializer(ScalarInitializer scalarInitializer) {
         super.visitScalarInitializer(scalarInitializer);
@@ -479,7 +494,7 @@ public class TyperTest {
         + "void main() {"
         + "  int x = 0xA03Bu;"
         + "}");
-    new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_300) {
+    new NullCheckTyper(tu) {
       @Override
       public void visitScalarInitializer(ScalarInitializer scalarInitializer) {
         super.visitScalarInitializer(scalarInitializer);
@@ -491,8 +506,9 @@ public class TyperTest {
   private void checkComputeShaderBuiltin(String builtin, String builtinConstant, BasicType baseType,
       TypeQualifier qualifier) throws IOException, ParseTimeoutException, InterruptedException,
       GlslParserException {
-    TranslationUnit tu = ParseHelper.parse("void main() { " + builtin + "; }");
-    Typer typer = new NullCheckTyper(tu, ShadingLanguageVersion.ESSL_310);
+    TranslationUnit tu = ParseHelper.parse("#version 310 es\n"
+        + "void main() { " + builtin + "; }");
+    Typer typer = new NullCheckTyper(tu);
     new StandardVisitor() {
       @Override
       public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
@@ -508,9 +524,8 @@ public class TyperTest {
 
   class NullCheckTyper extends Typer {
 
-    public NullCheckTyper(IAstNode node,
-          ShadingLanguageVersion shadingLanguageVersion) {
-      super(node, shadingLanguageVersion);
+    NullCheckTyper(TranslationUnit tu) {
+      super(tu);
     }
 
     @Override
@@ -684,24 +699,31 @@ public class TyperTest {
 
   private void testBuiltins(ShadingLanguageVersion shadingLanguageVersion)
       throws IOException, InterruptedException {
-    final File tempFile = temporaryFolder.newFile("shader.frag");
-    FileUtils.writeStringToFile(
-        tempFile,
-        makeBuiltinsProgram(shadingLanguageVersion).toString(),
-        StandardCharsets.UTF_8);
-    final ExecResult result = ToolHelper.runValidatorOnShader(RedirectType.TO_BUFFER, tempFile);
-    assertEquals(0, result.res);
+    for (ShaderKind shaderKind : ShaderKind.values()) {
+      if (shaderKind == ShaderKind.COMPUTE && !shadingLanguageVersion.supportedComputeShaders()) {
+        // Compute shaders are not supported for older GLSL versions.
+        continue;
+      }
+      final File tempFile = temporaryFolder.newFile("shader." + shaderKind.getFileExtension());
+      FileUtils.writeStringToFile(
+          tempFile,
+          makeBuiltinsProgram(shadingLanguageVersion, shaderKind).toString(),
+          StandardCharsets.UTF_8);
+      final ExecResult result = ToolHelper.runValidatorOnShader(RedirectType.TO_BUFFER, tempFile);
+      assertEquals(0, result.res);
+    }
   }
 
-  private StringBuilder makeBuiltinsProgram(ShadingLanguageVersion shadingLanguageVersion) {
+  private StringBuilder makeBuiltinsProgram(ShadingLanguageVersion shadingLanguageVersion,
+                                            ShaderKind shaderKind) {
     StringBuilder result = new StringBuilder();
     result.append("#version " + shadingLanguageVersion.getVersionString() + "\n");
     result.append("#ifdef GL_ES\n");
     result.append("precision mediump float;\n");
     result.append("#endif\n");
     int counter = 0;
-    for (String name : TyperHelper.getBuiltins(shadingLanguageVersion).keySet()) {
-      for (FunctionPrototype fp : TyperHelper.getBuiltins(shadingLanguageVersion).get(name)) {
+    for (String name : TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind).keySet()) {
+      for (FunctionPrototype fp : TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind).get(name)) {
         counter++;
         result.append(fp.getReturnType() + " test" + counter + "_" + fp.getName() + "(");
         boolean first = true;

--- a/common/src/main/java/com/graphicsfuzz/common/util/Obfuscator.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/Obfuscator.java
@@ -107,7 +107,7 @@ public class Obfuscator {
 
     private void obfuscateTranslationUnit(TranslationUnit tu) {
 
-      this.typer = new Typer(tu, tu.getShadingLanguageVersion());
+      this.typer = new Typer(tu);
       visit(tu);
       for (VariableDeclInfo declInfo : varDeclMapping.keySet()) {
         assert varDeclMapping.containsKey(declInfo);

--- a/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
@@ -38,18 +38,19 @@ import com.graphicsfuzz.common.typing.TyperHelper;
 public class SideEffectChecker {
 
   private static boolean isSideEffectFreeVisitor(IAstNode node,
-      ShadingLanguageVersion shadingLanguageVersion) {
+      ShadingLanguageVersion shadingLanguageVersion, ShaderKind shaderKind) {
     return !new CheckPredicateVisitor() {
 
       @Override
       public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
-        if (!TyperHelper.getBuiltins(shadingLanguageVersion)
+        if (!TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind)
             .containsKey(functionCallExpr.getCallee())) {
           // Assume that any call to a non-builtin might have a side-effect.
           predicateHolds();
         }
         for (FunctionPrototype p :
-            TyperHelper.getBuiltins(shadingLanguageVersion).get(functionCallExpr.getCallee())) {
+            TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind)
+                .get(functionCallExpr.getCallee())) {
           // We check each argument of the built-in's prototypes to see if they require lvalues -
           // if so, they can cause side effects.
           // We could be more precise here by finding the specific overload of the function rather
@@ -113,12 +114,14 @@ public class SideEffectChecker {
     }.test(node);
   }
 
-  public static boolean isSideEffectFree(Stmt stmt, ShadingLanguageVersion shadingLanguageVersion) {
-    return isSideEffectFreeVisitor(stmt, shadingLanguageVersion);
+  public static boolean isSideEffectFree(Stmt stmt, ShadingLanguageVersion shadingLanguageVersion,
+                                         ShaderKind shaderKind) {
+    return isSideEffectFreeVisitor(stmt, shadingLanguageVersion, shaderKind);
   }
 
-  public static boolean isSideEffectFree(Expr expr, ShadingLanguageVersion shadingLanguageVersion) {
-    return isSideEffectFreeVisitor(expr, shadingLanguageVersion);
+  public static boolean isSideEffectFree(Expr expr, ShadingLanguageVersion shadingLanguageVersion,
+                                         ShaderKind shaderKind) {
+    return isSideEffectFreeVisitor(expr, shadingLanguageVersion, shaderKind);
   }
 
 }

--- a/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
@@ -50,7 +50,7 @@ public class SideEffectCheckerTest {
           new VariableIdentifierExpr("v"),
           new IntConstantExpr("12"),
           BinOp.ASSIGN
-    )), ShadingLanguageVersion.ESSL_310));
+    )), ShadingLanguageVersion.ESSL_310, ShaderKind.FRAGMENT));
   }
 
   @Test
@@ -69,7 +69,7 @@ public class SideEffectCheckerTest {
             new VariableIdentifierExpr("i"),
             UnOp.POST_INC
         ), new BlockStmt(Collections.emptyList(), false)),
-        ShadingLanguageVersion.ESSL_310));
+        ShadingLanguageVersion.ESSL_310, ShaderKind.FRAGMENT));
   }
 
   @Test
@@ -92,7 +92,7 @@ public class SideEffectCheckerTest {
       @Override
       public void visitFunctionCallExpr(FunctionCallExpr expr) {
         assertTrue(expr.getCallee().equals("uaddCarry"));
-        assertFalse(SideEffectChecker.isSideEffectFree(expr, ShadingLanguageVersion.ESSL_310));
+        assertFalse(SideEffectChecker.isSideEffectFree(expr, ShadingLanguageVersion.ESSL_310, ShaderKind.FRAGMENT));
       }
     }.visit(tu);
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
@@ -220,45 +220,19 @@ public class Fuzzer {
 
   private Stream<IExprTemplate> availableTemplatesFromContext() {
     return Stream.concat(availableTemplatesFromScope(shadingLanguageVersion,
+        generationParams.getShaderKind(),
         fuzzingContext.getCurrentScope()),
       fuzzingContext.getFunctionPrototypes().stream().map(FunctionCallExprTemplate::new));
   }
 
   public static Stream<IExprTemplate> availableTemplatesFromScope(
       ShadingLanguageVersion shadingLanguageVersion,
+      ShaderKind shaderKind,
       Scope scope) {
-    return Stream.concat(Templates.get(shadingLanguageVersion).stream(),
+    return Stream.concat(Templates.get(shadingLanguageVersion, shaderKind).stream(),
         scope.namesOfAllVariablesInScope()
             .stream()
             .map(item -> new VariableIdentifierExprTemplate(item, scope.lookupType(item))));
-  }
-
-  public static void main(String[] args) {
-    try {
-      //testFuzzExpr(args);
-      showTemplates(args);
-
-    } catch (Throwable throwable) {
-      throwable.printStackTrace();
-      System.exit(1);
-    }
-
-  }
-
-  private static void showTemplates(String[] args) {
-    // Call this from main to produce a list of templates
-    List<IExprTemplate> templates = new ArrayList<>();
-    templates.addAll(Templates.get(ShadingLanguageVersion.fromVersionString(args[0])));
-    Collections.sort(templates, new Comparator<IExprTemplate>() {
-      @Override
-      public int compare(IExprTemplate t1, IExprTemplate t2) {
-        return t1.toString().compareTo(t2.toString());
-      }
-    });
-
-    for (IExprTemplate t : templates) {
-      System.out.println(t);
-    }
   }
 
   public TranslationUnit fuzzTranslationUnit() {
@@ -555,6 +529,35 @@ public class Fuzzer {
             ((ArrayType) type).getArrayInfo());
     }
     return type;
+  }
+
+  public static void main(String[] args) {
+    try {
+      //testFuzzExpr(args);
+      showTemplates(args);
+
+    } catch (Throwable throwable) {
+      throwable.printStackTrace();
+      System.exit(1);
+    }
+
+  }
+
+  private static void showTemplates(String[] args) {
+    // Call this from main to produce a list of templates
+    List<IExprTemplate> templates = new ArrayList<>();
+    templates.addAll(Templates.get(ShadingLanguageVersion.fromVersionString(args[0]),
+        ShaderKind.fromExtension(args[1])));
+    Collections.sort(templates, new Comparator<IExprTemplate>() {
+      @Override
+      public int compare(IExprTemplate t1, IExprTemplate t2) {
+        return t1.toString().compareTo(t2.toString());
+      }
+    });
+
+    for (IExprTemplate t : templates) {
+      System.out.println(t);
+    }
   }
 
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -746,7 +746,8 @@ public final class OpaqueExpressionGenerator {
       if (!exprMustBeSideEffectFree) {
         return true;
       }
-      return SideEffectChecker.isSideEffectFree(expr, shadingLanguageVersion);
+      return SideEffectChecker.isSideEffectFree(expr, shadingLanguageVersion,
+          generationParams.getShaderKind());
 
     }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/InterchangeExprMutationFinder.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/InterchangeExprMutationFinder.java
@@ -63,7 +63,8 @@ public class InterchangeExprMutationFinder extends Expr2ExprMutationFinder {
   private Expr applyInterchange(Expr expr, List<Type> argumentTypes) {
     final Type resultType = typer.lookupType(expr).getWithoutQualifiers();
     List<IExprTemplate> templates = Fuzzer.availableTemplatesFromScope(
-        getTranslationUnit().getShadingLanguageVersion(), currentScope)
+        getTranslationUnit().getShadingLanguageVersion(), getTranslationUnit().getShaderKind(),
+        currentScope)
         // Ignore templates that require l-values, so that invalidity is not too likely
         .filter(InterchangeExprMutationFinder::doesNotRequireLvalue)
         // Ignore the possibility of replacing a one-argument expression with parentheses, as it

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddLiveOutputWriteMutation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddLiveOutputWriteMutation.java
@@ -30,6 +30,7 @@ import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.util.IRandom;
+import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.generator.fuzzer.Fuzzer;
 import com.graphicsfuzz.generator.fuzzer.FuzzingContext;
 import com.graphicsfuzz.generator.fuzzer.OpaqueExpressionGenerator;
@@ -63,7 +64,8 @@ public class AddLiveOutputWriteMutation extends AddOutputWriteMutation {
         null, null))));
     stmts.add(new ExprStmt(new BinaryExpr(new VariableIdentifierExpr(backupName),
         new VariableIdentifierExpr(outputVariableName), BinOp.ASSIGN)));
-    final Fuzzer fuzzer = new Fuzzer(new FuzzingContext(), shadingLanguageVersion, random,
+    final Fuzzer fuzzer = new Fuzzer(new FuzzingContext(), shadingLanguageVersion,
+        random,
         generationParams);
     stmts.add(new ExprStmt(new BinaryExpr(
         new VariableIdentifierExpr(outputVariableName),

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
@@ -453,7 +453,7 @@ public class Generate {
                                                     ShadingLanguageVersion shadingLanguageVersion) {
     // Debugging aid: fail early if we end up messing up the translation unit so that type checking
     // does not work.
-    new Typer(reference, shadingLanguageVersion);
+    new Typer(reference);
     return true;
   }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -50,6 +50,7 @@ import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.OpenGlConstants;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
+import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.common.util.StructUtils;
 import com.graphicsfuzz.generator.fuzzer.FuzzedIntoACornerException;
 import com.graphicsfuzz.generator.fuzzer.Fuzzer;
@@ -250,7 +251,7 @@ public abstract class DonateCodeTransformation implements ITransformation {
     }
     donateFunctionsAndGlobals(tu);
     eliminateUsedDonors();
-    makeInjectedArrayAccessesInBounds(tu, injectedStmts, tu.getShadingLanguageVersion());
+    makeInjectedArrayAccessesInBounds(tu, injectedStmts);
 
     return !injectionPoints.isEmpty();
 
@@ -266,9 +267,8 @@ public abstract class DonateCodeTransformation implements ITransformation {
   }
 
   private void makeInjectedArrayAccessesInBounds(TranslationUnit tu,
-                                                 List<Stmt> injectedStmts,
-                                                 ShadingLanguageVersion shadingLanguageVersion) {
-    Typer typer = new Typer(tu, shadingLanguageVersion);
+                                                 List<Stmt> injectedStmts) {
+    Typer typer = new Typer(tu);
     for (Stmt stmt : injectedStmts) {
       MakeArrayAccessesInBounds.makeInBounds(stmt, typer);
     }

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RestrictFragmentShaderColors.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RestrictFragmentShaderColors.java
@@ -40,6 +40,7 @@ import com.graphicsfuzz.common.typing.ScopeTreeBuilder;
 import com.graphicsfuzz.common.typing.Typer;
 import com.graphicsfuzz.common.typing.TyperHelper;
 import com.graphicsfuzz.common.util.IRandom;
+import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.generator.fuzzer.Fuzzer;
 import com.graphicsfuzz.generator.fuzzer.FuzzingContext;
 import com.graphicsfuzz.generator.fuzzer.OpaqueExpressionGenerator;
@@ -156,7 +157,7 @@ public class RestrictFragmentShaderColors {
 
   private boolean adaptExistingWrites() {
 
-    final Typer typer = new Typer(shaderJob.getFragmentShader().get(), shadingLanguageVersion);
+    final Typer typer = new Typer(shaderJob.getFragmentShader().get());
 
     return new ScopeTreeBuilder() {
 
@@ -164,7 +165,8 @@ public class RestrictFragmentShaderColors {
       public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
         super.visitFunctionCallExpr(functionCallExpr);
         Set<String> acceptableFunctionNames = new HashSet<>();
-        acceptableFunctionNames.addAll(TyperHelper.getBuiltins(shadingLanguageVersion).keySet());
+        acceptableFunctionNames.addAll(TyperHelper.getBuiltins(shadingLanguageVersion,
+            ShaderKind.FRAGMENT).keySet());
         acceptableFunctionNames.add(Constants.GLF_FUZZED);
         acceptableFunctionNames.add(Constants.GLF_IDENTITY);
         if (acceptableFunctionNames.contains(functionCallExpr.getCallee())

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/donation/MakeArrayAccessesInBoundsTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/donation/MakeArrayAccessesInBoundsTest.java
@@ -29,10 +29,10 @@ public class MakeArrayAccessesInBoundsTest {
 
   @Test
   public void testBasic() throws Exception {
-    final String shader = "void main() { int A[5]; int x = 17; A[x] = 2; }";
-    final String expected = "void main() { int A[5]; int x = 17; A[(x) >= 0 && (x) < 5 ? x : 0] = 2; }";
+    final String shader = "#version 300 es\nvoid main() { int A[5]; int x = 17; A[x] = 2; }";
+    final String expected = "#version 300 es\nvoid main() { int A[5]; int x = 17; A[(x) >= 0 && (x) < 5 ? x : 0] = 2; }";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu, ShadingLanguageVersion.ESSL_300);
+    final Typer typer = new Typer(tu);
     MakeArrayAccessesInBounds.makeInBounds(tu, typer);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));
@@ -40,13 +40,13 @@ public class MakeArrayAccessesInBoundsTest {
 
   @Test
   public void testMatrixVector() throws Exception {
-    final String shader = "void main() { mat4x2 As[5]; int x = 17; int y = -22; int z = 100; As[x][y][z] = 2.0; }";
-    final String expected = "void main() { mat4x2 As[5]; int x = 17; int y = -22; int z = 100;"
+    final String shader = "#version 300 es\nvoid main() { mat4x2 As[5]; int x = 17; int y = -22; int z = 100; As[x][y][z] = 2.0; }";
+    final String expected = "#version 300 es\nvoid main() { mat4x2 As[5]; int x = 17; int y = -22; int z = 100;"
           + "As[(x) >= 0 && (x) < 5 ? x : 0]"
           + "  /* column */ [(y) >= 0 && (y) < 4 ? y : 0]"
           + "  /* row */ [(z) >= 0 && (z) < 2 ? z : 0] = 2.0; }";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu, ShadingLanguageVersion.ESSL_300);
+    final Typer typer = new Typer(tu);
     MakeArrayAccessesInBounds.makeInBounds(tu, typer);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));
@@ -54,7 +54,8 @@ public class MakeArrayAccessesInBoundsTest {
 
   @Test
   public void testMatrixVector2() throws Exception {
-    final String shader = "void main() { mat3x4 As[5];"
+    final String shader = "#version 300 es\n"
+          + "void main() { mat3x4 As[5];"
           + "  int x = 17;"
           + "  int y = -22;"
           + "  int z = 100;"
@@ -64,7 +65,8 @@ public class MakeArrayAccessesInBoundsTest {
           + "  float f;"
           + "  f = v[z];"
           + "}";
-    final String expected = "void main() { mat3x4 As[5];"
+    final String expected = "#version 300 es\n"
+          + "void main() { mat3x4 As[5];"
           + "  int x = 17;"
           + "  int y = -22;"
           + "  int z = 100;"
@@ -75,7 +77,7 @@ public class MakeArrayAccessesInBoundsTest {
           + "  f = v[(z) >= 0 && (z) < 4 ? z : 0];"
           + "}";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu, ShadingLanguageVersion.ESSL_300);
+    final Typer typer = new Typer(tu);
     MakeArrayAccessesInBounds.makeInBounds(tu, typer);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunities.java
@@ -112,7 +112,8 @@ public class CompoundToBlockReductionOpportunities
           || (StmtReductionOpportunities.isLiveCodeInjection(compoundStmt)
                && !isLoopLimiterCheck(compoundStmt))
           || enclosingFunctionIsDead()
-          || SideEffectChecker.isSideEffectFree(compoundStmt, context.getShadingLanguageVersion());
+          || SideEffectChecker.isSideEffectFree(compoundStmt, context.getShadingLanguageVersion(),
+        shaderKind);
   }
 
   private static boolean isLoopLimiterCheck(Stmt compoundStmt) {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunities.java
@@ -230,7 +230,7 @@ public final class FoldConstantReductionOpportunities extends SimplifyExprReduct
       // We could handle cases such as vec2(0.0).x resolving to 0.0; but for now we do not.
       return;
     }
-    if (!SideEffectChecker.isSideEffectFree(tce, context.getShadingLanguageVersion())) {
+    if (!SideEffectChecker.isSideEffectFree(tce, context.getShadingLanguageVersion(), shaderKind)) {
       // We mustn't eliminate side-effects from elements of the vector that we are not popping out.
       return;
     }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FunctionReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FunctionReductionOpportunities.java
@@ -46,7 +46,7 @@ public class FunctionReductionOpportunities extends StandardVisitor {
   private final List<FunctionPrototype> declaredFunctions; // All functions declared in the shader
 
   private FunctionReductionOpportunities(TranslationUnit tu, ReducerContext context) {
-    this.typer = new Typer(tu, context.getShadingLanguageVersion());
+    this.typer = new Typer(tu);
     this.opportunities = new ArrayList<>();
     this.calledFunctions = new HashSet<>();
     this.declaredFunctions = Collections

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineStructifiedFieldReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineStructifiedFieldReductionOpportunity.java
@@ -64,8 +64,7 @@ public class InlineStructifiedFieldReductionOpportunity extends AbstractReductio
   @Override
   public void applyReductionImpl() {
 
-    // The GLSL version is irrelevant; really we want a Typer that doesn't require this.
-    final Typer typer = new Typer(tu, ShadingLanguageVersion.ESSL_100);
+    final Typer typer = new Typer(tu);
 
     final int indexOfInlinedField = outerStruct.getFieldIndex(fieldToInline);
     outerStruct.removeField(fieldToInline);

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
@@ -41,7 +41,7 @@ abstract class SimplifyExprReductionOpportunities
         TranslationUnit tu,
         ReducerContext context) {
     super(tu, context);
-    this.typer = new Typer(tu, context.getShadingLanguageVersion());
+    this.typer = new Typer(tu);
     this.inLiveInjectedStmtOrDeclaration = false;
   }
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -110,7 +110,7 @@ public class StmtReductionOpportunities
       return true;
     }
 
-    if (SideEffectChecker.isSideEffectFree(stmt, context.getShadingLanguageVersion())) {
+    if (SideEffectChecker.isSideEffectFree(stmt, context.getShadingLanguageVersion(), shaderKind)) {
       return true;
     }
 


### PR DESCRIPTION
Now that we more comprehensively support builtins, we have the problem
that not all builtins are available for every kind of shader.  This
change adds a ShaderKind parameter to the function that produces
available builtins, so that only relevant builtins will be returned.
This has required quite a lot of plumbing through, as sometimes
builtins are asked for at relatively deep points in the code, where
the relevant ShaderKind was not always available.

The tests for validity of builtin functions have been extended to try
not just every shading language version and also every kind of shader;
this would catch the (previously uncaught) problem where a fragment
processing builtin could be generated in a compute shader.

Fixes #588.