### PR TITLE
Complete common builtins

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -292,4 +292,19 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
     return prototype.supportedHyperbolicAngleAndTrigonometricFunctions();
   }
+
+  @Override
+  public boolean supportedModf() {
+    return prototype.supportedModf();
+  }
+
+  @Override
+  public boolean supportedFrexp() {
+    return prototype.supportedFrexp();
+  }
+
+  @Override
+  public boolean supportedLdexp() {
+    return prototype.supportedLdexp();
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -293,4 +293,19 @@ final class Essl100 implements ShadingLanguageVersion {
   public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
     return false;
   }
+
+  @Override
+  public boolean supportedModf() {
+    return false;
+  }
+
+  @Override
+  public boolean supportedFrexp() {
+    return false;
+  }
+
+  @Override
+  public boolean supportedLdexp() {
+    return false;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
@@ -219,4 +219,9 @@ final class Essl300 extends CompositeShadingLanguageVersion {
   public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
     return true;
   }
+
+  @Override
+  public boolean supportedModf() {
+    return true;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
@@ -65,4 +65,14 @@ final class Essl310 extends CompositeShadingLanguageVersion {
     return true;
   }
 
+  @Override
+  public boolean supportedFrexp() {
+    return true;
+  }
+
+  @Override
+  public boolean supportedLdexp() {
+    return true;
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -296,4 +296,19 @@ final class Glsl110 implements ShadingLanguageVersion {
   public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
     return false;
   }
+
+  @Override
+  public boolean supportedModf() {
+    return false;
+  }
+
+  @Override
+  public boolean supportedFrexp() {
+    return false;
+  }
+
+  @Override
+  public boolean supportedLdexp() {
+    return false;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl130.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl130.java
@@ -119,4 +119,9 @@ final class Glsl130 extends CompositeShadingLanguageVersion {
   public boolean supportedHyperbolicAngleAndTrigonometricFunctions() {
     return true;
   }
+
+  @Override
+  public boolean supportedModf() {
+    return true;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl400.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl400.java
@@ -75,4 +75,13 @@ final class Glsl400 extends CompositeShadingLanguageVersion {
     return true;
   }
 
+  @Override
+  public boolean supportedFrexp() {
+    return true;
+  }
+
+  @Override
+  public boolean supportedLdexp() {
+    return true;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -305,6 +305,12 @@ public interface ShadingLanguageVersion {
 
   boolean supportedUnsigned();
 
+  boolean supportedModf();
+
+  boolean supportedFrexp();
+
+  boolean supportedLdexp();
+
   /**
    * Angle and Trigonometric Functions are a set of built-in functions related to the calculation
    * of an angle. For example, sin(angle) - computes the sine value of the angle provided.

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -327,297 +327,7 @@ public final class TyperHelper {
 
     // 8.3: Common Functions
 
-    {
-      final String name = "abs";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-      if (shadingLanguageVersion.supportedAbsInt()) {
-        for (Type t : igenType()) {
-          addBuiltin(builtinsForVersion, name, t, t);
-        }
-      }
-    }
-
-    {
-      final String name = "sign";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-      if (shadingLanguageVersion.supportedSignInt()) {
-        for (Type t : igenType()) {
-          addBuiltin(builtinsForVersion, name, t, t);
-        }
-      }
-    }
-
-    {
-      final String name = "floor";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-
-    if (shadingLanguageVersion.supportedTrunc()) {
-      final String name = "trunc";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-
-    if (shadingLanguageVersion.supportedRound()) {
-      final String name = "round";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-
-    if (shadingLanguageVersion.supportedRoundEven()) {
-      final String name = "roundEven";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-
-    {
-      final String name = "ceil";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-
-    {
-      final String name = "fract";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t);
-      }
-    }
-
-    {
-      final String name = "mod";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t);
-        }
-      }
-    }
-
-    // TODO: genType modf(genType, out genType)
-
-    {
-      final String name = "min";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t);
-        }
-      }
-      if (shadingLanguageVersion.supportedMinInt()) {
-        for (Type t : igenType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT);
-          if (t != BasicType.INT) {
-            addBuiltin(builtinsForVersion, name, t, t, t);
-          }
-        }
-      }
-      if (shadingLanguageVersion.supportedMinUint()) {
-        for (Type t : ugenType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.UINT);
-          if (t != BasicType.UINT) {
-            addBuiltin(builtinsForVersion, name, t, t, t);
-          }
-        }
-      }
-    }
-
-    {
-      final String name = "max";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t);
-        }
-      }
-      if (shadingLanguageVersion.supportedMaxInt()) {
-        for (Type t : igenType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT);
-          if (t != BasicType.INT) {
-            addBuiltin(builtinsForVersion, name, t, t, t);
-          }
-        }
-      }
-      if (shadingLanguageVersion.supportedMaxUint()) {
-        for (Type t : ugenType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.UINT);
-          if (t != BasicType.UINT) {
-            addBuiltin(builtinsForVersion, name, t, t, t);
-          }
-        }
-      }
-    }
-
-    {
-      final String name = "clamp";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT, BasicType.FLOAT);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t, t);
-        }
-      }
-      if (shadingLanguageVersion.supportedClampInt()) {
-        for (Type t : igenType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
-          if (t != BasicType.INT) {
-            addBuiltin(builtinsForVersion, name, t, t, t, t);
-          }
-        }
-      }
-      if (shadingLanguageVersion.supportedClampUint()) {
-        for (Type t : ugenType()) {
-          addBuiltin(builtinsForVersion, name, t, t, BasicType.UINT, BasicType.UINT);
-          if (t != BasicType.UINT) {
-            addBuiltin(builtinsForVersion, name, t, t, t, t);
-          }
-        }
-      }
-    }
-
-    {
-      final String name = "mix";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t, BasicType.FLOAT);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t, t);
-        }
-      }
-      if (shadingLanguageVersion.supportedMixFloatBool()) {
-        addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.FLOAT, BasicType.FLOAT,
-            BasicType.BOOL);
-        addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.VEC2, BasicType.VEC2,
-            BasicType.BVEC2);
-        addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.VEC3, BasicType.VEC3,
-            BasicType.BVEC3);
-        addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.VEC4, BasicType.VEC4,
-            BasicType.BVEC4);
-      }
-
-      if (shadingLanguageVersion.supportedMixNonfloatBool()) {
-        addBuiltin(builtinsForVersion, name, BasicType.INT, BasicType.INT, BasicType.INT,
-            BasicType.BOOL);
-        addBuiltin(builtinsForVersion, name, BasicType.IVEC2, BasicType.IVEC2, BasicType.IVEC2,
-            BasicType.BVEC2);
-        addBuiltin(builtinsForVersion, name, BasicType.IVEC3, BasicType.IVEC3, BasicType.IVEC3,
-            BasicType.BVEC3);
-        addBuiltin(builtinsForVersion, name, BasicType.IVEC4, BasicType.IVEC4, BasicType.IVEC4,
-            BasicType.BVEC4);
-
-        addBuiltin(builtinsForVersion, name, BasicType.UINT, BasicType.UINT, BasicType.UINT,
-            BasicType.BOOL);
-        addBuiltin(builtinsForVersion, name, BasicType.UVEC2, BasicType.UVEC2, BasicType.UVEC2,
-            BasicType.BVEC2);
-        addBuiltin(builtinsForVersion, name, BasicType.UVEC3, BasicType.UVEC3, BasicType.UVEC3,
-            BasicType.BVEC3);
-        addBuiltin(builtinsForVersion, name, BasicType.UVEC4, BasicType.UVEC4, BasicType.UVEC4,
-            BasicType.BVEC4);
-
-        addBuiltin(builtinsForVersion, name, BasicType.BOOL, BasicType.BOOL, BasicType.BOOL,
-            BasicType.BOOL);
-        addBuiltin(builtinsForVersion, name, BasicType.BVEC2, BasicType.BVEC2, BasicType.BVEC2,
-            BasicType.BVEC2);
-        addBuiltin(builtinsForVersion, name, BasicType.BVEC3, BasicType.BVEC3, BasicType.BVEC3,
-            BasicType.BVEC3);
-        addBuiltin(builtinsForVersion, name, BasicType.BVEC4, BasicType.BVEC4, BasicType.BVEC4,
-            BasicType.BVEC4);
-      }
-    }
-
-    {
-      final String name = "step";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, BasicType.FLOAT, t);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t);
-        }
-      }
-    }
-
-    {
-      final String name = "smoothstep";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, BasicType.FLOAT, BasicType.FLOAT, t);
-        if (t != BasicType.FLOAT) {
-          addBuiltin(builtinsForVersion, name, t, t, t, t);
-        }
-      }
-    }
-
-    if (shadingLanguageVersion.supportedIsnan()) {
-      final String name = "isnan";
-      addBuiltin(builtinsForVersion, name, BasicType.BOOL, BasicType.FLOAT);
-      addBuiltin(builtinsForVersion, name, BasicType.BVEC2, BasicType.VEC2);
-      addBuiltin(builtinsForVersion, name, BasicType.BVEC3, BasicType.VEC3);
-      addBuiltin(builtinsForVersion, name, BasicType.BVEC4, BasicType.VEC4);
-    }
-
-    if (shadingLanguageVersion.supportedIsinf()) {
-      final String name = "isinf";
-      addBuiltin(builtinsForVersion, name, BasicType.BOOL, BasicType.FLOAT);
-      addBuiltin(builtinsForVersion, name, BasicType.BVEC2, BasicType.VEC2);
-      addBuiltin(builtinsForVersion, name, BasicType.BVEC3, BasicType.VEC3);
-      addBuiltin(builtinsForVersion, name, BasicType.BVEC4, BasicType.VEC4);
-    }
-
-    if (shadingLanguageVersion.supportedFloatBitsToInt()) {
-      final String name = "floatBitsToInt";
-      addBuiltin(builtinsForVersion, name, BasicType.INT, BasicType.FLOAT);
-      addBuiltin(builtinsForVersion, name, BasicType.IVEC2, BasicType.VEC2);
-      addBuiltin(builtinsForVersion, name, BasicType.IVEC3, BasicType.VEC3);
-      addBuiltin(builtinsForVersion, name, BasicType.IVEC4, BasicType.VEC4);
-    }
-
-    if (shadingLanguageVersion.supportedFloatBitsToUint()) {
-      final String name = "floatBitsToUint";
-      addBuiltin(builtinsForVersion, name, BasicType.UINT, BasicType.FLOAT);
-      addBuiltin(builtinsForVersion, name, BasicType.UVEC2, BasicType.VEC2);
-      addBuiltin(builtinsForVersion, name, BasicType.UVEC3, BasicType.VEC3);
-      addBuiltin(builtinsForVersion, name, BasicType.UVEC4, BasicType.VEC4);
-    }
-
-    if (shadingLanguageVersion.supportedIntBitsToFloat()) {
-      final String name = "intBitsToFloat";
-      addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.INT);
-      addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.IVEC2);
-      addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.IVEC3);
-      addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.IVEC4);
-    }
-
-    if (shadingLanguageVersion.supportedUintBitsToFloat()) {
-      final String name = "uintBitsToFloat";
-      addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.UINT);
-      addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.UVEC2);
-      addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.UVEC3);
-      addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.UVEC4);
-    }
-
-    if (shadingLanguageVersion.supportedFma()) {
-      final String name = "fma";
-      for (Type t : genType()) {
-        addBuiltin(builtinsForVersion, name, t, t, t, t);
-      }
-    }
-
-    {
-      @SuppressWarnings("unused")
-      final String name = "frexp";
-      // TODO: genType frexp(genType, out genIType)
-    }
-
-    {
-      @SuppressWarnings("unused")
-      final String name = "ldexp";
-      // TODO: genType frexp(genType, in genIType)
-    }
+    getBuiltinsForGlslVersionCommon(shadingLanguageVersion, builtinsForVersion);
 
     // 8.4: Floating-Point Pack and Unpack Functions
 
@@ -1316,6 +1026,322 @@ public final class TyperHelper {
     if (shadingLanguageVersion.supportedUnpackHalf2x16()) {
       final String name = "unpackHalf2x16";
       addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.UINT);
+    }
+  }
+
+  private static void getBuiltinsForGlslVersionCommon(
+      ShadingLanguageVersion shadingLanguageVersion,
+      Map<String, List<FunctionPrototype>> builtinsForVersion) {
+    {
+      final String name = "abs";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+      if (shadingLanguageVersion.supportedAbsInt()) {
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+    }
+
+    {
+      final String name = "sign";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+      if (shadingLanguageVersion.supportedSignInt()) {
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t);
+        }
+      }
+    }
+
+    {
+      final String name = "floor";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    if (shadingLanguageVersion.supportedTrunc()) {
+      final String name = "trunc";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    if (shadingLanguageVersion.supportedRound()) {
+      final String name = "round";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    if (shadingLanguageVersion.supportedRoundEven()) {
+      final String name = "roundEven";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    {
+      final String name = "ceil";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    {
+      final String name = "fract";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t);
+      }
+    }
+
+    {
+      final String name = "mod";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t);
+        }
+      }
+    }
+
+    if (shadingLanguageVersion.supportedModf()) {
+      {
+        final String name = "modf";
+        for (Type t : genType()) {
+          addBuiltin(builtinsForVersion, name, t, t, new QualifiedType(t,
+              Arrays.asList(TypeQualifier.OUT_PARAM)));
+        }
+      }
+    }
+
+    {
+      final String name = "min";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t);
+        }
+      }
+      if (shadingLanguageVersion.supportedMinInt()) {
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT);
+          if (t != BasicType.INT) {
+            addBuiltin(builtinsForVersion, name, t, t, t);
+          }
+        }
+      }
+      if (shadingLanguageVersion.supportedMinUint()) {
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.UINT);
+          if (t != BasicType.UINT) {
+            addBuiltin(builtinsForVersion, name, t, t, t);
+          }
+        }
+      }
+    }
+
+    {
+      final String name = "max";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t);
+        }
+      }
+      if (shadingLanguageVersion.supportedMaxInt()) {
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT);
+          if (t != BasicType.INT) {
+            addBuiltin(builtinsForVersion, name, t, t, t);
+          }
+        }
+      }
+      if (shadingLanguageVersion.supportedMaxUint()) {
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.UINT);
+          if (t != BasicType.UINT) {
+            addBuiltin(builtinsForVersion, name, t, t, t);
+          }
+        }
+      }
+    }
+
+    {
+      final String name = "clamp";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t, BasicType.FLOAT, BasicType.FLOAT);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t, t);
+        }
+      }
+      if (shadingLanguageVersion.supportedClampInt()) {
+        for (Type t : igenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.INT, BasicType.INT);
+          if (t != BasicType.INT) {
+            addBuiltin(builtinsForVersion, name, t, t, t, t);
+          }
+        }
+      }
+      if (shadingLanguageVersion.supportedClampUint()) {
+        for (Type t : ugenType()) {
+          addBuiltin(builtinsForVersion, name, t, t, BasicType.UINT, BasicType.UINT);
+          if (t != BasicType.UINT) {
+            addBuiltin(builtinsForVersion, name, t, t, t, t);
+          }
+        }
+      }
+    }
+
+    {
+      final String name = "mix";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t, t, BasicType.FLOAT);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t, t);
+        }
+      }
+      if (shadingLanguageVersion.supportedMixFloatBool()) {
+        addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.FLOAT, BasicType.FLOAT,
+            BasicType.BOOL);
+        addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.VEC2, BasicType.VEC2,
+            BasicType.BVEC2);
+        addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.VEC3, BasicType.VEC3,
+            BasicType.BVEC3);
+        addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.VEC4, BasicType.VEC4,
+            BasicType.BVEC4);
+      }
+
+      if (shadingLanguageVersion.supportedMixNonfloatBool()) {
+        addBuiltin(builtinsForVersion, name, BasicType.INT, BasicType.INT, BasicType.INT,
+            BasicType.BOOL);
+        addBuiltin(builtinsForVersion, name, BasicType.IVEC2, BasicType.IVEC2, BasicType.IVEC2,
+            BasicType.BVEC2);
+        addBuiltin(builtinsForVersion, name, BasicType.IVEC3, BasicType.IVEC3, BasicType.IVEC3,
+            BasicType.BVEC3);
+        addBuiltin(builtinsForVersion, name, BasicType.IVEC4, BasicType.IVEC4, BasicType.IVEC4,
+            BasicType.BVEC4);
+
+        addBuiltin(builtinsForVersion, name, BasicType.UINT, BasicType.UINT, BasicType.UINT,
+            BasicType.BOOL);
+        addBuiltin(builtinsForVersion, name, BasicType.UVEC2, BasicType.UVEC2, BasicType.UVEC2,
+            BasicType.BVEC2);
+        addBuiltin(builtinsForVersion, name, BasicType.UVEC3, BasicType.UVEC3, BasicType.UVEC3,
+            BasicType.BVEC3);
+        addBuiltin(builtinsForVersion, name, BasicType.UVEC4, BasicType.UVEC4, BasicType.UVEC4,
+            BasicType.BVEC4);
+
+        addBuiltin(builtinsForVersion, name, BasicType.BOOL, BasicType.BOOL, BasicType.BOOL,
+            BasicType.BOOL);
+        addBuiltin(builtinsForVersion, name, BasicType.BVEC2, BasicType.BVEC2, BasicType.BVEC2,
+            BasicType.BVEC2);
+        addBuiltin(builtinsForVersion, name, BasicType.BVEC3, BasicType.BVEC3, BasicType.BVEC3,
+            BasicType.BVEC3);
+        addBuiltin(builtinsForVersion, name, BasicType.BVEC4, BasicType.BVEC4, BasicType.BVEC4,
+            BasicType.BVEC4);
+      }
+    }
+
+    {
+      final String name = "step";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, BasicType.FLOAT, t);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t);
+        }
+      }
+    }
+
+    {
+      final String name = "smoothstep";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, BasicType.FLOAT, BasicType.FLOAT, t);
+        if (t != BasicType.FLOAT) {
+          addBuiltin(builtinsForVersion, name, t, t, t, t);
+        }
+      }
+    }
+
+    if (shadingLanguageVersion.supportedIsnan()) {
+      final String name = "isnan";
+      addBuiltin(builtinsForVersion, name, BasicType.BOOL, BasicType.FLOAT);
+      addBuiltin(builtinsForVersion, name, BasicType.BVEC2, BasicType.VEC2);
+      addBuiltin(builtinsForVersion, name, BasicType.BVEC3, BasicType.VEC3);
+      addBuiltin(builtinsForVersion, name, BasicType.BVEC4, BasicType.VEC4);
+    }
+
+    if (shadingLanguageVersion.supportedIsinf()) {
+      final String name = "isinf";
+      addBuiltin(builtinsForVersion, name, BasicType.BOOL, BasicType.FLOAT);
+      addBuiltin(builtinsForVersion, name, BasicType.BVEC2, BasicType.VEC2);
+      addBuiltin(builtinsForVersion, name, BasicType.BVEC3, BasicType.VEC3);
+      addBuiltin(builtinsForVersion, name, BasicType.BVEC4, BasicType.VEC4);
+    }
+
+    if (shadingLanguageVersion.supportedFloatBitsToInt()) {
+      final String name = "floatBitsToInt";
+      addBuiltin(builtinsForVersion, name, BasicType.INT, BasicType.FLOAT);
+      addBuiltin(builtinsForVersion, name, BasicType.IVEC2, BasicType.VEC2);
+      addBuiltin(builtinsForVersion, name, BasicType.IVEC3, BasicType.VEC3);
+      addBuiltin(builtinsForVersion, name, BasicType.IVEC4, BasicType.VEC4);
+    }
+
+    if (shadingLanguageVersion.supportedFloatBitsToUint()) {
+      final String name = "floatBitsToUint";
+      addBuiltin(builtinsForVersion, name, BasicType.UINT, BasicType.FLOAT);
+      addBuiltin(builtinsForVersion, name, BasicType.UVEC2, BasicType.VEC2);
+      addBuiltin(builtinsForVersion, name, BasicType.UVEC3, BasicType.VEC3);
+      addBuiltin(builtinsForVersion, name, BasicType.UVEC4, BasicType.VEC4);
+    }
+
+    if (shadingLanguageVersion.supportedIntBitsToFloat()) {
+      final String name = "intBitsToFloat";
+      addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.INT);
+      addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.IVEC2);
+      addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.IVEC3);
+      addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.IVEC4);
+    }
+
+    if (shadingLanguageVersion.supportedUintBitsToFloat()) {
+      final String name = "uintBitsToFloat";
+      addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.UINT);
+      addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.UVEC2);
+      addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.UVEC3);
+      addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.UVEC4);
+    }
+
+    if (shadingLanguageVersion.supportedFma()) {
+      final String name = "fma";
+      for (Type t : genType()) {
+        addBuiltin(builtinsForVersion, name, t, t, t, t);
+      }
+    }
+
+    if (shadingLanguageVersion.supportedFrexp()) {
+      {
+        final String name = "frexp";
+        addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.FLOAT,
+            new QualifiedType(BasicType.INT, Arrays.asList(TypeQualifier.OUT_PARAM)));
+        addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.VEC2,
+            new QualifiedType(BasicType.IVEC2, Arrays.asList(TypeQualifier.OUT_PARAM)));
+        addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.VEC3,
+            new QualifiedType(BasicType.IVEC3, Arrays.asList(TypeQualifier.OUT_PARAM)));
+        addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.VEC4,
+            new QualifiedType(BasicType.IVEC4, Arrays.asList(TypeQualifier.OUT_PARAM)));
+      }
+    }
+
+    if (shadingLanguageVersion.supportedLdexp()) {
+      {
+        final String name = "ldexp";
+        addBuiltin(builtinsForVersion, name, BasicType.FLOAT, BasicType.FLOAT, BasicType.INT);
+        addBuiltin(builtinsForVersion, name, BasicType.VEC2, BasicType.VEC2, BasicType.IVEC2);
+        addBuiltin(builtinsForVersion, name, BasicType.VEC3, BasicType.VEC3, BasicType.IVEC3);
+        addBuiltin(builtinsForVersion, name, BasicType.VEC4, BasicType.VEC4, BasicType.IVEC4);
+      }
     }
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -1029,6 +1029,13 @@ public final class TyperHelper {
     }
   }
 
+  /**
+   * Helper function to register built-in function prototypes for Common Functions,
+   * as specified in section 8.3 of the GLSL 4.6 and ESSL 3.2 specifications.
+   *
+   * @param builtinsForVersion the list of builtins to add prototypes to
+   * @param shadingLanguageVersion the version of GLSL in use
+   */
   private static void getBuiltinsForGlslVersionCommon(
       ShadingLanguageVersion shadingLanguageVersion,
       Map<String, List<FunctionPrototype>> builtinsForVersion) {

--- a/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/SideEffectCheckerTest.java
@@ -96,4 +96,54 @@ public class SideEffectCheckerTest {
       }
     }.visit(tu);
   }
+
+  @Test
+  public void testOutParamModfHasSideEffects() throws Exception {
+    final String shader = "void main() { "
+        + "  float out1;"
+        + "  vec2 out2;"
+        + "  vec3 out3;"
+        + "  vec4 out4;"
+        + "  modf(0.0, out1);"
+        + "  modf(vec2(0.0), out2);"
+        + "  modf(vec3(0.0), out3);"
+        + "  modf(vec4(0.0), out4);"
+        + "}";
+
+    final TranslationUnit tu = ParseHelper.parse(shader, ShaderKind.FRAGMENT);
+    tu.setShadingLanguageVersion(ShadingLanguageVersion.ESSL_310);
+
+    new StandardVisitor() {
+      @Override
+      public void visitFunctionCallExpr(FunctionCallExpr expr) {
+        assertTrue(expr.getCallee().equals("modf"));
+        assertFalse(SideEffectChecker.isSideEffectFree(expr, ShadingLanguageVersion.ESSL_310, ShaderKind.FRAGMENT));
+      }
+    }.visit(tu);
+  }
+
+  @Test
+  public void testOutParamFrexpHasSideEffects() throws Exception {
+    final String shader = "void main() { "
+        + "  int out1;"
+        + "  ivec2 out2;"
+        + "  ivec3 out3;"
+        + "  ivec4 out4;"
+        + "  frexp(0.0, out1);"
+        + "  frexp(vec2(0.0), out2);"
+        + "  frexp(vec3(0.0), out3);"
+        + "  frexp(vec4(0.0), out4);"
+        + "}";
+
+    final TranslationUnit tu = ParseHelper.parse(shader, ShaderKind.FRAGMENT);
+    tu.setShadingLanguageVersion(ShadingLanguageVersion.ESSL_310);
+
+    new StandardVisitor() {
+      @Override
+      public void visitFunctionCallExpr(FunctionCallExpr expr) {
+        assertTrue(expr.getCallee().equals("frexp"));
+        assertFalse(SideEffectChecker.isSideEffectFree(expr, ShadingLanguageVersion.ESSL_310, ShaderKind.FRAGMENT));
+      }
+    }.visit(tu);
+  }
 }


### PR DESCRIPTION
Related issue: #462 

This PR refactors and adds 3 additional common built-in functions:
- modf GLSL 130+ and ESSL 300+)
- frexp (GLSL 400+ and ESSL 310+)
- ldexp (GLSL 400+ and ESSL 310+)

Tests for side effect are also implemented for `modf` and `frexp` as they have out qualifier parameters.

