### PR TITLE
Avoid injecting switch case labels into inappropriate places

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -33,7 +33,9 @@ import com.graphicsfuzz.generator.transformation.donation.DonationContext;
 import com.graphicsfuzz.generator.transformation.injection.IInjectionPoint;
 import com.graphicsfuzz.generator.util.GenerationParams;
 import com.graphicsfuzz.generator.util.RemoveDiscardStatements;
-import com.graphicsfuzz.generator.util.RemoveImmediateBreakAndContinueStatements;
+import com.graphicsfuzz.generator.util.RemoveImmediateBreakStatements;
+import com.graphicsfuzz.generator.util.RemoveImmediateCaseLabels;
+import com.graphicsfuzz.generator.util.RemoveImmediateContinueStatements;
 import com.graphicsfuzz.generator.util.RemoveReturnStatements;
 import com.graphicsfuzz.generator.util.TransformationProbabilities;
 import com.graphicsfuzz.util.Constants;
@@ -87,7 +89,9 @@ public class DonateLiveCodeTransformation extends DonateCodeTransformation {
     }
     donatedStmts.add(donationContext.getDonorFragment());
     BlockStmt donatedStmt = new BlockStmt(donatedStmts, true);
-    new RemoveImmediateBreakAndContinueStatements(donatedStmt);
+    new RemoveImmediateBreakStatements(donatedStmt);
+    new RemoveImmediateContinueStatements(donatedStmt);
+    new RemoveImmediateCaseLabels(donatedStmt);
     new RemoveReturnStatements(donatedStmt);
     new RemoveDiscardStatements(donatedStmt);
     return donatedStmt;

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -60,7 +60,7 @@ public class DonateLiveCodeTransformation extends DonateCodeTransformation {
   }
 
   @Override
