### PR TITLE
Reduce switch statements by replacing switch with do..while(false)

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
@@ -112,6 +112,7 @@ public class ReductionDriver {
         IReductionOpportunityFinder.mutationFinder(),
         IReductionOpportunityFinder.loopMergeFinder(),
         IReductionOpportunityFinder.compoundToBlockFinder(),
+        IReductionOpportunityFinder.switchToLoopFinder(),
         IReductionOpportunityFinder.outlinedStatementFinder(),
         IReductionOpportunityFinder.unwrapFinder(),
         IReductionOpportunityFinder.removeStructFieldFinder(),

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundToBlockReductionOpportunities.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class CompoundToBlockReductionOpportunities
       extends ReductionOpportunitiesBase<CompoundToBlockReductionOpportunity> {
 
-  public CompoundToBlockReductionOpportunities(
+  private CompoundToBlockReductionOpportunities(
         TranslationUnit tu,
         ReducerContext context) {
     super(tu, context);

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunities.java
@@ -53,7 +53,7 @@ public class GlobalVariableDeclToExprReductionOpportunities
     extends ReductionOpportunitiesBase<GlobalVariableDeclToExprReductionOpportunity> {
   private final List<VariablesDeclaration> globalVariableDecl;
 
-  public GlobalVariableDeclToExprReductionOpportunities(TranslationUnit tu,
+  private GlobalVariableDeclToExprReductionOpportunities(TranslationUnit tu,
                                                         ReducerContext context) {
     super(tu, context);
     this.globalVariableDecl = new ArrayList<>();

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
@@ -500,4 +500,23 @@ public interface IReductionOpportunityFinder<T extends IReductionOpportunity> {
     };
   }
 
+  static IReductionOpportunityFinder<SwitchToLoopReductionOpportunity>
+      switchToLoopFinder() {
+    return new IReductionOpportunityFinder<SwitchToLoopReductionOpportunity>() {
+      @Override
+      public List<SwitchToLoopReductionOpportunity> findOpportunities(
+          ShaderJob shaderJob,
+          ReducerContext context) {
+        return SwitchToLoopReductionOpportunities.findOpportunities(
+            shaderJob,
+            context);
+      }
+
+      @Override
+      public String getName() {
+        return "switchToLoop";
+      }
+    };
+  }
+
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/OutlinedStatementReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/OutlinedStatementReductionOpportunities.java
@@ -29,6 +29,7 @@ import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.util.Constants;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -48,8 +49,8 @@ public class OutlinedStatementReductionOpportunities extends StandardVisitor {
         ReducerContext context) {
     return shaderJob.getShaders()
         .stream()
-        .map(item -> findOpportunitiesForShader(item))
-        .reduce(Arrays.asList(), ListConcat::concatenate);
+        .map(OutlinedStatementReductionOpportunities::findOpportunitiesForShader)
+        .reduce(Collections.emptyList(), ListConcat::concatenate);
   }
 
   private static List<OutlinedStatementReductionOpportunity> findOpportunitiesForShader(

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunities.java
@@ -67,7 +67,8 @@ public final class ReductionOpportunities {
         IReductionOpportunityFinder.foldConstantFinder(),
         IReductionOpportunityFinder.inlineUniformFinder(),
         IReductionOpportunityFinder.redundantUniformMetadataFinder(),
-        IReductionOpportunityFinder.variableDeclToExprFinder())) {
+        IReductionOpportunityFinder.variableDeclToExprFinder(),
+        IReductionOpportunityFinder.switchToLoopFinder())) {
       final List<? extends IReductionOpportunity> currentOpportunities = ros
             .findOpportunities(shaderJob, context);
       if (ReductionDriver.DEBUG_REDUCER) {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
@@ -47,15 +47,15 @@ public abstract class ReductionOpportunitiesBase
       extends ScopeTreeBuilder {
 
   private final List<ReductionOpportunityT> opportunities;
-  protected final InjectionTracker injectionTracker;
-  protected final NotReferencedFromLiveContext notReferencedFromLiveContext;
+  final InjectionTracker injectionTracker;
+  final NotReferencedFromLiveContext notReferencedFromLiveContext;
   protected final IParentMap parentMap;
 
   protected final ReducerContext context;
 
-  protected final ShaderKind shaderKind;
+  final ShaderKind shaderKind;
 
-  protected String enclosingFunctionName;
+  private String enclosingFunctionName;
 
   private int numEnclosingLValues;
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunities.java
@@ -29,6 +29,11 @@ import java.util.stream.Collectors;
 
 public class RemoveRedundantUniformMetadataReductionOpportunities {
 
+  private RemoveRedundantUniformMetadataReductionOpportunities() {
+    // This class just provides a static method; there is no cause to create an instance of the
+    // class.
+  }
+
   static List<RemoveRedundantUniformMetadataReductionOpportunity> findOpportunities(
       ShaderJob shaderJob,
       ReducerContext context) {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SwitchToLoopReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SwitchToLoopReductionOpportunity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.IAstNode;
+import com.graphicsfuzz.common.ast.expr.BoolConstantExpr;
+import com.graphicsfuzz.common.ast.stmt.BlockStmt;
+import com.graphicsfuzz.common.ast.stmt.CaseLabel;
+import com.graphicsfuzz.common.ast.stmt.DoStmt;
+import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
+import com.graphicsfuzz.common.ast.visitors.VisitationDepth;
+import java.util.stream.Collectors;
+
+/**
+ * Turns a switch statement into a do...while(false) loop.  The body of the loop comprises all
+ * the non-case/default statements from the switch.  The reason a loop is used is to allow for
+ * break statements.  The reduction opportunity is not semantics-preserving.
+ */
+public class SwitchToLoopReductionOpportunity extends AbstractReductionOpportunity {
+
+  // The parent of the switch statemtnt
+  private final IAstNode parent;
+
+  // The switch statement to be replaced
+  private final SwitchStmt switchStmt;
+
+  SwitchToLoopReductionOpportunity(VisitationDepth depth, IAstNode parent, SwitchStmt switchStmt) {
+    super(depth);
+    this.parent = parent;
+    this.switchStmt = switchStmt;
+  }
+
+  @Override
+  void applyReductionImpl() {
+    final BlockStmt loopBody = new BlockStmt(
+        switchStmt.getBody().getStmts().stream().filter(item -> !(item instanceof CaseLabel))
+            .collect(Collectors.toList()), true);
+    parent.replaceChild(switchStmt, new DoStmt(loopBody, new BoolConstantExpr(false)));
+  }
+
+  @Override
+  public boolean preconditionHolds() {
+    return parent.hasChild(switchStmt);
+  }
+
+}

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclToExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclToExprReductionOpportunities.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class VariableDeclToExprReductionOpportunities
     extends ReductionOpportunitiesBase<VariableDeclToExprReductionOpportunity> {
 
-  public VariableDeclToExprReductionOpportunities(TranslationUnit tu, ReducerContext context) {
+  private VariableDeclToExprReductionOpportunities(TranslationUnit tu, ReducerContext context) {
     super(tu, context);
   }
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/SwitchToLoopReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/SwitchToLoopReductionOpportunitiesTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.IdGenerator;
+import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.util.Constants;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SwitchToLoopReductionOpportunitiesTest {
+
+  @Test
+  public void testDoNotReduceIfPreservingSemantics() throws Exception {
+    final String original = "void main() {\n"
+        + " if (" + Constants.GLF_DEAD + "(false)) {\n"
+        + "  switch (0) {\n"
+        + "   case 0:\n"
+        + "    return;\n"
+        + "  }\n"
+        + " }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<VariableDeclToExprReductionOpportunity> ops =
+        VariableDeclToExprReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_320,
+                new RandomWrapper(0), new IdGenerator()));
+    // There should be no opportunities as the preserve semantics is enabled.
+    assertTrue(ops.isEmpty());
+  }
+
+  @Test
+  public void testDoReduceWhenPreservingSemanticsIfInDeadCode() throws Exception {
+    final String original = "void main() {\n"
+        + " if (" + Constants.GLF_DEAD + "(false)) {\n"
+        + "  switch (0) {\n"
+        + "   case 0:\n"
+        + "    return;\n"
+        + "  }\n"
+        + " }\n"
+        + "}\n";
+    final String expected = "void main() {\n"
+        + " if (" + Constants.GLF_DEAD + "(false)) {\n"
+        + "  do {\n"
+        + "   return;\n"
+        + "  } while (false);\n"
+        + " }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<SwitchToLoopReductionOpportunity> ops =
+        SwitchToLoopReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+                ShadingLanguageVersion.ESSL_320,
+                new RandomWrapper(0), new IdGenerator()));
+    // There should be an opportunity, as the switch statement is in a dead code block.
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testNoBreaks() throws Exception {
+    final String original = "void main() {\n"
+        + " int a;\n"
+        + " int x = 3;\n"
+        + " switch (x) {\n"
+        + "  case 0:\n"
+        + "   {\n"
+        + "    x = 1;\n"
+        + "   }\n"
+        + "  case 1:\n"
+        + "   a = 4;\n"
+        + "   x = 2;\n"
+        + "  case 3:\n"
+        + "  default:\n"
+        + "   x = 1;\n"
+        + " }\n"
+        + "}\n";
+    final String expected = "void main() {\n"
+        + " int a;\n"
+        + " int x = 3;\n"
+        + " do {\n"
+        + "  {\n"
+        + "   x = 1;\n"
+        + "  }\n"
+        + "  a = 4;\n"
+        + "  x = 2;\n"
+        + "  x = 1;\n"
+        + " } while (false);\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<SwitchToLoopReductionOpportunity> ops =
+        SwitchToLoopReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+                ShadingLanguageVersion.ESSL_320,
+                new RandomWrapper(0), new IdGenerator()));
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testWithBreaks() throws Exception {
+    final String original = "void main() {\n"
+        + " int a;\n"
+        + " int x = 3;\n"
+        + " switch (x) {\n"
+        + "  case 0:\n"
+        + "   {\n"
+        + "    x = 1;\n"
+        + "   }\n"
+        + "   break;\n"
+        + "  case 1:\n"
+        + "   a = 4;\n"
+        + "   x = 2;\n"
+        + "   break;\n"
+        + "  case 3:\n"
+        + "  default:\n"
+        + "   x = 1;\n"
+        + "   break;\n"
+        + " }\n"
+        + "}\n";
+    final String expected = "void main() {\n"
+        + " int a;\n"
+        + " int x = 3;\n"
+        + " do {\n"
+        + "  {\n"
+        + "   x = 1;\n"
+        + "  }\n"
+        + "  break;\n"
+        + "  a = 4;\n"
+        + "  x = 2;\n"
+        + "  break;\n"
+        + "  x = 1;\n"
+        + "  break;\n"
+        + " } while (false);\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<SwitchToLoopReductionOpportunity> ops =
+        SwitchToLoopReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+                ShadingLanguageVersion.ESSL_320,
+                new RandomWrapper(0), new IdGenerator()));
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testTwoSwitches() throws Exception {
+    final String original = "void main() {\n"
+        + " int x;\n"
+        + " switch (0) {\n"
+        + "  case 0:\n"
+        + "   x = 1;\n"
+        + " }\n"
+        + " switch (1) {\n"
+        + "  case 1:\n"
+        + "   x = 2;\n"
+        + " }\n"
+        + "}\n";
+    final String expected = "void main() {\n"
+        + " int x;\n"
+        + " do {\n"
+        + "  x = 1;\n"
+        + " } while (false);\n"
+        + " do {\n"
+        + "  x = 2;\n"
+        + " } while (false);\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<SwitchToLoopReductionOpportunity> ops =
+        SwitchToLoopReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
+                ShadingLanguageVersion.ESSL_320,
+                new RandomWrapper(0), new IdGenerator()));
+    assertEquals(2, ops.size());
+    ops.get(0).applyReduction();
+    ops.get(1).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+}


### PR DESCRIPTION
Adds a reduction pass that will replace a switch statement with a loop
of the form:

do {
 // Body of switch statement, minus 'case' and 'default' labels
} while (false);

The loop construct is convenient as it allows for 'break' statements.
Existing reduction passes will then try to remove the loop.

Does not apply when --preserve-semantics is used, unless the switch
statement is part of a dead code injection.

Fixes #610