### PR TITLE
Eliminate redundant GLSL version arguments

### DIFF
--- a/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/GenerateAndRunShaders.java
+++ b/generate-and-run-shaders/src/main/java/com/graphicsfuzz/generator/GenerateAndRunShaders.java
@@ -16,12 +16,9 @@
 
 package com.graphicsfuzz.generator;
 
-import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
-import com.graphicsfuzz.common.util.RandomWrapper;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.generator.tool.Generate;
-import com.graphicsfuzz.util.ArgsUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
@@ -29,7 +26,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -63,10 +59,6 @@ public class GenerateAndRunShaders {
 
     parser.addArgument("worker")
           .help("Worker name.")
-          .type(String.class);
-
-    parser.addArgument("glsl-version")
-          .help("Version of GLSL to target.")
           .type(String.class);
 
     // Optional arguments

--- a/generate-and-run-shaders/src/test/java/com/graphicsfuzz/generator/GenerateAndRunShadersTest.java
+++ b/generate-and-run-shaders/src/test/java/com/graphicsfuzz/generator/GenerateAndRunShadersTest.java
@@ -44,8 +44,7 @@ public class GenerateAndRunShadersTest {
                 donors.getAbsolutePath(),
                 outputDir,
                 "dummy_server",
-                "dummy_worker",
-                "100"
+                "dummy_worker"
             }
       );
       throw new RuntimeException("Exception expected.");
@@ -70,8 +69,7 @@ public class GenerateAndRunShadersTest {
                 donors.getAbsolutePath(),
                 outputDir,
                 "dummy_server",
-                "dummy_worker",
-                "100"
+                "dummy_worker"
             }
       );
       throw new RuntimeException("Exception expected.");
@@ -95,8 +93,7 @@ public class GenerateAndRunShadersTest {
                 donors.getAbsolutePath(),
                 outputDir,
                 "dummy_server",
-                "dummy_worker",
-                "100"
+                "dummy_worker"
             }
       );
       throw new RuntimeException("Exception expected.");


### PR DESCRIPTION
GlslGenerate and GenerateAndRunShaders both required a 'glsl-version'
argument that was subsequently never used, due to the shading language
version now being inferred from the shader itself.  This change
removes those arguments, and in passing cleans up various style issues
(such as using method references in favour of lambdas), and uses
ShaderJobFileOperations more consistently in some tests that were
affected by the change.

Fixes #619 