### PR TITLE
Avoid pop-up on Windows during testing

### DIFF
--- a/reducer/src/test/java/com/graphicsfuzz/reducer/tool/GlslReduceTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/tool/GlslReduceTest.java
@@ -145,7 +145,10 @@ public class GlslReduceTest {
   @Test
   public void testAlwaysReduceJudgeMaximallyReduces() throws Exception {
     final File jsonFile = getShaderJobReady();
-    final File emptyFile = temporaryFolder.newFile();
+    // We make this a .bat file to avoid a "what application would you like to use to open this
+    // file?" pop-up on Windows.  (On other platforms the fact that it has the .bat extension does
+    // not matter.)
+    final File emptyFile = temporaryFolder.newFile("judge.bat");
     emptyFile.setExecutable(true);
     GlslReduce.mainHelper(new String[]{
         jsonFile.getAbsolutePath(),


### PR DESCRIPTION
A test uses an empty file as a custom interestingness judge.  Due to not having the .bat extension, this would lead to a pop-up on Windows asking what kind of program should be used to open the file.  As other platforms don't care about the file extension of an executable script, this change uses .bat to avoid the pop-up on Windows.

Fixes #557