### PR TITLE
Fix opaque expressions based on vector length

### DIFF
--- a/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGeneratorTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGeneratorTest.java
@@ -20,6 +20,7 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.decl.PrecisionDeclaration;
+import com.graphicsfuzz.common.ast.decl.ScalarInitializer;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.expr.BinOp;
@@ -31,12 +32,16 @@ import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.type.BasicType;
+import com.graphicsfuzz.common.ast.type.QualifiedType;
+import com.graphicsfuzz.common.ast.type.Type;
+import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
 import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.typing.SupportedTypes;
 import com.graphicsfuzz.common.util.IRandom;
+import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.PipelineInfo;
 import com.graphicsfuzz.common.util.RandomWrapper;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
@@ -46,6 +51,7 @@ import com.graphicsfuzz.generator.util.GenerationParams;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Rule;
@@ -61,25 +67,34 @@ public class OpaqueExpressionGeneratorTest {
 
   @Test
   public void testGeneratesValidExpressions() throws Exception {
+    // We make a random number generator here and pass it into functions below in order to maximise
+    // diversity - even though there are differences between shading languages, there is still a
+    // good chance that until such a difference is hit, generating expressions for different
+    // shading languages but from the same seed will lead to identical results.
+    final IRandom generator = new RandomWrapper(0);
+
+    // These are the shading language versions we support best, so test them thoroughly.
     for (ShadingLanguageVersion shadingLanguageVersion : Arrays.asList(
+        ShadingLanguageVersion.ESSL_100,
         ShadingLanguageVersion.ESSL_300,
-        ShadingLanguageVersion.ESSL_100)) {
+        ShadingLanguageVersion.ESSL_310,
+        ShadingLanguageVersion.ESSL_320)) {
       for (BasicType t : BasicType.allBasicTypes()) {
         if (!SupportedTypes.supported(t, shadingLanguageVersion)) {
           continue;
         }
-        final TranslationUnit tu = new TranslationUnit(Optional.of(ShadingLanguageVersion.ESSL_310),
+        final TranslationUnit tu = new TranslationUnit(Optional.of(shadingLanguageVersion),
             Arrays.asList(
                 new PrecisionDeclaration("precision mediump float;"),
                 new FunctionDefinition(
-                    new FunctionPrototype("main", VoidType.VOID, new ArrayList<>()),
+                    new FunctionPrototype("main", VoidType.VOID, Collections.emptyList()),
                     new BlockStmt(makeMutatedExpressionAssignments(t,
-                        shadingLanguageVersion, 1000),
+                        shadingLanguageVersion, 1000, generator),
                         false))));
         Generate.addInjectionSwitchIfNotPresent(tu);
         final File shaderJobFile = temporaryFolder.newFile("ex.json");
         final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
-        fileOps.writeShaderJobFile(new GlslShaderJob(Optional.empty(), new PipelineInfo("{}"),
+        fileOps.writeShaderJobFile(new GlslShaderJob(Optional.empty(), new PipelineInfo(),
             tu), shaderJobFile);
         assertTrue(fileOps.areShadersValid(shaderJobFile, false));
         fileOps.deleteShaderJobFile(shaderJobFile);
@@ -89,7 +104,8 @@ public class OpaqueExpressionGeneratorTest {
 
   private List<Stmt> makeMutatedExpressionAssignments(BasicType basicType,
                                                       ShadingLanguageVersion shadingLanguageVersion,
-                                                      int numberOfAssignments) {
+                                                      int numberOfAssignments,
+                                                      IRandom generator) {
     // We declare only one variable and generate a number of assignments to this variable,
     // instead of making multiple declarations and assignments.
     // numberOfAssignments should be large enough to get high coverage, e.g. 1000.
@@ -99,7 +115,6 @@ public class OpaqueExpressionGeneratorTest {
         new VariableDeclInfo("x", null,
             null))));
     for (int i = 0; i < numberOfAssignments; i++) {
-      final IRandom generator = new RandomWrapper(i);
       final OpaqueExpressionGenerator opaqueExpressionGenerator =
           new OpaqueExpressionGenerator(generator,
               generationParams, shadingLanguageVersion);
@@ -114,4 +129,80 @@ public class OpaqueExpressionGeneratorTest {
     }
     return newStmts;
   }
+
+  @Test
+  public void testWaysToMakeZeroAndOne() throws Exception {
+
+    final IRandom generator = new RandomWrapper(0);
+    final GenerationParams generationParams = GenerationParams.large(ShaderKind.FRAGMENT, true);
+
+    // These are the shading language versions we support best, so test them thoroughly.
+    for (ShadingLanguageVersion shadingLanguageVersion : Arrays.asList(
+        ShadingLanguageVersion.ESSL_100,
+        ShadingLanguageVersion.ESSL_300,
+        ShadingLanguageVersion.ESSL_310,
+        ShadingLanguageVersion.ESSL_320)) {
+      final IdGenerator idGenerator = new IdGenerator();
+      final List<Stmt> stmts = new ArrayList<>();
+      final OpaqueExpressionGenerator opaqueExpressionGenerator =
+          new OpaqueExpressionGenerator(generator,
+              generationParams, shadingLanguageVersion);
+      for (BasicType basicType : BasicType.allNumericTypes()) {
+        if (!SupportedTypes.supported(basicType, shadingLanguageVersion)) {
+          continue;
+        }
+        for (boolean constContext : Arrays.asList(true, false)) {
+          stmts.addAll(makeStatementsFromFactories(generator, generationParams,
+              shadingLanguageVersion,
+              idGenerator, basicType, constContext, opaqueExpressionGenerator.waysToMakeZero(), true));
+          // We do not allow making one for non-square matrices.
+          if (!BasicType.allNonSquareMatrixTypes().contains(basicType)) {
+            stmts.addAll(makeStatementsFromFactories(generator, generationParams,
+                shadingLanguageVersion,
+                idGenerator, basicType, constContext, opaqueExpressionGenerator.waysToMakeOne(),
+                false));
+          }
+        }
+      }
+      final TranslationUnit tu = new TranslationUnit(Optional.of(shadingLanguageVersion),
+          Arrays.asList(
+              new PrecisionDeclaration("precision mediump float;"),
+              new FunctionDefinition(
+                  new FunctionPrototype("main", VoidType.VOID, Collections.emptyList()),
+                  new BlockStmt(stmts,
+                      false))));
+      Generate.addInjectionSwitchIfNotPresent(tu);
+      final File shaderJobFile = temporaryFolder.newFile("ex.json");
+      final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
+      fileOps.writeShaderJobFile(new GlslShaderJob(Optional.empty(), new PipelineInfo(),
+          tu), shaderJobFile);
+      assertTrue(fileOps.areShadersValid(shaderJobFile, false));
+      fileOps.deleteShaderJobFile(shaderJobFile);
+    }
+  }
+
+  private List<Stmt> makeStatementsFromFactories(IRandom generator, GenerationParams generationParams, ShadingLanguageVersion shadingLanguageVersion, IdGenerator idGenerator, BasicType typeToGenerate, boolean constContext, List<OpaqueZeroOneFactory> factories, boolean makingZero) {
+    List<Stmt> result = new ArrayList<>();
+    for (OpaqueZeroOneFactory factory : factories) {
+      final Optional<Expr> expr = factory.tryMakeOpaque(typeToGenerate, constContext, 0,
+          new Fuzzer(new FuzzingContext(new Scope(null)), shadingLanguageVersion,
+          generator, generationParams), makingZero);
+      if (expr.isPresent()) {
+        final Type baseType = constContext ? new QualifiedType(typeToGenerate,
+            Collections.singletonList(TypeQualifier.CONST)) : typeToGenerate;
+        result.add(new DeclarationStmt(
+            new VariablesDeclaration(
+                baseType,
+                new VariableDeclInfo(
+                    "v" + idGenerator.freshId(),
+                    null,
+                    new ScalarInitializer(expr.get())
+                )
+            )
+        ));
+      }
+    }
+    return result;
+  }
+
 }


### PR DESCRIPTION
We recently added the ability to generate zero as length(zero vector),
and one as length(normalize(one vector)).  However, the code was
incorrectly assuming that the length of a vector of dimension n would
itself be a vector of dimension n, whereas in reality the length of a
vector is always a scalar.

As well as fixing this so that the expected return type for these ways
to make zero and one is 'float', the change allows the dimension of
the vector whose length is taken to be chosen at random.

Finer-grained tests for opaque zero and one generation are also added,
and the shading language versions for which opaque expression
generation is tested has been expanded a bit.

Fixes #559