### PR TITLE
gfauto: improvements and fixes to *_cts_gf_tests

### DIFF
--- a/gfauto/gfauto/download_cts_gf_tests.py
+++ b/gfauto/gfauto/download_cts_gf_tests.py
@@ -114,6 +114,13 @@ def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
             amber_file, output_dir=amber_file.parent, binaries=binaries
         )
 
+        zip_files = [
+            util.ZipEntry(f, Path(f.name))
+            for f in sorted(shader_dir.glob(f"{amber_file.stem}.*"))
+        ]
+
+        util.create_zip(amber_file.with_suffix(".zip"), zip_files)
+
 
 GERRIT_COOKIE_ARGUMENT_DESCRIPTION = (
     "The Gerrit cookie used for authentication. To get this, log in to the Khronos Gerrit page in your "

--- a/gfauto/gfauto/run_cts_gf_tests.py
+++ b/gfauto/gfauto/run_cts_gf_tests.py
@@ -37,7 +37,7 @@ from gfauto import (
 DEFAULT_TIMEOUT = 30
 
 
-def main() -> None:  # pylint: disable=too-many-locals,too-many-branches;
+def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements;
     parser = argparse.ArgumentParser(
         description="Runs GraphicsFuzz AmberScript tests on the active devices listed in "
         "the settings.json file."
@@ -70,6 +70,8 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches;
     binaries = binaries_util.BinaryManager()
 
     work_dir = Path() / "temp" / f"cts_run_{fuzz.get_random_name()[:8]}"
+
+    util.mkdirs_p(work_dir)
 
     with util.file_open_text(Path("results.txt"), "w") as log_handle:
 

--- a/gfauto/gfauto/util.py
+++ b/gfauto/gfauto/util.py
@@ -25,9 +25,12 @@ import os
 import pathlib
 import platform
 import shutil
+import zipfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, BinaryIO, Iterator, List, TextIO, cast
+from typing import Any, BinaryIO, Iterator, List, Optional, TextIO, cast
+
+import attr
 
 from gfauto import gflogging
 
@@ -280,3 +283,20 @@ def extract_archive(archive_file: Path, output_dir: Path) -> Path:
     shutil.unpack_archive(str(archive_file), extract_dir=str(output_dir))
     gflogging.log("Done")
     return output_dir
+
+
+@attr.dataclass
+class ZipEntry:
+    path: Path
+    path_in_archive: Optional[Path] = None
+
+
+def create_zip(output_file_path: Path, entries: List[ZipEntry]) -> Path:
+    gflogging.log(f"Creating zip {str(output_file_path)}:")
+    with zipfile.ZipFile(
+        output_file_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as file_handle:
+        for entry in entries:
+            file_handle.write(entry.path, entry.path_in_archive)
+            gflogging.log(f"Adding: {entry.path} {entry.path_in_archive or ''}")
+    return output_file_path


### PR DESCRIPTION
* Downloaded .amber tests have their shaders extracted, and now also are zipped for easier bug reporting. 
* Create work directory in run_cts_gf_tests.py. 
* Util function for creating zips