### PR TITLE
gfauto: fix .idea/inspectionProfiles/profiles_settings.xml

### DIFF
--- a/gfauto/.idea/inspectionProfiles/profiles_settings.xml
+++ b/gfauto/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
     <option name="PROJECT_PROFILE" value="gfauto_inspections" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
     <version value="1.0" />
   </settings>
 </component>


### PR DESCRIPTION
PyCharm automatically deletes `USE_PROJECT_PROFILE` because its value is already the default