-  public Stmt prepareStatementToDonate(IInjectionPoint injectionPoint,
+  Stmt prepareStatementToDonate(IInjectionPoint injectionPoint,
                                 DonationContext donationContext,
                                 TransformationProbabilities probabilities,
                                 IRandom generator, ShadingLanguageVersion shadingLanguageVersion) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/BlockInjectionPoint.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/BlockInjectionPoint.java
@@ -27,8 +27,8 @@ public class BlockInjectionPoint extends InjectionPoint {
   private Stmt nextStmt; // null if there is no next statement
 
   public BlockInjectionPoint(BlockStmt blockStmt, Stmt nextStmt,
-      FunctionDefinition enclosingFunction, boolean inLoop, Scope scope) {
-    super(enclosingFunction, inLoop, scope);
+      FunctionDefinition enclosingFunction, boolean inLoop, boolean inSwitch, Scope scope) {
+    super(enclosingFunction, inLoop, inSwitch, scope);
     this.blockStmt = blockStmt;
     this.nextStmt = nextStmt;
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/IInjectionPoint.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/IInjectionPoint.java
@@ -60,6 +60,13 @@ public interface IInjectionPoint {
   boolean inLoop();
 
   /**
+   * Determines whether the injection point is located inside a switch statement.
+   *
+   * @return true if and only if the injection point is inside a switch statement.
+   */
+  boolean inSwitch();
+
+  /**
    * Returns the function enclosing the injection point.
    *
    * @return the function enclosing the injection point

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/IfInjectionPoint.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/IfInjectionPoint.java
@@ -30,8 +30,8 @@ public class IfInjectionPoint extends InjectionPoint {
   private boolean chooseThen;
 
   public IfInjectionPoint(IfStmt ifStmt, boolean chooseThen, FunctionDefinition enclosingFunction,
-      boolean inLoop, Scope scope) {
-    super(enclosingFunction, inLoop, scope);
+      boolean inLoop, boolean inSwitch, Scope scope) {
+    super(enclosingFunction, inLoop, inSwitch, scope);
     this.ifStmt = ifStmt;
     this.chooseThen = chooseThen;
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/InjectionPoint.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/InjectionPoint.java
@@ -23,12 +23,15 @@ abstract class InjectionPoint implements IInjectionPoint {
 
   private final FunctionDefinition enclosingFunction;
   private final boolean inLoop;
+  private final boolean inSwitch;
   private final Scope scope;
 
   InjectionPoint(FunctionDefinition enclosingFunction, boolean inLoop,
+      boolean inSwitch,
       Scope scope) {
     this.enclosingFunction = enclosingFunction;
     this.inLoop = inLoop;
+    this.inSwitch = inSwitch;
     this.scope = scope.shallowClone();
   }
 
@@ -40,6 +43,11 @@ abstract class InjectionPoint implements IInjectionPoint {
   @Override
   public final boolean inLoop() {
     return inLoop;
+  }
+
+  @Override
+  public final boolean inSwitch() {
+    return inSwitch;
   }
 
   @Override

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/LoopInjectionPoint.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/injection/LoopInjectionPoint.java
@@ -29,8 +29,9 @@ public class LoopInjectionPoint extends InjectionPoint {
   private LoopStmt loopStmt;
 
   public LoopInjectionPoint(LoopStmt loopStmt, FunctionDefinition enclosingFunction,
-      Scope scope) {
-    super(enclosingFunction, true, scope);
+                            boolean inSwitch,
+                            Scope scope) {
+    super(enclosingFunction, true, inSwitch, scope);
     this.loopStmt = loopStmt;
   }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateBreakStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateBreakStatements.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.generator.util;
+
+import com.graphicsfuzz.common.ast.IAstNode;
+import com.graphicsfuzz.common.ast.stmt.BreakStmt;
+import com.graphicsfuzz.common.ast.stmt.DoStmt;
+import com.graphicsfuzz.common.ast.stmt.ForStmt;
+import com.graphicsfuzz.common.ast.stmt.NullStmt;
+import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
+import com.graphicsfuzz.common.ast.stmt.WhileStmt;
+import java.util.Optional;
+
+/**
+ * This class removes break statements that are not nested inside loop or switch statements.
+ */
+public class RemoveImmediateBreakStatements extends RemoveStatements {
+
+  public RemoveImmediateBreakStatements(IAstNode node) {
+    super(item -> item instanceof BreakStmt,
+        item -> Optional.of(new NullStmt()), node);
+  }
+
+  @Override
+  public void visitDoStmt(DoStmt doStmt) {
+    // Block visitation: we don't want to remove break statements from inside a loop
+  }
+
+  @Override
+  public void visitForStmt(ForStmt forStmt) {
+    // Block visitation: we don't want to remove break statements from inside a loop
+  }
+
+  @Override
+  public void visitWhileStmt(WhileStmt whileStmt) {
+    // Block visitation: we don't want to remove break statements from inside a loop
+  }
+
+  @Override
+  public void visitSwitchStmt(SwitchStmt switchStmt) {
+    // Block visitation: we don't want to remove break statements from inside a switch
+  }
+}

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateCaseLabels.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateCaseLabels.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.generator.util;
+
+import com.graphicsfuzz.common.ast.IAstNode;
+import com.graphicsfuzz.common.ast.stmt.CaseLabel;
+import com.graphicsfuzz.common.ast.stmt.NullStmt;
+import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
+import java.util.Optional;
+
+/**
+ * This class removes case labels (including default) that are not nested inside switch statements.
+ */
+public class RemoveImmediateCaseLabels extends RemoveStatements {
+
+  public RemoveImmediateCaseLabels(IAstNode node) {
+    super(item -> item instanceof CaseLabel,
+        item -> Optional.of(new NullStmt()), node);
+  }
+
+  @Override
+  public void visitSwitchStmt(SwitchStmt switchStmt) {
+    // Block visitation: we don't want to remove labels from inside switch statements
+  }
+
+}

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateContinueStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateContinueStatements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The GraphicsFuzz Project Authors
+ * Copyright 2019 The GraphicsFuzz Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.graphicsfuzz.generator.util;
 
 import com.graphicsfuzz.common.ast.IAstNode;
-import com.graphicsfuzz.common.ast.stmt.BreakStmt;
 import com.graphicsfuzz.common.ast.stmt.ContinueStmt;
 import com.graphicsfuzz.common.ast.stmt.DoStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
@@ -26,28 +25,28 @@ import com.graphicsfuzz.common.ast.stmt.WhileStmt;
 import java.util.Optional;
 
 /**
- * This class removes break and continue statements that are not nested inside loops.
+ * This class removes continue statements that are not nested inside loops.
  */
-public class RemoveImmediateBreakAndContinueStatements extends RemoveStatements {
+public class RemoveImmediateContinueStatements extends RemoveStatements {
 
-  public RemoveImmediateBreakAndContinueStatements(IAstNode node) {
-    super(item -> item instanceof BreakStmt || item instanceof ContinueStmt,
+  public RemoveImmediateContinueStatements(IAstNode node) {
+    super(item -> item instanceof ContinueStmt,
         item -> Optional.of(new NullStmt()), node);
   }
 
   @Override
   public void visitDoStmt(DoStmt doStmt) {
-    // Block visitation: we don't want to remove break and continue statements from inside a loop
+    // Block visitation: we don't want to remove continue statements from inside a loop
   }
 
   @Override
   public void visitForStmt(ForStmt forStmt) {
-    // Block visitation: we don't want to remove break and continue statements from inside a loop
+    // Block visitation: we don't want to remove continue statements from inside a loop
   }
 
   @Override
   public void visitWhileStmt(WhileStmt whileStmt) {
-    // Block visitation: we don't want to remove break and continue statements from inside a loop
+    // Block visitation: we don't want to remove continue statements from inside a loop
   }
 
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateContinueStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateContinueStatements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The GraphicsFuzz Project Authors
+ * Copyright 2018 The GraphicsFuzz Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2019 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.generator.transformation;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.stmt.BreakStmt;
+import com.graphicsfuzz.common.ast.stmt.ContinueStmt;
+import com.graphicsfuzz.common.ast.stmt.DefaultCaseLabel;
+import com.graphicsfuzz.common.ast.stmt.ExprCaseLabel;
+import com.graphicsfuzz.common.ast.stmt.ForStmt;
+import com.graphicsfuzz.common.ast.stmt.IfStmt;
+import com.graphicsfuzz.common.ast.stmt.Stmt;
+import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
+import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
+import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
+import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.IRandom;
+import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.ShaderKind;
+import com.graphicsfuzz.generator.transformation.donation.DonationContext;
+import com.graphicsfuzz.generator.transformation.injection.IInjectionPoint;
+import com.graphicsfuzz.generator.transformation.injection.InjectionPoints;
+import com.graphicsfuzz.generator.util.GenerationParams;
+import com.graphicsfuzz.generator.util.TransformationProbabilities;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DonateDeadCodeTransformationTest {
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  private DonateDeadCodeTransformation getDummyTransformationObject() {
+    return new DonateDeadCodeTransformation(IRandom::nextBoolean, testFolder.getRoot(),
+        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+  }
+
+  @Test
+  public void prepareStatementToDonateTopLevelBreakRemovedWhenNecessary() throws Exception {
+
+    // Checks that a top-level 'break' gets removed, unless injecting into a loop or switch.
+
+    final DonateDeadCodeTransformation dlc = getDummyTransformationObject();
+    final TranslationUnit donor = ParseHelper.parse("#version 310 es\n"
+        + "void main() {\n"
+        + "  for (int i = 0; i < 10; i ++)\n"
+        + "     if (i > 5) break;\n"
+        + "}\n");
+
+    final TranslationUnit reference = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  ;\n"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "    switch (i) {\n"
+        + "      case 0:\n"
+        + "        i++;\n"
+        + "      default:\n"
+        + "        i++;\n"
+        + "    }\n"
+        + "  }"
+        + "}\n");
+
+    for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
+        item -> true).getAllInjectionPoints()) {
+      final Stmt toDonate = ((ForStmt) donor.getMainFunction().getBody().getStmt(0)).getBody()
+          .clone();
+      assert toDonate instanceof IfStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
+      final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
+          TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
+          ShadingLanguageVersion.ESSL_310);
+      final boolean containsBreak = new CheckPredicateVisitor() {
+        @Override
+        public void visitBreakStmt(BreakStmt breakStmt) {
+          predicateHolds();
+        }
+      }.test(donated);
+      assertEquals(containsBreak, injectionPoint.inLoop() || injectionPoint.inSwitch());
+    }
+  }
+
+  @Test
+  public void prepareStatementToDonateTopLevelContinueRemovedWhenNecessary() throws Exception {
+
+    // Checks that a top-level 'continue' gets removed, unless injecting into a loop.
+
+    final DonateDeadCodeTransformation dlc = getDummyTransformationObject();
+    final TranslationUnit donor = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  for (int i = 0; i < 10; i ++)\n"
+        + "     if (i > 5) continue;\n"
+        + "\n"
+        + "}\n");
+
+    final TranslationUnit reference = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  ;\n"
+        + "  switch(0) {\n"
+        + "    case 1:\n"
+        + "      break;\n"
+        + "    default:\n"
+        + "      1;\n"
+        + "  }\n"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "    ;\n"
+        + "  }\n"
+        + "}\n");
+
+    for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
+        item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = ((ForStmt) donor.getMainFunction().getBody().getStmt(0)).getBody()
+          .clone();
+      assert toDonate instanceof IfStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
+      final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
+          TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
+          ShadingLanguageVersion.ESSL_100);
+
+      final boolean containsContinue = new CheckPredicateVisitor() {
+        @Override
+        public void visitContinueStmt(ContinueStmt continueStmt) {
+          predicateHolds();
+        }
+      }.test(donated);
+      assertEquals(containsContinue, injectionPoint.inLoop());
+    }
+
+  }
+
+  @Test
+  public void prepareStatementToDonateTopLevelCaseAndDefaultRemoved() throws Exception {
+    // Checks that top-level 'case' and 'default' labels get removed, even when injecting into
+    // a switch.
+
+    final DonateDeadCodeTransformation dlc = getDummyTransformationObject();
+    final TranslationUnit donor = ParseHelper.parse("#version 310 es\n"
+        + "void main() {\n"
+        + "  int x = 3;\n"
+        + "  switch (x) {\n"
+        + "    case 0:\n"
+        + "      x++;\n"
+        + "    default:\n"
+        + "      x++;\n"
+        + "  }\n"
+        + "}\n");
+
+    final TranslationUnit reference = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  switch (0) {\n"
+        + "    case 1:\n"
+        + "      1;\n"
+        + "    default:\n"
+        + "      2;\n"
+        + "  }\n"
+        + "}\n");
+
+    for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
+        item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = ((SwitchStmt) donor.getMainFunction().getBody().getStmt(1)).getBody()
+          .clone();
+
+      DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
+      final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
+          TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
+          ShadingLanguageVersion.ESSL_310);
+
+      new StandardVisitor() {
+        @Override
+        public void visitDefaultCaseLabel(DefaultCaseLabel defaultCaseLabel) {
+          // 'default' labels should have been removed.
+          fail();
+        }
+
+        @Override
+        public void visitExprCaseLabel(ExprCaseLabel exprCaseLabel) {
+          // 'case' labels should have been removed.
+          fail();
+        }
+      }.visit(donated);
+    }
+  }
+
+  @Test
+  public void prepareStatementToDonateBreakFromLoopKept() throws Exception {
+    // Checks that a 'break' in a loop gets kept if the whole loop is donated.
+
+    final DonateDeadCodeTransformation dlc = getDummyTransformationObject();
+    final TranslationUnit donor = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  for (int i = 0; i < 10; i ++)\n"
+        + "     if (i > 5) break;\n"
+        + "\n"
+        + "}\n");
+
+    final TranslationUnit reference = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  ;\n"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "  }\n"
+        + "}\n");
+
+    for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
+        item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0).clone();
+      assert toDonate instanceof ForStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
+      final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
+          TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
+          ShadingLanguageVersion.ESSL_100);
+      assertTrue(new CheckPredicateVisitor() {
+        @Override
+        public void visitBreakStmt(BreakStmt breakStmt) {
+          predicateHolds();
+        }
+      }.test(donated));
+    }
+  }
+
+  @Test
+  public void prepareStatementToDonateSwitchWithBreakAndDefaultKept() throws Exception {
+    // Checks that 'case', 'default' and 'break' occurring in a switch are kept if the whole
+    // switch statement is donated.
+
+    final DonateDeadCodeTransformation dlc = getDummyTransformationObject();
+    final TranslationUnit donor = ParseHelper.parse("#version 310 es\n"
+        + "void main() {\n"
+        + "  switch (0) {\n"
+        + "    case 0:\n"
+        + "      1;\n"
+        + "      break;\n"
+        + "    default:\n"
+        + "      2;\n"
+        + "  }\n"
+        + "}\n");
+
+    final TranslationUnit reference = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  ;\n"
+        + "  switch (0) {\n"
+        + "    case 1:\n"
+        + "      1;\n"
+        + "    default:\n"
+        + "      2;\n"
+        + "  }\n"
+        + "}\n");
+
+    for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
+        item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0).clone();
+      assert toDonate instanceof SwitchStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
+      final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
+          TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
+          ShadingLanguageVersion.ESSL_310);
+
+      // Check that the donated statement contains exactly one each of 'break', 'case' and
+      // 'default'.
+      new StandardVisitor() {
+
+        private boolean foundBreak = false;
+        private boolean foundCase = false;
+        private boolean foundDefault = false;
+
+        @Override
+        public void visitBreakStmt(BreakStmt breakStmt) {
+          assertFalse(foundBreak);
+          foundBreak = true;
+        }
+
+        @Override
+        public void visitExprCaseLabel(ExprCaseLabel exprCaseLabel) {
+          assertFalse(foundCase);
+          foundCase = true;
+        }
+
+        @Override
+        public void visitDefaultCaseLabel(DefaultCaseLabel defaultCaseLabel) {
+          assertFalse(foundDefault);
+          foundDefault = true;
+        }
+
+        private void check(Stmt stmt) {
+          visit(stmt);
+          assertTrue(foundBreak);
+          assertTrue(foundCase);
+          assertTrue(foundDefault);
+        }
+      };
+    }
+  }
+
+  @Test
+  public void prepareStatementToDonateContinueInLoopKept() throws Exception {
+    // Checks that a 'continue' in a loop gets kept if the whole loop is donated.
+
+    final DonateDeadCodeTransformation dlc = getDummyTransformationObject();
+    final TranslationUnit donor = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  for (int i = 0; i < 10; i ++)\n"
+        + "     if (i > 5) continue;\n"
+        + "\n"
+        + "}\n");
+
+    final TranslationUnit reference = ParseHelper.parse("#version 100\n"
+        + "void main() {\n"
+        + "  ;\n"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "  }\n"
+        + "}\n");
+
+    for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
+        item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0).clone();
+      assert toDonate instanceof ForStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
+      final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
+          TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
+          ShadingLanguageVersion.ESSL_100);
+
+      // Check that the 'continue' statement is retained.
+      assertTrue(new CheckPredicateVisitor() {
+        @Override
+        public void visitContinueStmt(ContinueStmt continueStmt) {
+          predicateHolds();
+        }
+      }.test(donated));
+    }
+  }
+
+}

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
@@ -124,7 +124,7 @@ public class DonateLiveCodeTransformationTest {
                 super.visitBlockStmt(stmt);
                 if (stmt.getNumStmts() == 0) {
                   blockInjectionPoint = new BlockInjectionPoint(stmt, null, getEnclosingFunction(),
-                        false, getCurrentScope());
+                        false, false, getCurrentScope());
                 }
               }
 

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
@@ -41,7 +41,6 @@ import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
-import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.typing.ScopeEntry;
 import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
 import com.graphicsfuzz.common.util.IRandom;
