### PR TITLE
Expression Generator: Add global initializer method

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/knownvaluegeneration/ExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/knownvaluegeneration/ExpressionGenerator.java
@@ -501,8 +501,8 @@ public class ExpressionGenerator {
 
     if (atGlobalScope) {
       // Searching for the already declared globals initializer's function prototype, if not found,
-      // we have to generate a new prototype, function and a function call expression at the top
-      // level of main method to invoke the initializer function.
+      // we have to generate a new prototype, function definition and a function call expression at
+      // the top level of main method to invoke the initializer function.
       FunctionDefinition initGlobalsFunction = translationUnit.getTopLevelDeclarations()
           .stream()
           .filter(item -> item instanceof FunctionDefinition)

--- a/util/src/main/java/com/graphicsfuzz/util/Constants.java
+++ b/util/src/main/java/com/graphicsfuzz/util/Constants.java
@@ -50,6 +50,7 @@ public final class Constants {
   public static final String GLF_COMPUTE = "_GLF_COMPUTE";
   public static final String GLF_PARAM = "_GLF_PARAM";
   public static final String GLF_UNKNOWN_PARAM = "GLF_UNKNOWN_PARAM";
+  public static final String GLF_INIT_GLOBALS = "_GLF_init_globals";
 
 
   public static final String INJECTED_LOOP_COUNTER = "_injected_loop_counter";


### PR DESCRIPTION
Fixes #652:

This PR adds a new implementation for generating a new method, `_GLF_init_globals`, that is in charge of initializing the global scope variables. 

```
void _GLF_init_globals();  // function prototype.

float foo;
void main() {
     _GLF_init_globals(); // invokes a function to initialize global vars.
}

void _GLF_init_globals() { // function that assigns values for global vars.
    foo = 1.0;
}
```