### PR TITLE
Include GSoC students in list of contributors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,7 @@ Imperial College London
  David MacIver
  Dragos Martac
  Paul Thomson
+
+Independent contributors via Google Summer of Code
+ Abel Briggs
+ Jiradet Ounjai


### PR DESCRIPTION
Added Abel Briggs and Jiradet Ounjai to the list of contributors in
recognition of their contributions to GraphicsFuzz via Google Summer
of Code.