### PR TITLE
 gfauto: fix issue in tool

### DIFF
--- a/gfauto/gfauto/tool.py
+++ b/gfauto/gfauto/tool.py
@@ -252,12 +252,11 @@ def glsl_shader_job_crash_to_amber_script_for_google_cts(
             )
         )
 
-    if not spirv_opt_args:
+    if test_metadata_path:
         check(
-            bool(test_metadata_path),
-            AssertionError("Must have test_metadata_path or binary_paths"),
+            bool(not spirv_opt_args),
+            AssertionError("Cannot have spirv_opt_args AND test_metadata_path"),
         )
-        assert test_metadata_path  # noqa
         spirv_opt_args = list(
             test_util.metadata_read_from_path(test_metadata_path).glsl.spirv_opt_args
         )

--- a/gfauto/temp/.gitignore
+++ b/gfauto/temp/.gitignore
@@ -1,0 +1,3 @@
+
+*
+!/.gitignore


### PR DESCRIPTION
Don't require test metadata if you don't provide spirv_opt_args.

Also add temp directory that is ignored.