### PR TITLE
Fix compilation problems

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -79,7 +79,7 @@ public class StmtReductionOpportunities
     final Stmt child = block.getStmt(index);
     if (isEmptyBlockStmt(child) || isDeadCodeInjection(child)
           || allowedToReduceStmt(block, index)) {
-      addOpportunity(new StmtReductionOpportunity(enclosingFunction, block, child,
+      addOpportunity(new StmtReductionOpportunity(getEnclosingFunction(), block, child,
           getVistitationDepth()));
     }
   }
@@ -130,7 +130,7 @@ public class StmtReductionOpportunities
     // Unless we are in an injected dead code block, we need to be careful about removing
     // non-void return statements, so as to avoid making the shader invalid.
     if (StmtReductionOpportunity
-        .removalCouldLeadToLackOfReturnFromNonVoidFunction(enclosingFunction, block, stmt)) {
+        .removalCouldLeadToLackOfReturnFromNonVoidFunction(getEnclosingFunction(), block, stmt)) {
       return false;
     }
 


### PR DESCRIPTION
Two seemingly independent PRs had clashed: one improved encapsulation
of ScopeTrackingVisitor, the other depended on the existing less tight
encapsulation.  This change fixes the mismatch.