### PR TITLE
Fix scripts to make shaders spirv-fuzz-ready

### DIFF
--- a/python/src/main/python/drivers/convert-shaders-to-spirv-fuzz-form.py
+++ b/python/src/main/python/drivers/convert-shaders-to-spirv-fuzz-form.py
@@ -58,21 +58,21 @@ def main_helper(args):
         shader_job_uniforms_to_spirv_fuzz_facts.main_helper([json_in_output_dir,
                                                              os.path.join(args.output_dir,
                                                                           shader_job_prefix
-                                                                          + ".facts")])
+                                                                          + ".frag.facts")])
         runspv.convert_glsl_to_spv(os.path.join(args.output_dir, shader_job_prefix + ".frag"),
-                                   os.path.join(args.output_dir, shader_job_prefix + ".spv"))
+                                   os.path.join(args.output_dir, shader_job_prefix + ".frag.spv"))
 
         for opt_settings in ["-O", "-Os"]:
             shutil.copyfile(os.path.join(args.output_dir, shader_job_prefix + ".json"),
                             os.path.join(args.output_dir, shader_job_prefix + opt_settings
                                          + ".json"))
-            shutil.copyfile(os.path.join(args.output_dir, shader_job_prefix + ".facts"),
+            shutil.copyfile(os.path.join(args.output_dir, shader_job_prefix + ".frag.facts"),
                             os.path.join(args.output_dir, shader_job_prefix + opt_settings
-                                         + ".facts"))
-            runspv.run_spirv_opt(os.path.join(args.output_dir, shader_job_prefix + ".spv"),
+                                         + ".frag.facts"))
+            runspv.run_spirv_opt(os.path.join(args.output_dir, shader_job_prefix + ".frag.spv"),
                                  [opt_settings],
                                  os.path.join(args.output_dir, shader_job_prefix + opt_settings
-                                              + ".spv"))
+                                              + ".frag.spv"))
 
 
 if __name__ == '__main__':

--- a/python/src/main/python/drivers/shader_job_uniforms_to_spirv_fuzz_facts.py
+++ b/python/src/main/python/drivers/shader_job_uniforms_to_spirv_fuzz_facts.py
@@ -57,23 +57,26 @@ def main_helper(args) -> None:
         if name == "$compute":
             continue
 
+        scalar_uniform_functions = ['glUniform1i', 'glUniform1f']
+        vector_uniform_functions = ['glUniform2i', 'glUniform3i', 'glUniform4i', 'glUniform2f',
+                                   'glUniform3f', 'glUniform4f']
+
+        if not (entry["func"] in scalar_uniform_functions or entry["func"] in vector_uniform_functions):
+            print("Ignoring unsupported uniform function " + entry["func"])
+            continue
+
         # Make a separate fact for every component value of each uniform.
         for i in range(0, len(entry["args"])):
             # Every uniform is in its own struct, so we index into the first element of that struct
             # using index 0.  If the uniform is a vector, we need to further index into the vector.
-            if entry["func"] in ['glUniform1i', 'glUniform1f']:
+            if entry["func"] in scalar_uniform_functions:
                 # The uniform is a scalar.
                 assert i == 0
                 index_list = [0]
-            elif entry["func"] in ['glUniform2i', 'glUniform3i', 'glUniform4i', 'glUniform2f',
-                                   'glUniform3f', 'glUniform4f']:
+            else:
+                assert entry["func"] in vector_uniform_functions
                 # The uniform is a vector, so we have two levels of indexing.
                 index_list = [0, i]
-            else:
-                # We can deal with other uniforms in due course.
-                index_list = []
-                print("Unsupported uniform function " + entry["func"])
-                exit(1)
 
             # We need to pass the component value as an integer.  If it is a float, we need to
             # reinterpret its bits as an integer.


### PR DESCRIPTION
Minor edits to scripts that take a GraphicsFuzz shader and turn it
into a shader suitable for use with spirv-fuzz.