### PR TITLE
Gracefully handle scenario where no compatible donors are available

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/util/GenerationParams.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/GenerationParams.java
@@ -29,7 +29,7 @@ public class GenerationParams {
     result.maxDepthForGeneratedExpr = 2;
     result.maxStructNestingDepth = 1;
     result.maxStructFields = 3;
-    result.maxDonors = 2;
+    result.maxDonorsPerDonationPass = 2;
     return result;
   }
 
@@ -38,7 +38,7 @@ public class GenerationParams {
     result.maxDepthForGeneratedExpr = 3;
     result.maxStructNestingDepth = 2;
     result.maxStructFields = 5;
-    result.maxDonors = 4;
+    result.maxDonorsPerDonationPass = 4;
     return result;
   }
 
@@ -47,7 +47,7 @@ public class GenerationParams {
     result.maxDepthForGeneratedExpr = 5;
     result.maxStructNestingDepth = 4;
     result.maxStructFields = 7;
-    result.maxDonors = 6;
+    result.maxDonorsPerDonationPass = 6;
     return result;
   }
 
@@ -67,8 +67,8 @@ public class GenerationParams {
   private int maxStructNestingDepth = 3;
   private int maxStructFields = 8;
 
-  // Donors
-  private int maxDonors = 5;
+  // The maximum number of distinct donors that can be used during one donation pass.
+  private int maxDonorsPerDonationPass = 5;
 
   private final boolean injectionSwitchIsAvailable;
 
@@ -84,8 +84,8 @@ public class GenerationParams {
     return maxStructFields;
   }
 
-  public int getMaxDonors() {
-    return maxDonors;
+  public int getMaxDonorsPerDonationPass() {
+    return maxDonorsPerDonationPass;
   }
 
   public ShaderKind getShaderKind() {


### PR DESCRIPTION
It is possible to get into a situation with live or dead code
injection where none of the available donors are compatible with the
reference.  For example, they might all share a named struct in common
(which at present is a source of incompatibility).  When such a
situation arises the generator would throw an exception.  This change
causes the generator, instead, to inject a null statement (;).

Fixes #645.