### PR TITLE
Fix issue where the reducer was replacing a dead code injection with its body

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InjectionTracker.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InjectionTracker.java
@@ -26,23 +26,17 @@ class InjectionTracker {
 
   private int numEnclosingFuzzedMacros;
   private int numEnclosingDeadCodeInjections;
-  private boolean underDeadMacro;
 
   private Deque<Optional<SwitchCaseStatus>> switchStmts;
 
   InjectionTracker() {
     this.numEnclosingFuzzedMacros = 0;
     this.numEnclosingDeadCodeInjections = 0;
-    this.underDeadMacro = false;
     this.switchStmts = new LinkedList<>();
   }
 
   boolean underFuzzedMacro() {
     return numEnclosingFuzzedMacros > 0;
-  }
-
-  boolean underDeadMacro() {
-    return underDeadMacro;
   }
 
   void enterFuzzedMacro() {
@@ -52,16 +46,6 @@ class InjectionTracker {
   void exitFuzzedMacro() {
     assert numEnclosingFuzzedMacros > 0;
     numEnclosingFuzzedMacros--;
-  }
-
-  void enterDeadMacro() {
-    assert !underDeadMacro;
-    underDeadMacro = true;
-  }
-
-  void exitDeadMacro() {
-    assert underDeadMacro;
-    underDeadMacro = false;
   }
 
   void enterDeadCodeInjection() {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
@@ -110,8 +110,7 @@ abstract class SimplifyExprReductionOpportunities
       return true;
     }
 
-    if (injectionTracker.enclosedByDeadCodeInjection() && !injectionTracker.underDeadMacro()) {
-      // We want to reduce expressions in dead code blocks, but not inside the dead macro itself
+    if (injectionTracker.enclosedByDeadCodeInjection()) {
       return true;
     }
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunitiesTest.java
@@ -125,22 +125,20 @@ public class CompoundToBlockReductionOpportunitiesTest {
   }
 
   @Test
-  public void testDoRemoveDeadIf() throws Exception {
+  public void testDoNotRemoveDeadIf() throws Exception {
     final String original = ""
           + "void main() {"
+          + "  int a = 2;"
           + "  if (" + Constants.GLF_DEAD + "(false)) {"
-          + "    int a = 2;"
           + "    a = a + 1;"
           + "  }"
           + "}";
-    final String expected = ""
-        + "void main() {"
-        + "  {"
-        + "    int a = 2;"
-        + "    a = a + 1;"
-        + "  }"
-        + "}";
-    check(false, original, expected);
+    final List<CompoundToBlockReductionOpportunity> opportunities =
+        CompoundToBlockReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(ParseHelper.parse(original)),
+            new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new IdGenerator()));
+    assertEquals(0, opportunities.size());
   }
 
   @Test
@@ -154,7 +152,7 @@ public class CompoundToBlockReductionOpportunitiesTest {
           + "    }"
           + "  }"
           + "}";
-    final String expected1 = ""
+    final String expected = ""
           + "void main() {"
           + "  if (" + Constants.GLF_DEAD + "(false)) {"
           + "    {"
@@ -163,16 +161,7 @@ public class CompoundToBlockReductionOpportunitiesTest {
           + "    }"
           + "  }"
           + "}";
-    final String expected2 = ""
-        + "void main() {"
-        + "  {"
-        + "    if (false) {"
-        + "      int a = 2;"
-        + "      a = a + 1;"
-        + "    }"
-        + "  }"
-        + "}";
-    check(false, original, expected1, expected2);
+    check(false, original, expected);
   }
 
   @Test
@@ -256,20 +245,7 @@ public class CompoundToBlockReductionOpportunitiesTest {
           + "    }"
           + "  }"
           + "}";
-    final String expected4 = ""
-        + "void main() {"
-        + "  int a = 4;"
-        + "  {"
-        + "    if (a) {"
-        + "      if (a > 0) {"
-        + "        int a = 2;"
-        + "        a = a + 1;"
-        + "      } else"
-        + "        a++;"
-        + "    }"
-        + "  }"
-        + "}";
-    check(false, original, expected1, expected2, expected3, expected4);
+    check(false, original, expected1, expected2, expected3);
   }
 
   @Test
@@ -532,6 +508,21 @@ public class CompoundToBlockReductionOpportunitiesTest {
             new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
+  }
+
+  @Test
+  public void doNotReplaceDeadCodeInjectionWithBody() throws Exception {
+    final String original = "void main() {"
+        + "  if (" + Constants.GLF_DEAD + "(" + Constants.GLF_FALSE + "(false))) {"
+        + "    discard;"
+        + "  }"
+        + "}";
+    final List<CompoundToBlockReductionOpportunity> opportunities =
+        CompoundToBlockReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(ParseHelper.parse(original)),
+            new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new IdGenerator()));
+    assertEquals(0, opportunities.size());
   }
 
 }


### PR DESCRIPTION
The reducer used to be very conservative about replacing dead code
injections with their bodies and was made less conservative.  However
this introduced a bug whereby the reducer would always replace
'if(_GLF_DEAD(...)) body' by 'body'.  The problem was that the guard
of the dead code injection was being regarded as itself being dead
code, which is wrong; it should only be the 'then' and 'else' branches
of the if statement that are regarded as dead.

This change fixes this problem.  It was necessary to change a number
of tests in the process: tests where the reducer was only managing to
do a particularly good job of reducing a shader due to this bug; for
example it could turn:

if (_GLF_DEAD(...)) {
  int a;
  a = 2;
}

into:

{
  int a;
  a = 2;
}

which is OK, because the body of the 'if' statement does not have
side-effects to data declared outside the 'if' statement.  But this
was only working due to the body of the 'if' being unconditionally
used to replace the 'if'.  Now that that problem is fixed, the side
effect analysis is not yet sophisticated enough to determine that the
body of the 'if' is side-effect free, thus the transformation does not
take place.

Fixes #598.