### PR TITLE
Add new versions of GraphicsFuzz shaders that use Integer Functions

### DIFF
--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag.frag
@@ -66,10 +66,10 @@ void main()
         }
     if(gl_FragCoord.x < resolution.x / 2.0)
         {
-            _GLF_color = vec4(data[findMSB(0)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, 1.0);
+            _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }
     else
         {
-            _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, data[findMSB(0)] / 10.0, 1.0);
+            _GLF_color = vec4(data[5] / 10.0, data[9] / 10.0, data[0] / 10.0, 1.0);
         }
 }

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag.frag
@@ -66,10 +66,10 @@ void main()
         }
     if(gl_FragCoord.x < resolution.x / 2.0)
         {
-            _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
+            _GLF_color = vec4(data[findMSB(0)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, 1.0);
         }
     else
         {
-            _GLF_color = vec4(data[5] / 10.0, data[9] / 10.0, data[0] / 10.0, 1.0);
+            _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, data[findMSB(0)] / 10.0, 1.0);
         }
 }

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
@@ -57,11 +57,11 @@ void main()
     } while(i < findMSB(512));
     if(gl_FragCoord.x < resolution.x / 2.0)
     {
-        _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
+        _GLF_color = vec4(data[findMSB(0)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, 1.0);
     }
     else
     {
-        _GLF_color = vec4(data[5] / 10.0, data[9] / 10.0, data[0] / 10.0, 1.0);
+        _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, data[findMSB(0)] / 10.0, 1.0);
     }
 }
 

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 
@@ -30,16 +31,18 @@ bool checkSwap(float a, float b)
 }
 void main()
 {
+    int msb10 = 1024;
+    int msb9 = 512;
     uint uselessOutVariable;
     float data[10];
-    for(int i = bitfieldReverse(int(injectionSwitch.x)); i < findMSB(1024); i++)
+    for(int i = bitfieldReverse(int(injectionSwitch.x)); i < findMSB(msb10); i++)
     {
         data[i] = float(usubBorrow(uint(10), uint(i), uselessOutVariable)) * injectionSwitch.y;
     }
     int i = bitfieldExtract(int(injectionSwitch.x), bitCount(0), int(injectionSwitch.x));
     do
     {
-        for(int j = bitfieldExtract(int(injectionSwitch.x), 0, 0); j < findLSB(1024); j++)
+        for(int j = bitfieldExtract(int(injectionSwitch.x), 0, 0); j < findLSB(msb10); j++)
         {
             if(uint(j) < uaddCarry(uint(i), 1u, uselessOutVariable))
             {
@@ -54,14 +57,14 @@ void main()
             }
         }
         i++;
-    } while(i < findMSB(512));
+    } while(i < findMSB(msb9));
     if(gl_FragCoord.x < resolution.x / 2.0)
     {
-        _GLF_color = vec4(data[findMSB(1)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, 1.0);
+        _GLF_color = vec4(data[findMSB(1)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(msb9)] / 10.0, 1.0);
     }
     else
     {
-        _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, data[findMSB(1)] / 10.0, 1.0);
+        _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(msb9)] / 10.0, data[findMSB(1)] / 10.0, 1.0);
     }
 }
 

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
@@ -1,0 +1,67 @@
+#version 310 es
+
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform vec2 injectionSwitch;
+
+uniform vec2 resolution;
+
+bool checkSwap(float a, float b)
+{
+    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+}
+void main()
+{
+    uint uselessOutVariable;
+    float data[10];
+    for(int i = bitfieldReverse(int(injectionSwitch.x)); i < findMSB(1024); i++)
+    {
+        data[i] = float(usubBorrow(uint(10), uint(i), uselessOutVariable)) * injectionSwitch.y;
+    }
+    int i = bitfieldExtract(int(injectionSwitch.x), bitCount(0), int(injectionSwitch.x));
+    do
+    {
+        for(int j = bitfieldExtract(int(injectionSwitch.x), 0, int(injectionSwitch.x)); j < findLSB(1024); j++)
+        {
+            if(uint(j) < uaddCarry(uint(i), 1u, uselessOutVariable))
+            {
+                continue;
+            }
+            bool doSwap = checkSwap(data[i], data[j]);
+            if(doSwap)
+            {
+                float temp = data[i];
+                data[i] = data[j];
+                data[j] = temp;
+            }
+        }
+        i++;
+    } while(i < findMSB(512));
+    if(gl_FragCoord.x < resolution.x / 2.0)
+    {
+        _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
+    }
+    else
+    {
+        _GLF_color = vec4(data[5] / 10.0, data[9] / 10.0, data[0] / 10.0, 1.0);
+    }
+}
+

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
@@ -57,11 +57,11 @@ void main()
     } while(i < findMSB(512));
     if(gl_FragCoord.x < resolution.x / 2.0)
     {
-        _GLF_color = vec4(data[findMSB(0)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, 1.0);
+        _GLF_color = vec4(data[findMSB(int(injectionSwitch.y))] / 10.0, data[findLSB(int(injectionSwitch.y * 32.0))] / 10.0, data[findMSB(int(injectionSwitch.y * 512.0))] / 10.0, 1.0);
     }
     else
     {
-        _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, data[findMSB(0)] / 10.0, 1.0);
+        _GLF_color = vec4(data[findLSB(int(injectionSwitch.y * 32.0))] / 10.0, data[findMSB(int(injectionSwitch.y * 512.0))] / 10.0, data[findMSB(int(injectionSwitch.y))] / 10.0, 1.0);
     }
 }
 

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.frag
@@ -39,7 +39,7 @@ void main()
     int i = bitfieldExtract(int(injectionSwitch.x), bitCount(0), int(injectionSwitch.x));
     do
     {
-        for(int j = bitfieldExtract(int(injectionSwitch.x), 0, int(injectionSwitch.x)); j < findLSB(1024); j++)
+        for(int j = bitfieldExtract(int(injectionSwitch.x), 0, 0); j < findLSB(1024); j++)
         {
             if(uint(j) < uaddCarry(uint(i), 1u, uselessOutVariable))
             {
@@ -57,11 +57,11 @@ void main()
     } while(i < findMSB(512));
     if(gl_FragCoord.x < resolution.x / 2.0)
     {
-        _GLF_color = vec4(data[findMSB(int(injectionSwitch.y))] / 10.0, data[findLSB(int(injectionSwitch.y * 32.0))] / 10.0, data[findMSB(int(injectionSwitch.y * 512.0))] / 10.0, 1.0);
+        _GLF_color = vec4(data[findMSB(1)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, 1.0);
     }
     else
     {
-        _GLF_color = vec4(data[findLSB(int(injectionSwitch.y * 32.0))] / 10.0, data[findMSB(int(injectionSwitch.y * 512.0))] / 10.0, data[findMSB(int(injectionSwitch.y))] / 10.0, 1.0);
+        _GLF_color = vec4(data[findLSB(32)] / 10.0, data[findMSB(512)] / 10.0, data[findMSB(1)] / 10.0, 1.0);
     }
 }
 

--- a/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/bubblesort_flag_intfunctions.json
@@ -1,0 +1,16 @@
+{
+    "injectionSwitch": {
+        "func":  "glUniform2f",
+        "args": [
+            0.0,
+            1.0
+        ]
+    },
+    "resolution": {
+        "func":  "glUniform2f",
+        "args": [
+            256.0,
+            256.0
+        ]
+    }
+}

--- a/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
@@ -1,0 +1,60 @@
+#version 310 es
+
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform vec2 resolution;
+
+float nb_mod(float limit, float ref) {
+    float s = 0.0;
+    int i = bitCount(1);
+    while(i < bitfieldInsert(800, 0, 0, 0)) {
+        if (mod(float(i), ref) <= 0.01) {
+            s += 0.2;
+        }
+        if (float(i) >= limit) {
+            return s;
+        }
+        i++;
+    }
+    return s;
+}
+
+void main()
+{
+    vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
+    float ref = floor(resolution.x / 8.0);
+
+    c.x = nb_mod(gl_FragCoord.x, ref);
+    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.z = c.x + c.y;
+    int i = bitfieldReverse(0);
+    do {
+        if (c[i] >= 1.0) {
+            c[i] = c[i] * c[i];
+        }
+        i++;
+    } while (i < findMSB(8));
+    c.x = mod(c.x, 1.0);
+    c.y = mod(c.y, 1.0);
+    c.z = mod(c.z, 1.0);
+    _GLF_color = c;
+}
+

--- a/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
@@ -25,7 +25,7 @@ uniform vec2 resolution;
 float nb_mod(float limit, float ref) {
     float s = float(bitfieldExtract(int(resolution.x), 0, 0));
     int i = bitCount(int(resolution.y));
-    while(i < bitfieldInsert(800, i, int(resolution.x), 0)) {
+    while(i < bitfieldInsert(800, i, 0, 0)) {
         if (mod(float(i), ref) <= 0.01) {
             s += 0.2;
         }
@@ -39,22 +39,22 @@ float nb_mod(float limit, float ref) {
 
 void main()
 {
-    vec4 c = vec4(bitfieldExtract(int(resolution.x), 0, 0), 0.0, 0.0, bitCount(int(resolution.x)));
+    vec4 c = vec4(bitfieldExtract(0, 0, 0), 0.0, 0.0, bitCount(int(resolution.x)));
     float ref = floor(resolution.x / float(findLSB(int(resolution.y))));
 
     c.x = nb_mod(gl_FragCoord.x, ref);
     c.y = nb_mod(gl_FragCoord.y, ref);
     c.z = c.x + c.y;
-    int i = bitfieldReverse(bitfieldExtract(int(resolution.x), 0, 0));
+    int i = bitfieldReverse(bitfieldExtract(0, 0, 0));
     do {
-        if (c[i] >= float(bitCount(int(resolution.y)))) {
+        if (c[i] >= 1.0) {
             c[i] = c[i] * c[i];
         }
         i++;
     } while (i < findMSB(findLSB(int(resolution.y))));
-    c.x = mod(c.x, float(bitCount(int(resolution.x))));
-    c.y = mod(c.y, float(bitCount(int(resolution.y))));
-    c.z = mod(c.z, float(bitCount(int(resolution.x))));
+    c.x = mod(c.x, 1.0);
+    c.y = mod(c.y, 1.0);
+    c.z = mod(c.z, 1.0);
     _GLF_color = c;
 }
 

--- a/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
@@ -23,9 +23,9 @@ layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;
 
 float nb_mod(float limit, float ref) {
-    float s = 0.0;
-    int i = bitCount(1);
-    while(i < bitfieldInsert(800, 0, 0, 0)) {
+    float s = float(bitfieldExtract(int(resolution.x), 0, 0));
+    int i = bitCount(int(resolution.y));
+    while(i < bitfieldInsert(800, i, int(resolution.x), 0)) {
         if (mod(float(i), ref) <= 0.01) {
             s += 0.2;
         }
@@ -39,22 +39,22 @@ float nb_mod(float limit, float ref) {
 
 void main()
 {
-    vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
-    float ref = floor(resolution.x / 8.0);
+    vec4 c = vec4(bitfieldExtract(int(resolution.x), 0, 0), 0.0, 0.0, bitCount(int(resolution.x)));
+    float ref = floor(resolution.x / float(findLSB(int(resolution.y))));
 
     c.x = nb_mod(gl_FragCoord.x, ref);
     c.y = nb_mod(gl_FragCoord.y, ref);
     c.z = c.x + c.y;
-    int i = bitfieldReverse(0);
+    int i = bitfieldReverse(bitfieldExtract(int(resolution.x), 0, 0));
     do {
-        if (c[i] >= 1.0) {
+        if (c[i] >= float(bitCount(int(resolution.y)))) {
             c[i] = c[i] * c[i];
         }
         i++;
-    } while (i < findMSB(8));
-    c.x = mod(c.x, 1.0);
-    c.y = mod(c.y, 1.0);
-    c.z = mod(c.z, 1.0);
+    } while (i < findMSB(findLSB(int(resolution.y))));
+    c.x = mod(c.x, float(bitCount(int(resolution.x))));
+    c.y = mod(c.y, float(bitCount(int(resolution.y))));
+    c.z = mod(c.z, float(bitCount(int(resolution.x))));
     _GLF_color = c;
 }
 

--- a/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.frag
@@ -17,14 +17,18 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 
 uniform vec2 resolution;
 
+int msb8 = 256;
+
 float nb_mod(float limit, float ref) {
+    int msb8 = 256;
     float s = float(bitfieldExtract(int(resolution.x), 0, 0));
-    int i = bitCount(int(resolution.y));
+    int i = bitCount(msb8);
     while(i < bitfieldInsert(800, i, 0, 0)) {
         if (mod(float(i), ref) <= 0.01) {
             s += 0.2;
@@ -39,8 +43,9 @@ float nb_mod(float limit, float ref) {
 
 void main()
 {
-    vec4 c = vec4(bitfieldExtract(0, 0, 0), 0.0, 0.0, bitCount(int(resolution.x)));
-    float ref = floor(resolution.x / float(findLSB(int(resolution.y))));
+    int msb8 = 256;
+    vec4 c = vec4(bitfieldExtract(0, 0, 0), 0.0, 0.0, bitCount(msb8));
+    float ref = floor(resolution.x / float(findLSB(msb8)));
 
     c.x = nb_mod(gl_FragCoord.x, ref);
     c.y = nb_mod(gl_FragCoord.y, ref);
@@ -51,7 +56,7 @@ void main()
             c[i] = c[i] * c[i];
         }
         i++;
-    } while (i < findMSB(findLSB(int(resolution.y))));
+    } while (i < findMSB(findLSB(msb8)));
     c.x = mod(c.x, 1.0);
     c.y = mod(c.y, 1.0);
     c.z = mod(c.z, 1.0);

--- a/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/colorgrid_modulo_intfunctions.json
@@ -1,0 +1,9 @@
+{
+  "resolution": {
+    "func": "glUniform2f",
+    "args": [
+      256.0,
+      256.0
+    ]
+  }
+}

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
@@ -1,0 +1,70 @@
+#version 310 es
+
+/*
+ * Copyright 2018 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform vec2 resolution;
+
+vec3 pickColor(int i) {
+  return vec3(float(i) / 50.0, float(i) / 120.0, float(i) / 140.0);
+}
+
+vec3 mand(float xCoord, float yCoord) {
+  float height = resolution.y;
+  float width = resolution.x;
+
+  float c_re = 0.8*(xCoord - width/2.0)*4.0/width - 0.4;
+  float c_im = 0.8*(yCoord - height/2.0)*4.0/width;
+  float x = 0.0, y = 0.0;
+  int iteration = bitfieldReverse(0);
+  int k = bitfieldExtract(0, bitCount(0), 0);
+  do {
+    if (x*x+y*y > 4.0) {
+      break;
+    }
+    float x_new = x*x - y*y + c_re;
+    y = 2.0*x*y + c_im;
+    x = x_new;
+    iteration++;
+    k++;
+  } while(k < bitfieldInsert(1001, 0, 0, 0));
+  if (iteration < bitfieldInsert(1000, 0, 0, 0)) {
+    return pickColor(iteration);
+  } else {
+    return vec3(0.0);
+  }
+}
+
+void main() {
+  uint uselessOutVariable;
+  vec3 data[findMSB(65536)];
+  for (int i = 0; i < findMSB(16); i++) {
+    for (int j = 0; j < findLSB(16); j++) {
+      data[uaddCarry(uint(4*j), uint(i), uselessOutVariable)] = mand(gl_FragCoord.x + float(i - bitCount(1)), gl_FragCoord.y + float(j - bitCount(1)));
+    }
+  }
+  vec3 sum = vec3(0.0);
+  for (int i = bitfieldReverse(0); i < findMSB(65536); i++) {
+    sum += data[i];
+  }
+  sum /= vec3(16.0);
+  _GLF_color = vec4(sum, 1.0);
+}
+

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 
@@ -63,6 +64,7 @@ vec3 mand(float xCoord, float yCoord) {
 }
 
 void main() {
+  int msb16 = 65536;
   uint uselessOutVariable;
   vec3 data[16];
   for (int i = 0; i < findMSB(16); i++) {
@@ -71,7 +73,7 @@ void main() {
     }
   }
   vec3 sum = vec3(0.0);
-  for (int i = bitfieldReverse(0); i < findMSB(65536); i++) {
+  for (int i = bitfieldReverse(0); i < findMSB(msb16); i++) {
     sum += data[i];
   }
   sum /= vec3(16.0);

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
@@ -33,8 +33,14 @@ vec3 mand(float xCoord, float yCoord) {
   float c_re = 0.8*(xCoord - width/2.0)*4.0/width - 0.4;
   float c_im = 0.8*(yCoord - height/2.0)*4.0/width;
   float x = 0.0, y = 0.0;
-  int iteration = bitfieldReverse(0);
-  int k = bitfieldExtract(0, bitCount(0), 0);
+  if (0.0 > resolution.x)
+  {
+    x = 1.0;
+    y = 1.0;
+  }
+  int iteration = bitfieldReverse(int(x));
+  int k = bitfieldExtract(int(y), bitCount(int(x)), int(y));
+  int iterationCap = 1000;
   do {
     if (x*x+y*y > 4.0) {
       break;
@@ -44,8 +50,12 @@ vec3 mand(float xCoord, float yCoord) {
     x = x_new;
     iteration++;
     k++;
-  } while(k < bitfieldInsert(1001, 0, 0, 0));
-  if (iteration < bitfieldInsert(1000, 0, 0, 0)) {
+  } while(k < bitfieldInsert(iterationCap + (257.0 > resolution.y ? 1 : 0), 0, 0, 0));
+  if (0.0 > resolution.y)
+  {
+    iterationCap += 1;
+  }
+  if (iteration < bitfieldInsert(iterationCap, 0, 0, 0)) {
     return pickColor(iteration);
   } else {
     return vec3(0.0);

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.frag
@@ -64,7 +64,7 @@ vec3 mand(float xCoord, float yCoord) {
 
 void main() {
   uint uselessOutVariable;
-  vec3 data[findMSB(65536)];
+  vec3 data[16];
   for (int i = 0; i < findMSB(16); i++) {
     for (int j = 0; j < findLSB(16); j++) {
       data[uaddCarry(uint(4*j), uint(i), uselessOutVariable)] = mand(gl_FragCoord.x + float(i - bitCount(1)), gl_FragCoord.y + float(j - bitCount(1)));

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_blurry_intfunctions.json
@@ -1,0 +1,9 @@
+{
+    "resolution": {
+        "func":  "glUniform2f",
+        "args": [
+            256.0,
+            256.0
+        ]
+    }
+}

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
@@ -1,0 +1,73 @@
+#version 310 es
+
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform vec2 resolution;
+
+void main(void) {
+  uint uselessOutVariable;
+  float A[bitfieldInsert(50, 0, 0, 0)];
+  int i = bitfieldExtract(0, bitCount(0), 0);
+  do {
+    if (i >= int(resolution.x)) {
+      break;
+    }
+    if (findLSB(16) * (i/findMSB(16)) == i) {
+      A[i/findLSB(16)] = float(i);
+    }
+    i++;
+  } while(i < bitfieldInsert(200, 0, 0, 0));
+  i = findLSB(0);
+  do {
+    if (i < int(gl_FragCoord.x)) {
+      break;
+    }
+    if (i > findMSB(0)) {
+      A[i] += A[usubBorrow(uint(i), uint(1), uselessOutVariable)];
+    }
+    i++;
+  } while(i < bitfieldInsert(50, 0, 0, 0));
+  if (int(gl_FragCoord.x) < findLSB(1048576)) {
+    _GLF_color = vec4(A[bitfieldReverse(0)]/resolution.x, A[findMSB(16)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(40, 0, 0, 0)) {
+    _GLF_color = vec4(A[findLSB(32)]/resolution.x, A[findMSB(512)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(60, 0, 0, 0)) {
+    _GLF_color = vec4(A[findMSB(1024)]/resolution.x, A[findLSB(16384)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(80, 0, 0, 0)) {
+    _GLF_color = vec4(A[findLSB(32768)]/resolution.x, A[findMSB(524288)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(100, 0, 0, 0)) {
+    _GLF_color = vec4(A[findMSB(1048576)]/resolution.x, A[findLSB(16777216)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(120, 0, 0, 0)) {
+    _GLF_color = vec4(A[findLSB(33554432)]/resolution.x, A[findMSB(536870912)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(140, 0, 0, 0)) {
+    _GLF_color = vec4(A[findMSB(1073741824)]/resolution.x, A[bitfieldInsert(34, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(160, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldInsert(35, 0, 0, 0)]/resolution.x, A[bitfieldInsert(39, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldInsert(40, 0, 0, 0)]/resolution.x, A[bitfieldInsert(44, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldInsert(45, 0, 0, 0)]/resolution.x, A[bitfieldInsert(49, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else {
+    discard;
+  }
+
+}
+

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
@@ -43,7 +43,7 @@ void main(void) {
       break;
     }
     if (i > findMSB(int(injectionSwitch.x))) {
-      A[i] += A[usubBorrow(uint(i), uint(injectionSwitch.y), uselessOutVariable)];
+      A[i] += A[int(usubBorrow(uint(i), uint(injectionSwitch.y), uselessOutVariable))];
     }
     i++;
   } while(i < bitfieldInsert(50 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x)));

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
@@ -20,51 +20,53 @@ precision highp float;
 
 layout(location = 0) out vec4 _GLF_color;
 
+uniform vec2 injectionSwitch;
+
 uniform vec2 resolution;
 
 void main(void) {
   uint uselessOutVariable;
-  float A[bitfieldInsert(50, 0, 0, 0)];
-  int i = bitfieldExtract(0, bitCount(0), 0);
+  float A[50];
+  int i = bitfieldExtract(0, bitCount(int(injectionSwitch.x)), int(injectionSwitch.x));
   do {
     if (i >= int(resolution.x)) {
       break;
     }
-    if (findLSB(16) * (i/findMSB(16)) == i) {
-      A[i/findLSB(16)] = float(i);
+    if (findLSB(16 * int(injectionSwitch.y)) * (i/findMSB(16 * int(injectionSwitch.y))) == i) {
+      A[i/findLSB(16 * int(injectionSwitch.y))] = float(i);
     }
     i++;
-  } while(i < bitfieldInsert(200, 0, 0, 0));
-  i = findLSB(0);
+  } while(i < bitfieldInsert(200 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x)));
+  i = findLSB(int(injectionSwitch.x));
   do {
     if (i < int(gl_FragCoord.x)) {
       break;
     }
-    if (i > findMSB(0)) {
-      A[i] += A[usubBorrow(uint(i), uint(1), uselessOutVariable)];
+    if (i > findMSB(int(injectionSwitch.x))) {
+      A[i] += A[usubBorrow(uint(i), uint(injectionSwitch.y), uselessOutVariable)];
     }
     i++;
-  } while(i < bitfieldInsert(50, 0, 0, 0));
+  } while(i < bitfieldInsert(50 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x)));
   if (int(gl_FragCoord.x) < findLSB(1048576)) {
-    _GLF_color = vec4(A[bitfieldReverse(0)]/resolution.x, A[findMSB(16)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(40, 0, 0, 0)) {
-    _GLF_color = vec4(A[findLSB(32)]/resolution.x, A[findMSB(512)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(60, 0, 0, 0)) {
-    _GLF_color = vec4(A[findMSB(1024)]/resolution.x, A[findLSB(16384)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(80, 0, 0, 0)) {
-    _GLF_color = vec4(A[findLSB(32768)]/resolution.x, A[findMSB(524288)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(100, 0, 0, 0)) {
-    _GLF_color = vec4(A[findMSB(1048576)]/resolution.x, A[findLSB(16777216)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(120, 0, 0, 0)) {
-    _GLF_color = vec4(A[findLSB(33554432)]/resolution.x, A[findMSB(536870912)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(140, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldReverse(int(injectionSwitch.x))]/resolution.x, A[findMSB(16)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(40 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[findLSB(32 * int(injectionSwitch.y))]/resolution.x, A[findMSB(512)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(60 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[findMSB(1024 * int(injectionSwitch.y))]/resolution.x, A[findLSB(16384)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(80 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[findLSB(32768 * int(injectionSwitch.y))]/resolution.x, A[findMSB(524288)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(100 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[findMSB(1048576)]/resolution.x, A[findLSB(16777216 * int(injectionSwitch.y))]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(120 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[findLSB(33554432)]/resolution.x, A[findMSB(536870912 * int(injectionSwitch.y))]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(140 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
     _GLF_color = vec4(A[findMSB(1073741824)]/resolution.x, A[bitfieldInsert(34, 0, 0, 0)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(160, 0, 0, 0)) {
-    _GLF_color = vec4(A[bitfieldInsert(35, 0, 0, 0)]/resolution.x, A[bitfieldInsert(39, 0, 0, 0)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {
-    _GLF_color = vec4(A[bitfieldInsert(40, 0, 0, 0)]/resolution.x, A[bitfieldInsert(44, 0, 0, 0)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {
-    _GLF_color = vec4(A[bitfieldInsert(45, 0, 0, 0)]/resolution.x, A[bitfieldInsert(49, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(160 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[bitfieldInsert(35, 0, 0, int(injectionSwitch.x))]/resolution.x, A[bitfieldInsert(39, 0, 0, int(injectionSwitch.x))]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(180 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[bitfieldInsert(40, 0, 0, int(injectionSwitch.x))]/resolution.x, A[bitfieldInsert(44, 0, 0, int(injectionSwitch.x))]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(180 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[bitfieldInsert(45, 0, 0, int(injectionSwitch.x))]/resolution.x, A[bitfieldInsert(49, 0, 0, int(injectionSwitch.x))]/resolution.y, 1.0, 1.0);
   } else {
     discard;
   }

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
@@ -17,12 +17,23 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 
 uniform vec2 resolution;
 
 void main(void) {
+  int msb9 = 512;
+  int msb10 = 1024;
+  int msb14 = 16384;
+  int msb15 = 32768;
+  int msb19 = 524288;
+  int msb20 = 1048576;
+  int msb24 = 16777216;
+  int msb25 = 33554432;
+  int msb29 = 536870912;
+  int msb30 = 1073741824;
   uint uselessOutVariable;
   float A[50];
   int i = bitfieldExtract(0, 0, 0);
@@ -45,20 +56,20 @@ void main(void) {
     }
     i++;
   } while(i < bitfieldInsert(50, 0, 0, 0));
-  if (int(gl_FragCoord.x) < findLSB(1048576)) {
+  if (int(gl_FragCoord.x) < findLSB(msb20)) {
     _GLF_color = vec4(A[bitfieldReverse(0)]/resolution.x, A[findMSB(16)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(40, 0, 0, 0)) {
-    _GLF_color = vec4(A[findLSB(32)]/resolution.x, A[findMSB(512)]/resolution.y, 1.0, 1.0);
+    _GLF_color = vec4(A[findLSB(32)]/resolution.x, A[findMSB(msb9)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(60, 0, 0, 0)) {
-    _GLF_color = vec4(A[findMSB(1024)]/resolution.x, A[findLSB(16384)]/resolution.y, 1.0, 1.0);
+    _GLF_color = vec4(A[findMSB(msb10)]/resolution.x, A[findLSB(msb14)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(80, 0, 0, 0)) {
-    _GLF_color = vec4(A[findLSB(32768)]/resolution.x, A[findMSB(524288)]/resolution.y, 1.0, 1.0);
+    _GLF_color = vec4(A[findLSB(msb15)]/resolution.x, A[findMSB(msb19)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(100, 0, 0, 0)) {
-    _GLF_color = vec4(A[findMSB(1048576)]/resolution.x, A[findLSB(16777216)]/resolution.y, 1.0, 1.0);
+    _GLF_color = vec4(A[findMSB(msb20)]/resolution.x, A[findLSB(msb24)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(120, 0, 0, 0)) {
-    _GLF_color = vec4(A[findLSB(33554432)]/resolution.x, A[findMSB(536870912)]/resolution.y, 1.0, 1.0);
+    _GLF_color = vec4(A[findLSB(msb25)]/resolution.x, A[findMSB(msb29)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(140, 0, 0, 0)) {
-    _GLF_color = vec4(A[findMSB(1073741824)]/resolution.x, A[bitfieldInsert(34, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+    _GLF_color = vec4(A[findMSB(msb30)]/resolution.x, A[bitfieldInsert(34, 0, 0, 0)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(160, 0, 0, 0)) {
     _GLF_color = vec4(A[bitfieldInsert(35, 0, 0, 0)]/resolution.x, A[bitfieldInsert(39, 0, 0, 0)]/resolution.y, 1.0, 1.0);
   } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.frag
@@ -20,53 +20,51 @@ precision highp float;
 
 layout(location = 0) out vec4 _GLF_color;
 
-uniform vec2 injectionSwitch;
-
 uniform vec2 resolution;
 
 void main(void) {
   uint uselessOutVariable;
   float A[50];
-  int i = bitfieldExtract(0, bitCount(int(injectionSwitch.x)), int(injectionSwitch.x));
+  int i = bitfieldExtract(0, 0, 0);
   do {
     if (i >= int(resolution.x)) {
       break;
     }
-    if (findLSB(16 * int(injectionSwitch.y)) * (i/findMSB(16 * int(injectionSwitch.y))) == i) {
-      A[i/findLSB(16 * int(injectionSwitch.y))] = float(i);
+    if (findLSB(16) * (i/findMSB(16)) == i) {
+      A[i/findLSB(16)] = float(i);
     }
     i++;
-  } while(i < bitfieldInsert(200 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x)));
-  i = findLSB(int(injectionSwitch.x));
+  } while(i < bitfieldInsert(200, 0, 0, 0));
+  i = findLSB(0);
   do {
     if (i < int(gl_FragCoord.x)) {
       break;
     }
-    if (i > findMSB(int(injectionSwitch.x))) {
-      A[i] += A[int(usubBorrow(uint(i), uint(injectionSwitch.y), uselessOutVariable))];
+    if (i > findMSB(0)) {
+      A[i] += A[int(usubBorrow(uint(i), 1u, uselessOutVariable))];
     }
     i++;
-  } while(i < bitfieldInsert(50 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x)));
+  } while(i < bitfieldInsert(50, 0, 0, 0));
   if (int(gl_FragCoord.x) < findLSB(1048576)) {
-    _GLF_color = vec4(A[bitfieldReverse(int(injectionSwitch.x))]/resolution.x, A[findMSB(16)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(40 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[findLSB(32 * int(injectionSwitch.y))]/resolution.x, A[findMSB(512)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(60 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[findMSB(1024 * int(injectionSwitch.y))]/resolution.x, A[findLSB(16384)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(80 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[findLSB(32768 * int(injectionSwitch.y))]/resolution.x, A[findMSB(524288)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(100 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[findMSB(1048576)]/resolution.x, A[findLSB(16777216 * int(injectionSwitch.y))]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(120 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[findLSB(33554432)]/resolution.x, A[findMSB(536870912 * int(injectionSwitch.y))]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(140 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
+    _GLF_color = vec4(A[bitfieldReverse(0)]/resolution.x, A[findMSB(16)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(40, 0, 0, 0)) {
+    _GLF_color = vec4(A[findLSB(32)]/resolution.x, A[findMSB(512)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(60, 0, 0, 0)) {
+    _GLF_color = vec4(A[findMSB(1024)]/resolution.x, A[findLSB(16384)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(80, 0, 0, 0)) {
+    _GLF_color = vec4(A[findLSB(32768)]/resolution.x, A[findMSB(524288)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(100, 0, 0, 0)) {
+    _GLF_color = vec4(A[findMSB(1048576)]/resolution.x, A[findLSB(16777216)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(120, 0, 0, 0)) {
+    _GLF_color = vec4(A[findLSB(33554432)]/resolution.x, A[findMSB(536870912)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(140, 0, 0, 0)) {
     _GLF_color = vec4(A[findMSB(1073741824)]/resolution.x, A[bitfieldInsert(34, 0, 0, 0)]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(160 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[bitfieldInsert(35, 0, 0, int(injectionSwitch.x))]/resolution.x, A[bitfieldInsert(39, 0, 0, int(injectionSwitch.x))]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(180 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[bitfieldInsert(40, 0, 0, int(injectionSwitch.x))]/resolution.x, A[bitfieldInsert(44, 0, 0, int(injectionSwitch.x))]/resolution.y, 1.0, 1.0);
-  } else if (int(gl_FragCoord.x) < bitfieldInsert(180 * int(injectionSwitch.y), 0, 0, int(injectionSwitch.x))) {
-    _GLF_color = vec4(A[bitfieldInsert(45, 0, 0, int(injectionSwitch.x))]/resolution.x, A[bitfieldInsert(49, 0, 0, int(injectionSwitch.x))]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(160, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldInsert(35, 0, 0, 0)]/resolution.x, A[bitfieldInsert(39, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldInsert(40, 0, 0, 0)]/resolution.x, A[bitfieldInsert(44, 0, 0, 0)]/resolution.y, 1.0, 1.0);
+  } else if (int(gl_FragCoord.x) < bitfieldInsert(180, 0, 0, 0)) {
+    _GLF_color = vec4(A[bitfieldInsert(45, 0, 0, 0)]/resolution.x, A[bitfieldInsert(49, 0, 0, 0)]/resolution.y, 1.0, 1.0);
   } else {
     discard;
   }

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.json
@@ -1,0 +1,9 @@
+{
+    "resolution": {
+        "func":  "glUniform2f",
+        "args": [
+            256.0,
+            256.0
+        ]
+    }
+}

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.json
@@ -1,11 +1,4 @@
 {
-    "injectionSwitch": {
-        "func":  "glUniform2f",
-        "args": [
-            0.0,
-            1.0
-        ]
-    },
     "resolution": {
         "func":  "glUniform2f",
         "args": [

--- a/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/prefix_sum_intfunctions.json
@@ -1,4 +1,11 @@
 {
+    "injectionSwitch": {
+        "func":  "glUniform2f",
+        "args": [
+            0.0,
+            1.0
+        ]
+    },
     "resolution": {
         "func":  "glUniform2f",
         "args": [

--- a/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
@@ -31,7 +31,7 @@ float b_b;
 void doConvert()
 {
     vec3 temp;
-    temp = b_b * (float(bitCount(int(resolution.x))) - s_g) + (b_b - b_b * (float(bitCount(int(resolution.y))) - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), findMSB(bitCount(int(resolution.x))), findLSB(2)) / 3.0)) - 3.0) - float(bitCount(int(resolution.y))), float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))));
+    temp = b_b * (float(bitCount(int(resolution.x))) - s_g) + (b_b - b_b * (float(bitCount(int(resolution.y))) - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), bitCount(int(resolution.x)), 2) / 3.0)) - 3.0) - float(bitCount(int(resolution.y))), float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))));
     h_r = temp.x;
     s_g = temp.y;
     b_b = temp.z;

--- a/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
@@ -31,7 +31,7 @@ float b_b;
 void doConvert()
 {
     vec3 temp;
-    temp = b_b * (1.0 - s_g) + (b_b - b_b * (1.0 - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), findMSB(1), findLSB(2)) / 3.0)) - 3.0) - 1.0, 0.0, 1.0);
+    temp = b_b * (float(bitCount(int(resolution.x))) - s_g) + (b_b - b_b * (float(bitCount(int(resolution.y))) - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), findMSB(bitCount(int(resolution.x))), findLSB(2)) / 3.0)) - 3.0) - float(bitCount(int(resolution.y))), float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))));
     h_r = temp.x;
     s_g = temp.y;
     b_b = temp.z;
@@ -40,19 +40,19 @@ void doConvert()
 vec3 computeColor(float c, vec2 position)
 {
     h_r = fract(c);
-    s_g = 1.0;
+    s_g = float(bitCount(int(resolution.y)));
     b_b = (0.5 + (sin(time) * 0.5 + 0.5));
     doConvert();
-    s_g *= 1.0 / position.y;
-    h_r *= 1.0 / position.x;
+    s_g *= float(bitCount(int(resolution.x))) / position.y;
+    h_r *= float(bitCount(int(resolution.y))) / position.x;
     if (abs(position.y - position.x) < 0.5) {
-      b_b = clamp(0.0, 1.0, b_b * 3.0);
+      b_b = clamp(float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))), b_b * float(bitCount(int(resolution.x))) * 3.0);
     }
     return vec3(h_r, s_g, b_b);
 }
 
 vec3 defaultColor() {
-  return vec3(0.0);
+  return vec3(float(bitfieldExtract(int(resolution.y), 0, 0)));
 }
 
 vec3 drawShape(vec2 pos, vec2 square, vec3 setting)
@@ -76,19 +76,19 @@ vec3 drawShape(vec2 pos, vec2 square, vec3 setting)
     
     bool c5 = pos.x - (setting.x - setting.y) < square.x;
     if (!c5) {
-      return computeColor(setting.z / 40.0, pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
     }
     bool c6 = pos.x + (setting.x - setting.y) > square.x;
     if (!c6) {
-      return computeColor(setting.z / 40.0, pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
     }
     bool c7 = pos.y - (setting.x - setting.y) < square.y;
     if (!c7) {
-      return computeColor(setting.z / 40.0, pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
     }
     bool c8 = pos.y + (setting.x - setting.y) > square.y;
     if (!c8) {
-      return computeColor(setting.z / 40.0, pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
     }
     return defaultColor();
 }
@@ -104,11 +104,11 @@ vec3 computePoint(mat2 rotationMatrix)
     position *= rotationMatrix;
     center *= rotationMatrix;
     vec3 result = vec3(0.0);
-    for(int i = bitfieldInsert(35, 0, 0, 0); i >= bitfieldReverse(0); i --)
+    for(int i = bitfieldInsert(35, 0, 0, bitfieldExtract(int(resolution.x), 0, 0)); i >= bitfieldReverse(bitfieldExtract(int(resolution.x), 0, 0)); i --)
         {
             vec3 d;
-            d = drawShape(position, center + vec2(sin(float(i) / 10.0 + time) / 4.0, 0.0), vec3(0.01 + sin(float(i) / 100.0), 0.01, float(i)));
-            if(length(d) <= 0.0) {
+            d = drawShape(position, center + vec2(sin(float(i) / (float(bitCount(int(resolution.x))) * 10.0) + time) / 4.0 * float(bitCount(int(resolution.x))), float(bitfieldExtract(int(resolution.x), 0, 0))), vec3(0.01 + sin(float(i) / 100.0 * float(bitCount(int(resolution.x)))), 0.01, float(i)));
+            if(length(d) <= float(bitfieldExtract(int(resolution.x), 0, 0))) {
               continue;
             }
             result = vec3(d);
@@ -134,6 +134,6 @@ void main() {
     vec3 mixed;
     mixed = mix(point1, point2, vec3(0.3));
     mixed = mix(mixed, point3, vec3(0.3));
-    _GLF_color = vec4(mixed, 1.0);
+    _GLF_color = vec4(mixed, float(bitCount(int(resolution.x))));
 }
 

--- a/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
@@ -1,0 +1,139 @@
+#version 310 es
+
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform float time;
+
+uniform vec2 resolution;
+
+float h_r;
+float s_g;
+float b_b;
+
+void doConvert()
+{
+    vec3 temp;
+    temp = b_b * (1.0 - s_g) + (b_b - b_b * (1.0 - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), findMSB(1), findLSB(2)) / 3.0)) - 3.0) - 1.0, 0.0, 1.0);
+    h_r = temp.x;
+    s_g = temp.y;
+    b_b = temp.z;
+}
+
+vec3 computeColor(float c, vec2 position)
+{
+    h_r = fract(c);
+    s_g = 1.0;
+    b_b = (0.5 + (sin(time) * 0.5 + 0.5));
+    doConvert();
+    s_g *= 1.0 / position.y;
+    h_r *= 1.0 / position.x;
+    if (abs(position.y - position.x) < 0.5) {
+      b_b = clamp(0.0, 1.0, b_b * 3.0);
+    }
+    return vec3(h_r, s_g, b_b);
+}
+
+vec3 defaultColor() {
+  return vec3(0.0);
+}
+
+vec3 drawShape(vec2 pos, vec2 square, vec3 setting)
+{
+    bool c1 = pos.x - setting.x < square.x;
+    if (!c1) {
+      return defaultColor();
+    }
+    bool c2 = pos.x + setting.x > square.x;
+    if (!c2) {
+      return defaultColor();
+    }
+    bool c3 = pos.y - setting.x < square.y;
+    if (!c3) {
+      return defaultColor();
+    }
+    bool c4 = pos.y + setting.x > square.y;
+    if (!c4) {
+      return defaultColor();
+    }
+    
+    bool c5 = pos.x - (setting.x - setting.y) < square.x;
+    if (!c5) {
+      return computeColor(setting.z / 40.0, pos);
+    }
+    bool c6 = pos.x + (setting.x - setting.y) > square.x;
+    if (!c6) {
+      return computeColor(setting.z / 40.0, pos);
+    }
+    bool c7 = pos.y - (setting.x - setting.y) < square.y;
+    if (!c7) {
+      return computeColor(setting.z / 40.0, pos);
+    }
+    bool c8 = pos.y + (setting.x - setting.y) > square.y;
+    if (!c8) {
+      return computeColor(setting.z / 40.0, pos);
+    }
+    return defaultColor();
+}
+
+vec3 computePoint(mat2 rotationMatrix)
+{
+    vec2 aspect;
+    aspect = resolution.xy / min(resolution.x, resolution.y);
+    vec2 position;
+    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    vec2 center;
+    center = vec2(0.5) * aspect;
+    position *= rotationMatrix;
+    center *= rotationMatrix;
+    vec3 result = vec3(0.0);
+    for(int i = bitfieldInsert(35, 0, 0, 0); i >= bitfieldReverse(0); i --)
+        {
+            vec3 d;
+            d = drawShape(position, center + vec2(sin(float(i) / 10.0 + time) / 4.0, 0.0), vec3(0.01 + sin(float(i) / 100.0), 0.01, float(i)));
+            if(length(d) <= 0.0) {
+              continue;
+            }
+            result = vec3(d);
+        }
+    return result;
+}
+
+void main() {
+    float angle;
+    angle = sin(time) * 0.1;
+    mat2 rotationMatrix;
+    rotationMatrix = mat2(sin(angle), - cos(angle), cos(angle), sin(angle));
+    vec3 point1;
+    point1 = computePoint(rotationMatrix);
+    mat2 rotationMatrix2;
+    rotationMatrix2 = rotationMatrix * rotationMatrix;
+    vec3 point2;
+    point2 = computePoint(rotationMatrix2);
+    mat2 rotationMatrix3;
+    rotationMatrix3 = rotationMatrix * rotationMatrix * rotationMatrix;
+    vec3 point3;
+    point3 = computePoint(rotationMatrix3);
+    vec3 mixed;
+    mixed = mix(point1, point2, vec3(0.3));
+    mixed = mix(mixed, point3, vec3(0.3));
+    _GLF_color = vec4(mixed, 1.0);
+}
+

--- a/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/310es/squares_intfunctions.frag
@@ -30,8 +30,9 @@ float b_b;
 
 void doConvert()
 {
+    int msb8 = 256;
     vec3 temp;
-    temp = b_b * (float(bitCount(int(resolution.x))) - s_g) + (b_b - b_b * (float(bitCount(int(resolution.y))) - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), bitCount(int(resolution.x)), 2) / 3.0)) - 3.0) - float(bitCount(int(resolution.y))), float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))));
+    temp = b_b * (float(bitCount(msb8)) - s_g) + (b_b - b_b * (float(bitCount(msb8)) - s_g)) * clamp(abs(abs(6.0 * (h_r - vec3(bitfieldReverse(0), bitCount(msb8), 2) / 3.0)) - 3.0) - float(bitCount(msb8)), float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))));
     h_r = temp.x;
     s_g = temp.y;
     b_b = temp.z;
@@ -39,14 +40,15 @@ void doConvert()
 
 vec3 computeColor(float c, vec2 position)
 {
+    int msb8 = 256;
     h_r = fract(c);
-    s_g = float(bitCount(int(resolution.y)));
+    s_g = float(bitCount(msb8));
     b_b = (0.5 + (sin(time) * 0.5 + 0.5));
     doConvert();
-    s_g *= float(bitCount(int(resolution.x))) / position.y;
-    h_r *= float(bitCount(int(resolution.y))) / position.x;
+    s_g *= float(bitCount(msb8)) / position.y;
+    h_r *= float(bitCount(msb8)) / position.x;
     if (abs(position.y - position.x) < 0.5) {
-      b_b = clamp(float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(int(resolution.x))), b_b * float(bitCount(int(resolution.x))) * 3.0);
+      b_b = clamp(float(bitfieldExtract(int(resolution.x), 0, 0)), float(bitCount(msb8)), b_b * float(bitCount(msb8)) * 3.0);
     }
     return vec3(h_r, s_g, b_b);
 }
@@ -57,6 +59,7 @@ vec3 defaultColor() {
 
 vec3 drawShape(vec2 pos, vec2 square, vec3 setting)
 {
+    int msb8 = 256;
     bool c1 = pos.x - setting.x < square.x;
     if (!c1) {
       return defaultColor();
@@ -73,28 +76,29 @@ vec3 drawShape(vec2 pos, vec2 square, vec3 setting)
     if (!c4) {
       return defaultColor();
     }
-    
+
     bool c5 = pos.x - (setting.x - setting.y) < square.x;
     if (!c5) {
-      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(msb8))), pos);
     }
     bool c6 = pos.x + (setting.x - setting.y) > square.x;
     if (!c6) {
-      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(msb8))), pos);
     }
     bool c7 = pos.y - (setting.x - setting.y) < square.y;
     if (!c7) {
-      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(msb8))), pos);
     }
     bool c8 = pos.y + (setting.x - setting.y) > square.y;
     if (!c8) {
-      return computeColor(setting.z / (5.0 * float(findMSB(int(resolution.x)))), pos);
+      return computeColor(setting.z / (5.0 * float(findMSB(msb8))), pos);
     }
     return defaultColor();
 }
 
 vec3 computePoint(mat2 rotationMatrix)
 {
+    int msb8 = 256;
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
@@ -107,7 +111,7 @@ vec3 computePoint(mat2 rotationMatrix)
     for(int i = bitfieldInsert(35, 0, 0, bitfieldExtract(int(resolution.x), 0, 0)); i >= bitfieldReverse(bitfieldExtract(int(resolution.x), 0, 0)); i --)
         {
             vec3 d;
-            d = drawShape(position, center + vec2(sin(float(i) / (float(bitCount(int(resolution.x))) * 10.0) + time) / 4.0 * float(bitCount(int(resolution.x))), float(bitfieldExtract(int(resolution.x), 0, 0))), vec3(0.01 + sin(float(i) / 100.0 * float(bitCount(int(resolution.x)))), 0.01, float(i)));
+            d = drawShape(position, center + vec2(sin(float(i) / (float(bitCount(msb8)) * 10.0) + time) / 4.0 * float(bitCount(msb8)), float(bitfieldExtract(int(resolution.x), 0, 0))), vec3(0.01 + sin(float(i) / 100.0 * float(bitCount(msb8))), 0.01, float(i)));
             if(length(d) <= float(bitfieldExtract(int(resolution.x), 0, 0))) {
               continue;
             }
@@ -117,6 +121,7 @@ vec3 computePoint(mat2 rotationMatrix)
 }
 
 void main() {
+    int msb8 = 256;
     float angle;
     angle = sin(time) * 0.1;
     mat2 rotationMatrix;
@@ -134,6 +139,6 @@ void main() {
     vec3 mixed;
     mixed = mix(point1, point2, vec3(0.3));
     mixed = mix(mixed, point3, vec3(0.3));
-    _GLF_color = vec4(mixed, float(bitCount(int(resolution.x))));
+    _GLF_color = vec4(mixed, float(bitCount(msb8)));
 }
 

--- a/shaders/src/main/glsl/samples/310es/squares_intfunctions.json
+++ b/shaders/src/main/glsl/samples/310es/squares_intfunctions.json
@@ -1,0 +1,22 @@
+{
+  "time": {
+    "func": "glUniform1f",
+    "args": [
+      0.0
+    ]
+  },
+  "mouse": {
+    "func": "glUniform2f",
+    "args": [
+      0.0,
+      0.0
+    ]
+  },
+  "resolution": {
+    "func": "glUniform2f",
+    "args": [
+      256.0,
+      256.0
+    ]
+  }
+}


### PR DESCRIPTION
Implements #543. 

This PR adds modified versions of the default GraphicsFuzz shaders to the 310es directory that use GLES features not found in GLES 1.00, including do/while loops, while loops and Integer Functions.

Note - I couldn't make too many useful changes to colorgrid_modulo and squares - they heavily make use of floating point rather than integers and some parts of them rely on having a for loop(continue statement) rather than another type of control flow. Please make suggestions if you have any ideas for spicing those two up.