@@ -107,31 +106,33 @@ public class DonateLiveCodeTransformationTest {
 
     final DonateLiveCodeTransformation dlc = getDummyTransformationObject();
     final TranslationUnit donor = ParseHelper.parse("#version 310 es\n"
-        + "void main() {"
+        + "void main() {\n"
         + "  for (int i = 0; i < 10; i ++)\n"
         + "     if (i > 5) break;\n"
-        + "\n"
         + "}\n");
-    final Stmt toDonate = ((ForStmt) donor.getMainFunction().getBody().getStmt(0)).getBody();
-    assert toDonate instanceof IfStmt;
-
-    DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
-        new ArrayList<>(), donor.getMainFunction());
 
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
-        + "  for(int i = 0; i < 100; i++) {"
+        + "  for(int i = 0; i < 100; i++) {\n"
         + "    switch (i) {\n"
         + "      case 0:\n"
         + "        i++;\n"
         + "      default:\n"
         + "        i++;\n"
         + "    }\n"
-        + "  }"
+        + "  }\n"
         + "}\n");
 
     for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
         item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = ((ForStmt) donor.getMainFunction().getBody().getStmt(0)).getBody()
+          .clone();
+      assert toDonate instanceof IfStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
       final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
           TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
           ShadingLanguageVersion.ESSL_310);
