### PR TITLE
Fix acosh() input range

### DIFF
--- a/shaders/src/main/glsl/samples/300es/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/300es/mergesort_mosaic.frag
@@ -138,7 +138,7 @@ void main() {
             color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
-            color = fract(acosh(vecCoor.yx - trunc(float(data[3]))));
+            color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1, 1000)));
             color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {

--- a/shaders/src/main/glsl/samples/300es/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/300es/mergesort_mosaic.frag
@@ -138,7 +138,7 @@ void main() {
             color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
-            color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1, 1000)));
+            color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1.0, 1000.0)));
             color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {

--- a/shaders/src/main/glsl/samples/310es/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/310es/mergesort_mosaic.frag
@@ -136,7 +136,7 @@ void main() {
             color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
-            color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1, 1000)));
+            color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1.0, 1000.0)));
             color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {

--- a/shaders/src/main/glsl/samples/310es/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/310es/mergesort_mosaic.frag
@@ -136,7 +136,7 @@ void main() {
             color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
-            color = fract(acosh(vecCoor.yx - trunc(float(data[3]))));
+            color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1, 1000)));
             color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {


### PR DESCRIPTION
acosh() is only defined for input values >=1, but the shader feeds values that are less than that (including negative values). This leads to undefined behavior as per SPIR-V spec. In C++ the result may have bee NaN, which is optional in Vulkan. 