### PR TITLE
gfauto: generate amber code for comparing two shader jobs

### DIFF
--- a/gfauto/gfauto/amber_converter.py
+++ b/gfauto/gfauto/amber_converter.py
@@ -562,9 +562,9 @@ def graphics_shader_job_amber_test_to_amber_script(
 
     # Add fuzzy compare of framebuffers if there's more than one pipeline
 
-    for pipeline_index in range(len(jobs) - 1):
+    for pipeline_index in range(1, len(jobs)):
         prefix0 = jobs[0].name_prefix
-        prefix1 = jobs[pipeline_index + 1].name_prefix
+        prefix1 = jobs[pipeline_index].name_prefix
         result += f"EXPECT {prefix0}_framebuffer RMSE_BUFFER {prefix1}_framebuffer TOLERANCE 7"
 
     if amberfy_settings.extra_commands:

--- a/gfauto/gfauto/amber_converter.py
+++ b/gfauto/gfauto/amber_converter.py
@@ -521,7 +521,8 @@ def graphics_shader_job_amber_test_to_amber_script(
     jobs = [shader_job_amber_test.variant]
 
     if shader_job_amber_test.reference:
-        jobs.append(shader_job_amber_test.reference)
+        assert isinstance(shader_job_amber_test.reference, GraphicsShaderJob)  # noqa
+        jobs.insert(0, shader_job_amber_test.reference)
 
     for job in jobs:
         prefix = job.name_prefix
@@ -531,15 +532,11 @@ def graphics_shader_job_amber_test_to_amber_script(
 
         # Define shaders.
 
-        result += get_amber_script_shader_def(
-            job.vertex_shader, vertex_shader_name
-        )
+        result += get_amber_script_shader_def(job.vertex_shader, vertex_shader_name)
 
-        result += get_amber_script_shader_def(
-            job.fragment_shader, fragment_shader_name
-        )
+        result += get_amber_script_shader_def(job.fragment_shader, fragment_shader_name)
 
-        # Define uniforms for variant shader job.
+        # Define uniforms for shader job.
 
         result += "\n"
         result += job.uniform_definitions

--- a/gfauto/gfauto/amber_converter.py
+++ b/gfauto/gfauto/amber_converter.py
@@ -563,9 +563,9 @@ def graphics_shader_job_amber_test_to_amber_script(
     # Add fuzzy compare of framebuffers if there's more than one pipeline
 
     for pipeline_index in range(1, len(jobs)):
-        prefix0 = jobs[0].name_prefix
-        prefix1 = jobs[pipeline_index].name_prefix
-        result += f"EXPECT {prefix0}_framebuffer RMSE_BUFFER {prefix1}_framebuffer TOLERANCE 7"
+        prefix_0 = jobs[0].name_prefix
+        prefix_1 = jobs[pipeline_index].name_prefix
+        result += f"EXPECT {prefix_0}_framebuffer RMSE_BUFFER {prefix_1}_framebuffer TOLERANCE 7"
 
     if amberfy_settings.extra_commands:
         result += amberfy_settings.extra_commands

--- a/gfauto/gfauto/amber_converter.py
+++ b/gfauto/gfauto/amber_converter.py
@@ -513,51 +513,62 @@ def get_amber_script_shader_def(shader: Shader, name: str) -> str:
 def graphics_shader_job_amber_test_to_amber_script(
     shader_job_amber_test: ShaderJobBasedAmberTest, amberfy_settings: AmberfySettings
 ) -> str:
-    # TODO: handle reference, if present.
-
     # Guaranteed, and needed for type checker.
     assert isinstance(shader_job_amber_test.variant, GraphicsShaderJob)  # noqa
 
     result = get_amber_script_header(amberfy_settings)
 
-    variant = shader_job_amber_test.variant
+    jobs = [shader_job_amber_test.variant]
 
-    variant_vertex_shader_name = f"{variant.name_prefix}_vertex_shader"
-    variant_fragment_shader_name = f"{variant.name_prefix}_fragment_shader"
+    if shader_job_amber_test.reference:
+        jobs.append(shader_job_amber_test.reference)
 
-    # Define shaders.
+    for job in jobs:
+        prefix = job.name_prefix
 
-    result += get_amber_script_shader_def(
-        variant.vertex_shader, variant_vertex_shader_name
-    )
+        vertex_shader_name = f"{prefix}_vertex_shader"
+        fragment_shader_name = f"{prefix}_fragment_shader"
 
-    result += get_amber_script_shader_def(
-        variant.fragment_shader, variant_fragment_shader_name
-    )
+        # Define shaders.
 
-    # Define uniforms for variant shader job.
+        result += get_amber_script_shader_def(
+            job.vertex_shader, vertex_shader_name
+        )
 
-    result += "\n"
-    result += variant.uniform_definitions
+        result += get_amber_script_shader_def(
+            job.fragment_shader, fragment_shader_name
+        )
 
-    # Currently, this buffer must be called "framebuffer" to be able to dump it from Amber.
-    result += "\nBUFFER framebuffer FORMAT B8G8R8A8_UNORM\n"
+        # Define uniforms for variant shader job.
 
-    # Create a pipeline that uses the variant shaders and writes the output to "framebuffer".
+        result += "\n"
+        result += job.uniform_definitions
 
-    result += "\nPIPELINE graphics gfz_pipeline\n"
-    result += f"  ATTACH {variant_vertex_shader_name}\n"
-    result += f"  ATTACH {variant_fragment_shader_name}\n"
-    result += "  FRAMEBUFFER_SIZE 256 256\n"
-    result += "  BIND BUFFER framebuffer AS color LOCATION 0\n"
-    result += variant.uniform_bindings
-    result += "END\n"
-    result += "CLEAR_COLOR gfz_pipeline 0 0 0 255\n"
+        result += f"\nBUFFER {prefix}_framebuffer FORMAT B8G8R8A8_UNORM\n"
 
-    # Run the pipeline.
+        # Create a pipeline.
 
-    result += "\nCLEAR gfz_pipeline\n"
-    result += "RUN gfz_pipeline DRAW_RECT POS 0 0 SIZE 256 256\n"
+        result += f"\nPIPELINE graphics {prefix}_pipeline\n"
+        result += f"  ATTACH {vertex_shader_name}\n"
+        result += f"  ATTACH {fragment_shader_name}\n"
+        result += "  FRAMEBUFFER_SIZE 256 256\n"
+        result += f"  BIND BUFFER {prefix}_framebuffer AS color LOCATION 0\n"
+        result += job.uniform_bindings
+        result += "END\n"
+        result += f"CLEAR_COLOR {prefix}_pipeline 0 0 0 255\n"
+
+        # Run the pipeline.
+
+        result += f"\nCLEAR {prefix}_pipeline\n"
+        result += f"RUN {prefix}_pipeline DRAW_RECT POS 0 0 SIZE 256 256\n"
+        result += "\n"
+
+    # Add fuzzy compare of framebuffers if there's more than one pipeline
+
+    for pipeline_index in range(len(jobs) - 1):
+        prefix0 = jobs[0].name_prefix
+        prefix1 = jobs[pipeline_index + 1].name_prefix
+        result += f"EXPECT {prefix0}_framebuffer RMSE_BUFFER {prefix1}_framebuffer TOLERANCE 7"
 
     if amberfy_settings.extra_commands:
         result += amberfy_settings.extra_commands

--- a/gfauto/gfauto/android_device.py
+++ b/gfauto/gfauto/android_device.py
@@ -233,7 +233,7 @@ def run_amber_on_device_helper(
         amber_flags += " -ps"
     else:
         if dump_image:
-            amber_flags += f" -i {fuzz.IMAGE_FILE_NAME}"
+            amber_flags += f" -i {fuzz.IMAGE_FILE_NAME} -I variant_framebuffer"
         if dump_buffer:
             amber_flags += f" -b {fuzz.BUFFER_FILE_NAME} -B 0"
 

--- a/gfauto/gfauto/host_device_util.py
+++ b/gfauto/gfauto/host_device_util.py
@@ -89,6 +89,8 @@ def run_amber_helper(
         if dump_image:
             cmd.append("-i")
             cmd.append(str(image_file))
+            cmd.append("-I")
+            cmd.append("variant_framebuffer")
         if dump_buffer:
             cmd.append("-b")
             cmd.append(str(buffer_file))

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -171,7 +171,7 @@ unindexed
 vec2
 vec4
 framebuffer
-gfautotests
 framebuffers
+gfautotests
 cdb
 Dbg

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -172,6 +172,4 @@ vec2
 vec4
 framebuffer
 gfautotests
-prefix0
-prefix1
 framebuffers

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -172,3 +172,6 @@ vec2
 vec4
 framebuffer
 gfautotests
+prefix0
+prefix1
+framebuffers


### PR DESCRIPTION
Modified amber generation script to add two pipelines and comparison of their framebuffers when reference shader job is present.