@@ -150,25 +151,26 @@ public class DonateLiveCodeTransformationTest {
 
     final DonateLiveCodeTransformation dlc = getDummyTransformationObject();
     final TranslationUnit donor = ParseHelper.parse("#version 100\n"
-        + "void main() {"
+        + "void main() {\n"
         + "  for (int i = 0; i < 10; i ++)\n"
         + "     if (i > 5) continue;\n"
-        + "\n"
         + "}\n");
-    final Stmt toDonate = ((ForStmt) donor.getMainFunction().getBody().getStmt(0)).getBody();
-    assert toDonate instanceof IfStmt;
-
-    DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
-        new ArrayList<>(), donor.getMainFunction());
 
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
-        + "  for(int i = 0; i < 100; i++) {"
-        + "  }"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "  }\n"
         + "}\n");
 
     for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
         item -> true).getAllInjectionPoints()) {
+      final Stmt toDonate = ((ForStmt) donor.getMainFunction().getBody().getStmt(0)).getBody()
+          .clone();
+      assert toDonate instanceof IfStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
       final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
           TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
           ShadingLanguageVersion.ESSL_100);
@@ -187,7 +189,7 @@ public class DonateLiveCodeTransformationTest {
 
     final DonateLiveCodeTransformation dlc = getDummyTransformationObject();
     final TranslationUnit donor = ParseHelper.parse("#version 310 es\n"
-        + "void main() {"
+        + "void main() {\n"
         + "  int x = 3;\n"
         + "  switch (x) {\n"
         + "    case 0:\n"
@@ -196,10 +198,6 @@ public class DonateLiveCodeTransformationTest {
         + "      x++;\n"
         + "  }\n"
         + "}\n");
-    final Stmt toDonate = ((SwitchStmt) donor.getMainFunction().getBody().getStmt(1)).getBody();
-
-    DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
-        new ArrayList<>(), donor.getMainFunction());
 
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
@@ -213,6 +211,13 @@ public class DonateLiveCodeTransformationTest {
 
     for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
         item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = ((SwitchStmt) donor.getMainFunction().getBody().getStmt(1)).getBody()
+          .clone();
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
       final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
           TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
           ShadingLanguageVersion.ESSL_310);
@@ -233,26 +238,28 @@ public class DonateLiveCodeTransformationTest {
 
     final DonateLiveCodeTransformation dlc = getDummyTransformationObject();
     final TranslationUnit donor = ParseHelper.parse("#version 100\n"
-        + "void main() {"
+        + "void main() {\n"
         + "  for (int i = 0; i < 10; i ++)\n"
         + "     if (i > 5) break;\n"
-        + "\n"
         + "}\n");
-    final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0);
-    assert toDonate instanceof ForStmt;
-
-    DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
-        new ArrayList<>(), donor.getMainFunction());
 
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
         + "  ;\n"
