### PR TITLE
Remove redundant code to check for GraphicsFuzz defines

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -310,29 +310,6 @@ public class ShaderJobFileOperations {
   }
 
   /**
-   * Determines whether the underlying shader files for the shader jobs use GraphicsFuzz defines.
-   * Assumes that if one shader does, they all do.
-   */
-  public boolean doesShaderJobUseGraphicsFuzzDefines(File shaderJobFile) throws IOException {
-    for (ShaderKind shaderKind : ShaderKind.values()) {
-      //noinspection deprecation: fine inside this class.
-      final File shaderFile = getUnderlyingShaderFile(shaderJobFile, shaderKind);
-      if (!shaderFile.isFile()) {
-        continue;
-      }
-      try (BufferedReader br = new BufferedReader(new FileReader(shaderFile))) {
-        String line;
-        while ((line = br.readLine()) != null) {
-          if (line.trim().startsWith(ParseHelper.END_OF_GRAPHICSFUZZ_DEFINES)) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
    * Does this shaderJobResultFile have an associated image result?
    *
    * <p>Perhaps we should be able to check this by reading the result file,

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
@@ -515,9 +515,6 @@ public class GlslReduce {
             shaderJobFile
         );
 
-    final boolean emitGraphicsFuzzDefines =
-        fileOps.doesShaderJobUseGraphicsFuzzDefines(shaderJobFile);
-
     new ReductionDriver(
         new ReducerContext(
             reduceEverywhere,


### PR DESCRIPTION
A recent change removed the need to explicitly track whether
GraphicsFuzz defines are present in a shader, instead opting to emit
them if and only if the shader uses at least one GraphicsFuzz macro.
Some old code for tracking when the defines were used had been left
behind.  This change removes that old code.