### PR TITLE
Added fudge factor to calculation to make it more stable

### DIFF
--- a/shaders/src/main/glsl/samples/300es/quicksort_palette.frag
+++ b/shaders/src/main/glsl/samples/300es/quicksort_palette.frag
@@ -82,7 +82,7 @@ vec3 palette(vec3 a, vec3 b, vec3 c, vec3 d) {
 
 float randomize(vec2 co)
 {
-    return float(floor(fract(sin(dot(co.xy ,vec2(12.5, 3.))) * 4250.) + 0.5));
+    return float(floor(fract(sin(dot(co.xy ,vec2(12.5, 3.))) * 4250. + 0.02) + 0.5));
 }
 
 bool puzzlelize(vec2 pos)

--- a/shaders/src/main/glsl/samples/310es/quicksort_palette.frag
+++ b/shaders/src/main/glsl/samples/310es/quicksort_palette.frag
@@ -82,7 +82,7 @@ vec3 palette(vec3 a, vec3 b, vec3 c, vec3 d) {
 
 float randomize(vec2 co)
 {
-    return float(floor(fract(sin(dot(co.xy ,vec2(12.5, 3.))) * 4250.) + 0.5));
+    return float(floor(fract(sin(dot(co.xy ,vec2(12.5, 3.))) * 4250. + 0.02) + 0.5));
 }
 
 bool puzzlelize(vec2 pos)


### PR DESCRIPTION
Multiplying floating point 1.0 with a large number followed by fract() may not result in expected result. Adding a fudge factor before fract stabilizes this, making 64bit and 32bit float return the same result even when asking more results than the default grid in the shader does. With the default grid, I could mask out 3 of the bits from the 32bit float before I got a different result compared to 64bit floats.