-        + "  for(int i = 0; i < 100; i++) {"
-        + "  }"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "  }\n"
         + "}\n");
 
     for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
         item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0)
+          .clone();
+      assert toDonate instanceof ForStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
       final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
           TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
           ShadingLanguageVersion.ESSL_100);
@@ -275,7 +282,7 @@ public class DonateLiveCodeTransformationTest {
 
     final DonateLiveCodeTransformation dlc = getDummyTransformationObject();
     final TranslationUnit donor = ParseHelper.parse("#version 310 es\n"
-        + "void main() {"
+        + "void main() {\n"
         + "  switch (0) {\n"
         + "    case 0:\n"
         + "      1;\n"
@@ -284,11 +291,6 @@ public class DonateLiveCodeTransformationTest {
         + "      2;\n"
         + "  }\n"
         + "}\n");
-    final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0);
-    assert toDonate instanceof SwitchStmt;
-
-    DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
-        new ArrayList<>(), donor.getMainFunction());
 
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
@@ -303,6 +305,13 @@ public class DonateLiveCodeTransformationTest {
 
     for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
         item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0).clone();
+      assert toDonate instanceof SwitchStmt;
+
+      final DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
       final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
           TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
           ShadingLanguageVersion.ESSL_310);
@@ -325,26 +334,27 @@ public class DonateLiveCodeTransformationTest {
 
     final DonateLiveCodeTransformation dlc = getDummyTransformationObject();
     final TranslationUnit donor = ParseHelper.parse("#version 100\n"
-        + "void main() {"
+        + "void main() {\n"
         + "  for (int i = 0; i < 10; i ++)\n"
         + "     if (i > 5) continue;\n"
-        + "\n"
         + "}\n");
-    final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0);
-    assert toDonate instanceof ForStmt;
-
-    DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
-        new ArrayList<>(), donor.getMainFunction());
 
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
         + "  ;\n"
