### PR TITLE
Remove VkScript support from runspv

### DIFF
--- a/python/src/main/python/drivers/glsl-to-spv-worker.py
+++ b/python/src/main/python/drivers/glsl-to-spv-worker.py
@@ -17,7 +17,6 @@
 import argparse
 import os
 import random
-import shutil
 import subprocess
 import sys
 import time
@@ -209,8 +208,7 @@ def do_image_job(
                     force=args.force,
                     is_android=(args.target == 'android'),
                     skip_render=skip_render,
-                    spirv_opt_args=resolved_spirvopt_args,
-                    use_amberscript=True
+                    spirv_opt_args=resolved_spirvopt_args
                 )
         except Exception as ex:
             runspv.log('Exception: ' + str(ex))
@@ -305,8 +303,7 @@ def do_compute_job(
                 force=args.force,
                 is_android=(args.target == 'android'),
                 skip_render=comp_job.skipRender,
-                spirv_opt_args=spirv_opt_args,
-                use_amberscript=True
+                spirv_opt_args=spirv_opt_args
             )
         except Exception as ex:
             runspv.log('Exception: ' + str(ex))

--- a/python/src/main/python/test_scripts/test_runspv/runspv_tests.py
+++ b/python/src/main/python/test_scripts/test_runspv/runspv_tests.py
@@ -118,8 +118,6 @@ def check_images_match(tmp_path: pathlib2.Path,
                        is_amber_1: bool,
                        is_amber_2: bool,
                        fuzzy_image_comparison: bool,
-                       use_amberscript_1: bool=None,
-                       use_amberscript_2: bool=None,
                        spirvopt_options_1: str=None,
                        spirvopt_options_2: str=None):
     out_dir_1 = tmp_path / 'out_1'
