### PR TITLE
Simplify loop limiters

### DIFF
--- a/ast/pom.xml
+++ b/ast/pom.xml
@@ -68,10 +68,6 @@ limitations under the License.
       <groupId>net.sourceforge.argparse4j</groupId>
       <artifactId>argparse4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
 
   </dependencies>
 

--- a/ast/src/main/java/com/graphicsfuzz/common/util/TruncateLoops.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/util/TruncateLoops.java
@@ -23,10 +23,7 @@ import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
-import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
-import com.graphicsfuzz.common.ast.expr.Op;
-import com.graphicsfuzz.common.ast.expr.ParenExpr;
 import com.graphicsfuzz.common.ast.expr.UnOp;
 import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
@@ -45,8 +42,6 @@ import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class TruncateLoops extends StandardVisitor {
 

--- a/ast/src/main/java/com/graphicsfuzz/common/util/TruncateLoops.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/util/TruncateLoops.java
@@ -53,15 +53,12 @@ public class TruncateLoops extends StandardVisitor {
   private final int limit;
   private final TranslationUnit tu;
   private final String prefix;
-  private final boolean ignoreShortRunningForLoops;
   private int counter;
 
-  public TruncateLoops(int limit, String prefix, TranslationUnit tu,
-                       boolean ignoreShortRunningForLoops) {
+  public TruncateLoops(int limit, String prefix, TranslationUnit tu) {
     this.limit = limit;
     this.tu = tu;
     this.prefix = prefix;
-    this.ignoreShortRunningForLoops = ignoreShortRunningForLoops;
     counter = 0;
     visit(tu);
   }
@@ -69,9 +66,7 @@ public class TruncateLoops extends StandardVisitor {
   @Override
   public void visitForStmt(ForStmt forStmt) {
     super.visitForStmt(forStmt);
-    if (!ignoreShortRunningForLoops || maybeLongRunning(forStmt)) {
-      handleLoop(forStmt);
-    }
+    handleLoop(forStmt);
   }
 
   @Override
@@ -122,163 +117,6 @@ public class TruncateLoops extends StandardVisitor {
     final BlockStmt replacementBlock = new BlockStmt(
           Arrays.asList(limiterDeclaration, loopStmt), true);
     parentMap.getParent(loopStmt).replaceChild(loopStmt, replacementBlock);
-  }
-
-  private boolean maybeLongRunning(ForStmt forStmt) {
-    final Optional<ImmutablePair<String, Integer>> initValueAndLoopCounterName
-        = getLoopCounterNameAndInitValue(forStmt.getInit());
-    if (!initValueAndLoopCounterName.isPresent()) {
-      return false;
-    }
-    final String loopCounterName = initValueAndLoopCounterName.get().left;
-    final int initValue = initValueAndLoopCounterName.get().right;
-
-    final Optional<ImmutablePair<BinOp, Integer>> condTestTypeAndLimitValue
-        = getCondTestTypeAndLimitValue(forStmt.getCondition(), loopCounterName);
-    if (!condTestTypeAndLimitValue.isPresent()) {
-      return false;
-    }
-    final BinOp condTestType = condTestTypeAndLimitValue.get().left;
-    final int condLimitValue = condTestTypeAndLimitValue.get().right;
-    if (condTestType.isSideEffecting()) {
-      return false;
-    }
-
-    final Optional<Integer> incrementValue
-        = getIncrementValue(forStmt.getIncrement(), loopCounterName);
-    if (!incrementValue.isPresent()) {
-      return false;
-    }
-
-    return (((condTestType == BinOp.LT || condTestType == BinOp.LE) && incrementValue.get() <= 0)
-        || ((condTestType == BinOp.GT || condTestType == BinOp.GE) && incrementValue.get() >= 0)
-        || ((condLimitValue - initValue) / incrementValue.get() >= limit));
-  }
-
-  private Optional<ImmutablePair<String, Integer>> getLoopCounterNameAndInitValue(Stmt init) {
-    String name = null;
-    Expr expr = null;
-    if (init instanceof ExprStmt
-        && ((ExprStmt) init).getExpr() instanceof BinaryExpr
-        && ((BinaryExpr)(((ExprStmt) init).getExpr())).getOp() == BinOp.ASSIGN
-        && ((BinaryExpr)(((ExprStmt) init).getExpr())).getLhs()
-        instanceof VariableIdentifierExpr) {
-      name = ((VariableIdentifierExpr) (((BinaryExpr)(((ExprStmt) init)
-          .getExpr())).getLhs())).getName();
-      expr = ((BinaryExpr)(((ExprStmt) init)
-          .getExpr())).getRhs();
-    } else if (init instanceof DeclarationStmt
-        && ((DeclarationStmt) init).getVariablesDeclaration().getNumDecls() == 1
-        && ((DeclarationStmt) init).getVariablesDeclaration().getDeclInfo(0)
-        .getInitializer() instanceof ScalarInitializer) {
-      name = ((DeclarationStmt) init).getVariablesDeclaration()
-          .getDeclInfo(0).getName();
-      expr = ((ScalarInitializer)((DeclarationStmt) init)
-          .getVariablesDeclaration().getDeclInfo(0)
-          .getInitializer()).getExpr();
-    }
-    if (name == null || expr == null) {
-      return Optional.empty();
-    }
-    Optional<Integer> constant = getAsConstant(expr);
-    if (!constant.isPresent()) {
-      return Optional.empty();
-    }
-    return Optional.of(new ImmutablePair<>(name, constant.get()));
-  }
-
-  private Optional<ImmutablePair<BinOp,Integer>> getCondTestTypeAndLimitValue(Expr cond,
-      String loopCounterName) {
-    if (!(cond instanceof BinaryExpr)) {
-      return Optional.empty();
-    }
-    final BinaryExpr binaryExprCond = (BinaryExpr) cond;
-    Optional<Integer> condLimitValue = getAsConstant(binaryExprCond.getRhs());
-    if (condLimitValue.isPresent()
-        && isSameVarIdentifier(binaryExprCond.getLhs(), loopCounterName)) {
-      return Optional.of(new ImmutablePair<>(binaryExprCond.getOp(), condLimitValue.get()));
-    }
-    condLimitValue = getAsConstant(binaryExprCond.getLhs());
-    if (condLimitValue.isPresent()
-        && isSameVarIdentifier(binaryExprCond.getRhs(), loopCounterName)) {
-      return Optional.of(new ImmutablePair<>(switchCondTestType(binaryExprCond.getOp()),
-          condLimitValue.get()));
-    }
-
-    return Optional.empty();
-  }
-
-  private Optional<Integer> getIncrementValue(Expr incr, String loopCounterName) {
-    if (incr instanceof UnaryExpr
-        && isSameVarIdentifier(((UnaryExpr) incr).getExpr(), loopCounterName)) {
-      switch (((UnaryExpr) incr).getOp()) {
-        case POST_INC:
-        case PRE_INC:
-          return Optional.of(1);
-        case POST_DEC:
-        case PRE_DEC:
-          return Optional.of(-1);
-        default:
-          return Optional.empty();
-      }
-    }
-    if (incr instanceof BinaryExpr
-        && isSameVarIdentifier(((BinaryExpr) incr).getLhs(), loopCounterName)) {
-      final Optional<Integer> incrementValue = getAsConstant(((BinaryExpr) incr).getRhs());
-      if (!incrementValue.isPresent()) {
-        return Optional.empty();
-      }
-      switch (((BinaryExpr) incr).getOp()) {
-        case ADD_ASSIGN:
-          return incrementValue;
-        case SUB_ASSIGN:
-          return incrementValue.map(item -> -item);
-        default:
-          return Optional.empty();
-      }
-    }
-    return Optional.empty();
-  }
-
-  private boolean isSameVarIdentifier(Expr expr, String loopCounterName) {
-    return expr instanceof VariableIdentifierExpr
-        && ((VariableIdentifierExpr)expr).getName().equals(loopCounterName);
-  }
-
-  private Optional<Integer> getAsConstant(Expr expr) {
-    if (expr instanceof ParenExpr) {
-      return getAsConstant(((ParenExpr)expr).getExpr());
-    }
-    if (expr instanceof IntConstantExpr) {
-      return Optional.of(Integer.valueOf(((IntConstantExpr) expr).getValue()));
-    }
-    if (expr instanceof UnaryExpr) {
-      final UnaryExpr unaryExpr = (UnaryExpr) expr;
-      switch (unaryExpr.getOp()) {
-        case MINUS:
-          return getAsConstant(unaryExpr.getExpr()).map(item -> -item);
-        case PLUS:
-          return getAsConstant(unaryExpr.getExpr());
-        default:
-          return Optional.empty();
-      }
-    }
-    return Optional.empty();
-  }
-
-  private BinOp switchCondTestType(BinOp binOp) {
-    switch (binOp) {
-      case LT:
-        return BinOp.GT;
-      case GT:
-        return BinOp.LT;
-      case LE:
-        return BinOp.GE;
-      case GE:
-        return BinOp.LE;
-      default:
-        return binOp;
-    }
   }
 
 }

--- a/ast/src/test/java/com/graphicsfuzz/common/util/TruncateLoopsTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/util/TruncateLoopsTest.java
@@ -26,60 +26,6 @@ import static org.junit.Assert.assertEquals;
 
 public class TruncateLoopsTest {
 
-  private static final String[] CONDITIONS = {"x < -(-20)", "20 > x", "x <= 20", "20 >= x",
-      "x > -2", "-2 < x","x >= -2", "-2 <= x"};
-  private static final String[] INCREMETS = {"x++", "++x", "x += 1", "x += -(-1)", "x += 5",
-      "x--", "--x", "x -= 1", "x -= 5"};
-  private static final String[] INIT_CONSTS = {"x = -1", "x = 0", "int x = 0", "x = -(+(-10))",
-      "int x = 10"};
-
-  @Test
-  public void intConstantsTest() throws Exception {
-    final String programBody =
-        "void main() {"
-            + "int u = 10;"
-            + "int x;"
-            + "  for($INIT; $COND; $INCREMENT) {"
-            + "    u = u * 2;"
-            + "  }"
-            + "}";
-
-    for (int cond_index = 0; cond_index < CONDITIONS.length; ++cond_index) {
-      for (int incr_index = 0; incr_index < INCREMETS.length; ++incr_index) {
-        for (int init_index = 0; init_index < INIT_CONSTS.length; ++init_index) {
-          final boolean isSane = (cond_index < 4 && incr_index < 5)
-              || (4 <= cond_index && 5 <= incr_index);
-          testProgram(programBody
-                  .replace("$INIT", INIT_CONSTS[init_index])
-                  .replace("$COND", CONDITIONS[cond_index])
-                  .replace("$INCREMENT", INCREMETS[incr_index]),
-              isSane);
-
-        }
-      }
-    }
-  }
-
-  private void testProgram(String program, boolean isSane) throws IOException,
-      ParseTimeoutException, InterruptedException, GlslParserException {
-    TranslationUnit tu =  ParseHelper.parse(program);
-    new TruncateLoops(30, "webGL_", tu, true);
-    if(isSane) {
-      CompareAstsDuplicate.assertEqualAsts(program, tu);
-    } else {
-      assertProgramsNotEqual(program, tu);
-    }
-    tu =  ParseHelper.parse(program);
-    new TruncateLoops(0, "webGL_", tu, true);
-    assertProgramsNotEqual(program, tu);
-  }
-
-  private void assertProgramsNotEqual(String program, TranslationUnit otherProgram)
-      throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
-    assert !PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program))
-        .equals(PrettyPrinterVisitor.prettyPrintAsString(otherProgram));
-  }
-
   @Test
   public void testTruncateLoops() throws Exception {
     final String program = "void main() {"
@@ -132,7 +78,7 @@ public class TruncateLoopsTest {
         + "  }\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new TruncateLoops(3, "pre", tu, true);
+    new TruncateLoops(3, "pre", tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -189,7 +135,7 @@ public class TruncateLoopsTest {
         + "  }\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new TruncateLoops(3, "pre", tu, false);
+    new TruncateLoops(3, "pre", tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -210,29 +156,43 @@ public class TruncateLoopsTest {
     final String expected = ""
         + "void main() {\n"
         + "  int x = 0;\n"
-        + "  for (int i = 0; i < 2; i++) {\n"
-        + "    int pre_looplimiter1 = 0;\n"
-        + "    while (x < i) {\n"
-        + "      if (pre_looplimiter1 >= 3) {\n"
+        + "  {"
+        + "    int pre_looplimiter3 = 0;\n"
+        + "    for (int i = 0; i < 2; i++) {\n"
+        + "      if (pre_looplimiter3 >= 3) {\n"
         + "        break;\n"
         + "      }\n"
-        + "      pre_looplimiter1++;\n"
-        + "      int pre_looplimiter0 = 0;\n"
-        + "      do {\n"
-        + "        if (pre_looplimiter0 >= 3) {\n"
+        + "      pre_looplimiter3++;\n"
+        + "      int pre_looplimiter2 = 0;\n"
+        + "      while (x < i) {\n"
+        + "        if (pre_looplimiter2 >= 3) {\n"
         + "          break;\n"
         + "        }\n"
-        + "        pre_looplimiter0++;\n"
-        + "        x++;\n"
-        + "        for (int j = 0; j < 2; j++) {\n"
-        + "          ;\n"
-        + "        }\n"
-        + "      } while (x > 0);\n"
+        + "        pre_looplimiter2++;\n"
+        + "        int pre_looplimiter1 = 0;\n"
+        + "        do {\n"
+        + "          if (pre_looplimiter1 >= 3) {\n"
+        + "            break;\n"
+        + "          }\n"
+        + "          pre_looplimiter1++;\n"
+        + "          x++;\n"
+        + "          {\n"
+        + "            int pre_looplimiter0 = 0;\n"
+        + "            for (int j = 0; j < 2; j++) {\n"
+        + "              if (pre_looplimiter0 >= 3) {\n"
+        + "                break;\n"
+        + "              }\n"
+        + "              pre_looplimiter0++;\n"
+        + "              ;\n"
+        + "            }\n"
+        + "          }\n"
+        + "        } while (x > 0);\n"
+        + "      }\n"
         + "    }\n"
         + "  }\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(program);
-    new TruncateLoops(3, "pre", tu, true);
+    new TruncateLoops(3, "pre", tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -101,7 +101,7 @@ public class DonateLiveCodeTransformation extends DonateCodeTransformation {
   @Override
   void adaptTranslationUnitForSpecificDonation(TranslationUnit tu, IRandom generator) {
     if (!allowLongLoops) {
-      new TruncateLoops(3 + generator.nextInt(5), addPrefix(""), tu, false);
+      new TruncateLoops(3 + generator.nextInt(5), addPrefix(""), tu);
     }
   }
 


### PR DESCRIPTION
We had functionality that was not used anywhere to avoid adding
limiters to short-running loops, and associated tests for this that
took quite a long time to run.  This change removes that unused
functionality.