-        + "  for(int i = 0; i < 100; i++) {"
-        + "  }"
+        + "  for(int i = 0; i < 100; i++) {\n"
+        + "  }\n"
         + "}\n");
 
     for (IInjectionPoint injectionPoint : new InjectionPoints(reference, new RandomWrapper(0),
         item -> true).getAllInjectionPoints()) {
+
+      final Stmt toDonate = donor.getMainFunction().getBody().getStmt(0).clone();
+      assert toDonate instanceof ForStmt;
+
+      DonationContext dc = new DonationContext(toDonate, new HashMap<>(),
+          new ArrayList<>(), donor.getMainFunction());
+
       final Stmt donated = dlc.prepareStatementToDonate(injectionPoint, dc,
           TransformationProbabilities.DEFAULT_PROBABILITIES, new RandomWrapper(0),
           ShadingLanguageVersion.ESSL_100);
@@ -367,12 +377,12 @@ public class DonateLiveCodeTransformationTest {
     // here in the spirit of "why delete a test?"
 
     final String reference = "#version 300 es\n"
-          + "void main() {"
-          + "  int t;"
-          + "  {"
-          + "  }"
-          + "  gl_FragColor = vec4(float(t));"
-          + "}";
+          + "void main() {\n"
+          + "  int t;\n"
+          + "  {\n"
+          + "  }\n"
+          + "  gl_FragColor = vec4(float(t));\n"
+          + "}\n";
 
     final IRandom generator = new RandomWrapper(0);
 
@@ -500,9 +510,8 @@ public class DonateLiveCodeTransformationTest {
 
     {
       final String referenceSource = "#version 300 es\n"
-          + "void main() {"
-          + "  "
-          + "}";
+          + "void main() {\n"
+          + "}\n";
 
       fileOps.writeShaderJobFileFromImageJob(
           new ImageJob()
@@ -567,9 +576,8 @@ public class DonateLiveCodeTransformationTest {
 
     {
       final String referenceSource = "#version 300 es\n"
-          + "void main() {"
-          + "  "
-          + "}";
+          + "void main() {\n"
+          + "}\n";
 
       fileOps.writeShaderJobFileFromImageJob(
           new ImageJob()
@@ -620,19 +628,19 @@ public class DonateLiveCodeTransformationTest {
       final String donorSource =
           "#version 300 es\n"
               + "void main() {\n"
-              + " int x = 0;"
-              + " {"
-              + "  int A[1];"
-              + "  A[x] = 42;"
-              + "  {"
-              + "   int B[1];"
-              + "   B[x] = 42;"
-              + "   {"
-              + "    int C[1];"
-              + "    C[x] = 42;"
-              + "   }"
-              + "  }"
-              + " }"
+              + " int x = 0;\n"
+              + " {\n"
+              + "  int A[1];\n"
+              + "  A[x] = 42;\n"
+              + "  {\n"
+              + "   int B[1];\n"
+              + "   B[x] = 42;\n"
+              + "   {\n"
+              + "    int C[1];\n"
+              + "    C[x] = 42;\n"
+              + "   }\n"
+              + "  }\n"
+              + " }\n"
               + "}\n";
 
       fileOps.writeShaderJobFileFromImageJob(
@@ -645,9 +653,8 @@ public class DonateLiveCodeTransformationTest {
 
     {
       final String referenceSource = "#version 300 es\n"
-          + "void main() {"
-          + "  "
-          + "}";
+          + "void main() {\n"
+          + "}\n";
 
       fileOps.writeShaderJobFileFromImageJob(
           new ImageJob()

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/SplitForLoopTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/SplitForLoopTransformationTest.java
@@ -94,6 +94,11 @@ public class SplitForLoopTransformationTest {
           }
 
           @Override
+          public boolean inSwitch() {
+            throw new RuntimeException();
+          }
+
+          @Override
           public FunctionDefinition getEnclosingFunction() {
             throw new RuntimeException();
           }

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/InjectionPointTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/InjectionPointTest.java
@@ -34,7 +34,7 @@ public class InjectionPointTest {
 
     final Scope scope = new Scope(null);
     assertNotNull(
-      new InjectionPoint(null, false, scope) {
+      new InjectionPoint(null, false, false, scope) {
 
         @Override
         public void inject(Stmt stmt) {
@@ -64,7 +64,7 @@ public class InjectionPointTest {
   public void testThatScopeIsCloned() {
     Scope s = new Scope(null);
     s.add("v", BasicType.INT, Optional.empty());
-    IInjectionPoint injectionPoint = new InjectionPoint(null, false, s) {
+    IInjectionPoint injectionPoint = new InjectionPoint(null, false, false, s) {
       @Override
       public void inject(Stmt stmt) {
         throw new RuntimeException();


### PR DESCRIPTION
Adds checks to make sure that we don't inject top-level 'case' or
'default' labels into code, by being aware of switch statements during
donation.  Does allow the insertion of top-level break statements into
switch statements (which was previously disallowed due to switch
statements not being considered, and loops being regarded as the only
acceptable place to add break statements).

Fixes #665.