### PR TITLE
Fix binarytree shader

### DIFF
--- a/shaders/src/main/glsl/samples/300es/binarysearch_tree.frag
+++ b/shaders/src/main/glsl/samples/300es/binarysearch_tree.frag
@@ -170,7 +170,7 @@ void main() {
           }
         }
     }
-    float a = sinh(x + y * float(sum));
+    float a = tan(x + y * float(sum));
     _GLF_color = vec4(hueColor(a), 1.);
 
 }

--- a/shaders/src/main/glsl/samples/310es/binarysearch_tree.frag
+++ b/shaders/src/main/glsl/samples/310es/binarysearch_tree.frag
@@ -170,7 +170,7 @@ void main() {
           }
         }
     }
-    float a = sinh(x + y * float(sum));
+    float a = tan(x + y * float(sum));
     _GLF_color = vec4(hueColor(a), 1.);
 
 }


### PR DESCRIPTION
The sinh() function caused the shader to be numerically unstable (differing result image with 3 and 64 bit floats). Since this was only used for making the output image look nice, replacing it with tan() still creates a relatively nice image while leaving the actual binary tree functionality alone.