### PR TITLE
Prevent the reducer from trying to simplify case labels

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
@@ -94,7 +94,10 @@ public abstract class ReductionOpportunitiesBase
 
   @Override
   public void visitExprCaseLabel(ExprCaseLabel exprCaseLabel) {
-    super.visitExprCaseLabel(exprCaseLabel);
+    // Do *not* invoke super.visitExprCaseLabel(...), as we do not wish to look for opportunities
+    // to simplify the literal expression that is used as a case label.  Literals are simple enough
+    // already, and attempting to change the value of a case label literal runs the risk of
+    // introducing duplicate case labels.
     injectionTracker.notifySwitchCase(exprCaseLabel);
   }
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundExprToSubExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundExprToSubExprReductionOpportunitiesTest.java
@@ -172,4 +172,21 @@ public class CompoundExprToSubExprReductionOpportunitiesTest {
           new RandomWrapper(0), new IdGenerator()));
   }
 
+  @Test
+  public void testSwitch() throws Exception {
+    final String program = "#version 310 es\n"
+        + "void main() {\n"
+        + "  switch(0) {\n"
+        + "    case - 1:\n"
+        + "      1;\n"
+        + "  }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final List<SimplifyExprReductionOpportunity> ops =
+        CompoundExprToSubExprReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+        new ReducerContext(true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+            new IdGenerator()));
+    assertEquals(0, ops.size());
+  }
+
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
@@ -82,4 +82,20 @@ public class ExprToConstantReductionOpportunitiesTest {
     CompareAsts.assertEqualAsts("void main() { int GLF_live3_a; 1; }", tu);
   }
 
+  @Test
+  public void testSwitch() throws Exception {
+    final String program = "#version 310 es\n"
+        + "void main() {\n"
+        + "  switch(0) {\n"
+        + "    case - 1:\n"
+        + "      1;\n"
+        + "  }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+        new ReducerContext(true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+            new IdGenerator()));
+    assertEquals(0, ops.size());
+  }
+
 }


### PR DESCRIPTION
The reducer could throw an exception due to trying to simplify case
statement labels, for which child querying and replacement is not
supported.  Rather than supporting child querying and replacement,
this change prevents the reducer from trying to simplify case labels.
Case labels already need to be literal expressions - so there is not
much to simplify - and changing the values of these literals would be
risky; for example it could easily lead to a switch statement with
duplicate case labels, which is not valid.

Fixes #697.