@@ -128,16 +126,12 @@ def check_images_match(tmp_path: pathlib2.Path,
     args_1 = ['android' if is_android_1 else 'host', get_image_test(json_filename), str(out_dir_1)]
     if not is_amber_1:
         args_1.append('--legacy-worker')
-    elif use_amberscript_1:
-        args_1.append('--use-amberscript')
     if spirvopt_options_1:
         args_1.append('--spirvopt=' + spirvopt_options_1)
 
     args_2 = ['android' if is_android_2 else 'host', get_image_test(json_filename), str(out_dir_2)]
     if not is_amber_2:
         args_2.append('--legacy-worker')
-    elif use_amberscript_2:
-        args_2.append('--use-amberscript')
     if spirvopt_options_2:
         args_2.append('--spirvopt=' + spirvopt_options_2)
 
@@ -181,26 +175,9 @@ def check_images_match_spirvopt(tmp_path: pathlib2.Path, json_filename: str, opt
                        spirvopt_options_2=None)
 
 
-def check_images_match_vkscript_amberscript(tmp_path: pathlib2.Path, json_filename: str,
-                                            is_android: bool) -> None:
-    check_images_match(tmp_path,
-                       json_filename=json_filename,
-                       is_android_1=is_android,
-                       is_android_2=is_android,
-                       is_amber_1=True,
-                       is_amber_2=True,
-                       fuzzy_image_comparison=False,
-                       use_amberscript_1=False,
-                       use_amberscript_2=True,
-                       spirvopt_options_1=None,
-                       spirvopt_options_2=None)
-
-
 def check_compute_matches(tmp_path: pathlib2.Path, json_filename: str,
                           is_android_1: bool,
                           is_android_2: bool,
-                          use_amberscript_1: bool=None,
-                          use_amberscript_2: bool=None,
                           spirvopt_options_1: str=None,
                           spirvopt_options_2: str=None):
     out_dir_1 = tmp_path / 'out_1'
@@ -208,10 +185,6 @@ def check_compute_matches(tmp_path: pathlib2.Path, json_filename: str,
 
     args_1 = ['android' if is_android_1 else 'host', get_compute_samples_dir() + os.sep + json_filename, str(out_dir_1)]
     args_2 = ['android' if is_android_2 else 'host', get_compute_samples_dir() + os.sep + json_filename, str(out_dir_2)]
-    if use_amberscript_1:
-        args_1.append('--use-amberscript')
-    if use_amberscript_2:
-        args_2.append('--use-amberscript')
     if spirvopt_options_1:
         args_1.append('--spirvopt=' + spirvopt_options_1)
     if spirvopt_options_2:
@@ -241,17 +214,6 @@ def check_host_and_android_match_compute(tmp_path: pathlib2.Path, json_filename:
                           json_filename=json_filename,
                           is_android_1=False,
                           is_android_2=True)
-
-
-def check_compute_matches_vkscript_amberscript(tmp_path: pathlib2.Path, json_filename: str, is_android: bool):
-    check_compute_matches(tmp_path,
-                          json_filename=json_filename,
-                          is_android_1=is_android,
-                          is_android_2=is_android,
-                          use_amberscript_1=False,
-                          use_amberscript_2=True,
-                          spirvopt_options_1=None,
-                          spirvopt_options_2=None)
 
 
 def check_no_image_skip_render(tmp_path: pathlib2.Path, is_android: bool, is_legacy_worker: bool,
@@ -809,173 +771,3 @@ def test_image_0006_spirvopt_android_legacy(tmp_path: pathlib2.Path):
                                 options='-Os',
                                 is_android=True,
                                 is_amber=False)
-
-#################################
-# VkScript vs AmberScript
-
-def test_image_0000_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0000.json',
-                                            is_android=False)
-
-
-def test_image_0000_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0000.json',
-                                            is_android=True)
-
-
-def test_image_0001_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0001.json',
-                                            is_android=False)
-
-
-def test_image_0001_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0001.json',
-                                            is_android=True)
-
-
-def test_image_0002_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0002.json',
-                                            is_android=False)
-
-
-def test_image_0002_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0002.json',
-                                            is_android=True)
-
-
-def test_image_0003_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0003.json',
-                                            is_android=False)
-
-
-def test_image_0003_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0003.json',
-                                            is_android=True)
-
-
-def test_image_0004_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0004.json',
-                                            is_android=False)
-
-
-def test_image_0004_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0004.json',
-                                            is_android=True)
-
-
-def test_image_0005_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0005.json',
-                                            is_android=False)
-
-
-def test_image_0005_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0005.json',
-                                            is_android=True)
-
-
-def test_image_0006_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0006.json',
-                                            is_android=False)
-
-
-def test_image_0006_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0006.json',
-                                            is_android=True)
-
-
-def test_image_0007_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0007.json',
-                                            is_android=False)
-
-
-def test_image_0007_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0007.json',
-                                            is_android=True)
-
-
-def test_image_0008_vksript_amberscript_host(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0008.json',
-                                            is_android=False)
-
-
-def test_image_0008_vksript_amberscript_android(tmp_path: pathlib2.Path):
-    check_images_match_vkscript_amberscript(tmp_path,
-                                            'image_test_0008.json',
-                                            is_android=True)
-
-
-def test_compute_0001_vkscript_amberscript_host(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0001-findmax.json',
-                                               is_android=False)
-
-
-def test_compute_0001_vkscript_amberscript_android(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0001-findmax.json',
-                                               is_android=True)
-
-
-def test_compute_0002_vkscript_amberscript_host(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0002-smooth-mean.json',
-                                               is_android=False)
-
-
-def test_compute_0002_vkscript_amberscript_android(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0002-smooth-mean.json',
-                                               is_android=True)
-
-
-def test_compute_0003_vkscript_amberscript_host(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0003-random-middle-square.json',
-                                               is_android=False)
-
-
-def test_compute_0003_vkscript_amberscript_android(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0003-random-middle-square.json',
-                                               is_android=True)
-
-
-def test_compute_0004_vkscript_amberscript_host(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0004-koggestone.json',
-                                               is_android=False)
-
-
-def test_compute_0004_vkscript_amberscript_android(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0004-koggestone.json',
-                                               is_android=True)
-
-
-def test_compute_0005_vkscript_amberscript_host(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0005-sklansky.json',
-                                               is_android=False)
-
-
-def test_compute_0005_vkscript_amberscript_android(tmp_path: pathlib2.Path):
-    check_compute_matches_vkscript_amberscript(tmp_path,
-                                               'comp-0005-sklansky.json',
-                                               is_android=True)


### PR DESCRIPTION
AmberScript support is now working well, so we no longer need VkScript
support to cross-check against.

Fixes #751.