### PR TITLE
Add an open_helper argument in spv-worker

### DIFF
--- a/python/src/main/python/drivers/glsl-to-spv-worker.py
+++ b/python/src/main/python/drivers/glsl-to-spv-worker.py
@@ -539,7 +539,7 @@ def main():
 
             assert os.path.isfile(args.local_shader_job), \
                 'Shader job {} does not exist'.format(args.local_shader_job)
-            with gfuzz_common.open_helper(args.local_shader_job) as f:
+            with gfuzz_common.open_helper(args.local_shader_job, 'r') as f:
                 fake_job.uniformsInfo = f.read()
             if os.path.isfile(shader_job_prefix + '.frag'):
                 with gfuzz_common.open_helper(shader_job_prefix + '.frag', 'r') as f:


### PR DESCRIPTION
Related issue: #530 

I frequently use the glsl-to-spv-worker with option ` --local-shader-job` to run the local shader job and have to add the argument locally to fix such error, I thus believe it is worth doing this small fix.