### PR TITLE
Use '1;' instead of ';' when replacing jump statements

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveDiscardStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveDiscardStatements.java
@@ -18,14 +18,12 @@ package com.graphicsfuzz.generator.util;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.stmt.DiscardStmt;
-import com.graphicsfuzz.common.ast.stmt.NullStmt;
-import java.util.Optional;
 
 public class RemoveDiscardStatements extends RemoveStatements {
 
   public RemoveDiscardStatements(IAstNode node) {
     super(item -> item instanceof DiscardStmt,
-        item -> Optional.of(new NullStmt()), node);
+        item -> makeIntConstantExprStmt(), node);
   }
 
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateBreakStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateBreakStatements.java
@@ -20,10 +20,8 @@ import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.stmt.BreakStmt;
 import com.graphicsfuzz.common.ast.stmt.DoStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
-import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
 import com.graphicsfuzz.common.ast.stmt.WhileStmt;
-import java.util.Optional;
 
 /**
  * This class removes break statements that are not nested inside loop or switch statements.
@@ -32,7 +30,7 @@ public class RemoveImmediateBreakStatements extends RemoveStatements {
 
   public RemoveImmediateBreakStatements(IAstNode node) {
     super(item -> item instanceof BreakStmt,
-        item -> Optional.of(new NullStmt()), node);
+        item -> makeIntConstantExprStmt(), node);
   }
 
   @Override

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateCaseLabels.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateCaseLabels.java
@@ -18,9 +18,7 @@ package com.graphicsfuzz.generator.util;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.stmt.CaseLabel;
-import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
-import java.util.Optional;
 
 /**
  * This class removes case labels (including default) that are not nested inside switch statements.
@@ -29,7 +27,7 @@ public class RemoveImmediateCaseLabels extends RemoveStatements {
 
   public RemoveImmediateCaseLabels(IAstNode node) {
     super(item -> item instanceof CaseLabel,
-        item -> Optional.of(new NullStmt()), node);
+        item -> makeIntConstantExprStmt(), node);
   }
 
   @Override

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateContinueStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveImmediateContinueStatements.java
@@ -20,9 +20,7 @@ import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.stmt.ContinueStmt;
 import com.graphicsfuzz.common.ast.stmt.DoStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
-import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.WhileStmt;
-import java.util.Optional;
 
 /**
  * This class removes continue statements that are not nested inside loops.
@@ -31,7 +29,7 @@ public class RemoveImmediateContinueStatements extends RemoveStatements {
 
   public RemoveImmediateContinueStatements(IAstNode node) {
     super(item -> item instanceof ContinueStmt,
-        item -> Optional.of(new NullStmt()), node);
+        item -> makeIntConstantExprStmt(), node);
   }
 
   @Override

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveReturnStatements.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RemoveReturnStatements.java
@@ -26,8 +26,8 @@ public class RemoveReturnStatements extends RemoveStatements {
   public RemoveReturnStatements(IAstNode node) {
     super(item -> item instanceof ReturnStmt,
         item -> ((ReturnStmt) item).hasExpr()
-            ? Optional.of(new ExprStmt(((ReturnStmt) item).getExpr()))
-            : Optional.empty(),
+            ? new ExprStmt(((ReturnStmt) item).getExpr())
+            : makeIntConstantExprStmt(),
         node);
   }
 

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
@@ -138,7 +138,7 @@ public class DonateLiveCodeTransformationTest {
           ShadingLanguageVersion.ESSL_310);
       assertEquals("{\n"
           + " if(i > 5)\n"
-          + "  ;\n"
+          + "  1;\n"
           + "}\n", donated.getText());
     }
 
@@ -159,6 +159,7 @@ public class DonateLiveCodeTransformationTest {
     final TranslationUnit reference = ParseHelper.parse("#version 100\n"
         + "void main() {\n"
         + "  for(int i = 0; i < 100; i++) {\n"
+        + "      1;\n"
         + "  }\n"
         + "}\n");
 
@@ -176,7 +177,7 @@ public class DonateLiveCodeTransformationTest {
           ShadingLanguageVersion.ESSL_100);
       assertEquals("{\n"
           + " if(i > 5)\n"
-          + "  ;\n"
+          + "  1;\n"
           + "}\n", donated.getText());
     }
 
@@ -223,9 +224,9 @@ public class DonateLiveCodeTransformationTest {
           ShadingLanguageVersion.ESSL_310);
       assertEquals("{\n"
           + " {\n"
-          + "  ;\n"
+          + "  1;\n"
           + "  x ++;\n"
-          + "  ;\n"
+          + "  1;\n"
           + "  x ++;\n"
           + " }\n"
           + "}\n", donated.getText());

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/RemoveReturnStatementsTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/RemoveReturnStatementsTest.java
@@ -29,7 +29,7 @@ public class RemoveReturnStatementsTest {
   @Test
   public void testDo() throws Exception {
     final String prog = "void main() { do return; while(true); }";
-    final String expectedProg = "void main() { do ; while(true); }";
+    final String expectedProg = "void main() { do 1; while(true); }";
     TranslationUnit tu = ParseHelper.parse(prog);
     new RemoveReturnStatements(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expectedProg)),
@@ -39,7 +39,7 @@ public class RemoveReturnStatementsTest {
   @Test
   public void testWhile() throws Exception {
     final String prog = "void main() { while(true) return; }";
-    final String expectedProg = "void main() { while(true) ; }";
+    final String expectedProg = "void main() { while(true) 1; }";
     TranslationUnit tu = ParseHelper.parse(prog);
     new RemoveReturnStatements(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expectedProg)),
@@ -49,7 +49,7 @@ public class RemoveReturnStatementsTest {
   @Test
   public void testFor() throws Exception {
     final String prog = "void main() { for(int i = 0; i < 100; i++) return; }";
-    final String expectedProg = "void main() { for(int i = 0; i < 100; i++) ; }";
+    final String expectedProg = "void main() { for(int i = 0; i < 100; i++) 1; }";
     TranslationUnit tu = ParseHelper.parse(prog);
     new RemoveReturnStatements(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expectedProg)),
@@ -59,7 +59,27 @@ public class RemoveReturnStatementsTest {
   @Test
   public void testIf() throws Exception {
     final String prog = "void main() { if(true) return; else return; }";
-    final String expectedProg = "void main() { if(true) ; else ; }";
+    final String expectedProg = "void main() { if(true) 1; else 1; }";
+    TranslationUnit tu = ParseHelper.parse(prog);
+    new RemoveReturnStatements(tu);
+    assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expectedProg)),
+        PrettyPrinterVisitor.prettyPrintAsString(tu));
+  }
+
+  @Test
+  public void testSwitch() throws Exception {
+    final String prog = "void main() {\n"
+        + "  switch(0) {\n"
+        + "    case 0:\n"
+        + "      return;\n"
+        + "  }\n"
+        + "}\n";
+    final String expectedProg = "void main() {\n"
+        + "  switch(0) {\n"
+        + "    case 0:\n"
+        + "      1;\n"
+        + "  }\n"
+        + "}\n";
     TranslationUnit tu = ParseHelper.parse(prog);
     new RemoveReturnStatements(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expectedProg)),


### PR DESCRIPTION
Before this change, the null statement, ';', was used when replacing
break, continue, case label and discard statements during live code
injection, and void return statements were completely removed.  The
latter - completely removing a return - caused problems when a return
appeared at the end of a switch statement.  Since it is questionable
whether it is OK for the final case/default label of a switch to be
followed by simply a null statement (e.g. glslangValidator gives a
warning about this), this change makes it so that the statement '1;'
is used in all cases where a null statement was previously used, and
is also used as a replacement for a void return.

Fixes #718.