### PR TITLE
"Fix" image tests by extending blacklist

### DIFF
--- a/assembly-binaries/pom.xml
+++ b/assembly-binaries/pom.xml
@@ -60,7 +60,7 @@ limitations under the License.
   <properties>
     <spirv-tools-version>422f2fe0f0f32494fa687a12ba343d24863b330a</spirv-tools-version>
     <angle-version>9d3202492d78aae5ced08ff14679b81c98d71c15</angle-version>
-    <swiftshader-version>803082da4f73920729938905cb1727e11ff79530</swiftshader-version>
+    <swiftshader-version>0565d5aee279a4782689297ada0aa2489e24ad3e</swiftshader-version>
     <glslang-version>1586e566f4949b1957e7c32454cbf27e501ed632</glslang-version>
     <getimage-version>d987dc0e5f8aeae0dc2f5aac2013e9a3edd54465</getimage-version>
   </properties>

--- a/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
@@ -142,8 +142,8 @@ public class GeneratorUnitTest {
             Util.getDonorsFolder(),
             GenerationParams.normal(ShaderKind.FRAGMENT, true)), TransformationProbabilities.likelyDonateDeadCode(),
         "donatedead",
-        Arrays.asList("bubblesort_flag.json", "squares.json"),
-        Arrays.asList("bubblesort_flag.json", "squares.json"));
+        Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_blurry.json"),
+        Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_blurry.json"));
     // Reason for blacklisting^: slow.
   }
 
@@ -199,8 +199,8 @@ public class GeneratorUnitTest {
     testTransformationMultiVersions(() -> new AddWrappingConditionalTransformation(),
         TransformationProbabilities.onlyWrap(),
         "wrap",
-        Arrays.asList("bubblesort_flag.json"),
-        Arrays.asList("bubblesort_flag.json"));
+        Arrays.asList("bubblesort_flag.json", "colorgrid_modulo.json"),
+        Arrays.asList("bubblesort_flag.json", "colorgrid_modulo.json"));
     // Reason for blacklisting^: slow.
   }
 


### PR DESCRIPTION
Also, update SwiftShader. The bugs we encounter are known SwiftShader bugs that are unlikely to be fixed soon. 