### PR TITLE
Fix piglit converter not accepting blank JSON

### DIFF
--- a/python/src/main/python/drivers/graphicsfuzz_piglit_converter.py
+++ b/python/src/main/python/drivers/graphicsfuzz_piglit_converter.py
@@ -182,8 +182,6 @@ def get_json_properties(shader_job: str) -> List:
     """
     with gfuzz_common.open_helper(shader_job, 'r') as job:
         json_parsed = json.load(job)
-    if not json_parsed:
-        raise IOError('Malformed shader job file.')
     return json_parsed
 
 


### PR DESCRIPTION
We don't need to error check the variable - json.load() just returns nothing if the JSON is empty, and errors out by itself if it detects malformed JSON.