### PR TITLE
Add fixed point variants of mandelbrot shaders

### DIFF
--- a/docs/glsl-reduce.md
+++ b/docs/glsl-reduce.md
@@ -1,7 +1,7 @@
 # glsl-reduce manual
 
 For instructions on how to run glsl-reduce in conjunction with glsl-fuzz,
-see the [glsl-reduce manual for reducing fuzzed shaders](docs/glsl-fuzz-reduce.md).
+see the [glsl-reduce manual for reducing fuzzed shaders](glsl-fuzz-reduce.md).
 
 ## Synopsis
 

--- a/shaders/src/main/glsl/samples/300es/mandelbrot_fixpoint.frag
+++ b/shaders/src/main/glsl/samples/300es/mandelbrot_fixpoint.frag
@@ -1,0 +1,75 @@
+#version 300 es
+
+/*
+ * Copyright 2018 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform vec2 resolution;
+
+vec3 pickColor(int i) {
+  return vec3(float(i) / 50.0, float(i) / 120.0, float(i) / 140.0);
+}
+
+vec3 mand(float xCoord, float yCoord) 
+{
+	int xpos = (int)xCoord * 256;
+	int ypos = (int)yCoord * 256;
+	int height = (int)resolution.y * 256;
+	int width = (int)resolution.x * 256;
+
+	int c_re = ((xpos - width / 2) * 819) / width - 102;
+	int c_im = ((ypos - height / 2) * 819) / width;
+
+	int x = 0, y = 0;
+	int iteration = 0;
+	for (int k = 0; k < 1000; k++) 
+	{
+		if (x * x + y * y > 262144) 
+		{
+			break;
+		}
+		int x_new = ((x * x - y * y) / 256 + c_re);
+		y = (2 * x * y / 256 + c_im);
+		x = x_new;
+		iteration++;
+	}
+	if (iteration < 1000) 
+	{
+		return pickColor(iteration);
+	}
+	else 
+	{
+		return vec3(0.0, 0.0, 0.5);
+	}
+}
+
+void main() {
+  vec3 data[16];
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+    }
+  }
+  vec3 sum = vec3(0.0);
+  for (int i = 0; i < 16; i++) {
+    sum += data[i];
+  }
+  sum /= vec3(16.0);
+  _GLF_color = vec4(sum, 1.0);
+}

--- a/shaders/src/main/glsl/samples/300es/mandelbrot_fixpoint.json
+++ b/shaders/src/main/glsl/samples/300es/mandelbrot_fixpoint.json
@@ -1,0 +1,9 @@
+{
+    "resolution": {
+        "func":  "glUniform2f",
+        "args": [
+            256.0,
+            256.0
+        ]
+    }
+}

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_fixpoint.frag
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_fixpoint.frag
@@ -1,0 +1,75 @@
+#version 310 es
+
+/*
+ * Copyright 2018 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+precision highp float;
+
+layout(location = 0) out vec4 _GLF_color;
+
+uniform vec2 resolution;
+
+vec3 pickColor(int i) {
+  return vec3(float(i) / 50.0, float(i) / 120.0, float(i) / 140.0);
+}
+
+vec3 mand(float xCoord, float yCoord) 
+{
+	int xpos = (int)xCoord * 256;
+	int ypos = (int)yCoord * 256;
+	int height = (int)resolution.y * 256;
+	int width = (int)resolution.x * 256;
+
+	int c_re = ((xpos - width / 2) * 819) / width - 102;
+	int c_im = ((ypos - height / 2) * 819) / width;
+
+	int x = 0, y = 0;
+	int iteration = 0;
+	for (int k = 0; k < 1000; k++) 
+	{
+		if (x * x + y * y > 262144) 
+		{
+			break;
+		}
+		int x_new = ((x * x - y * y) / 256 + c_re);
+		y = (2 * x * y / 256 + c_im);
+		x = x_new;
+		iteration++;
+	}
+	if (iteration < 1000) 
+	{
+		return pickColor(iteration);
+	}
+	else 
+	{
+		return vec3(0.0, 0.0, 0.5);
+	}
+}
+
+void main() {
+  vec3 data[16];
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+    }
+  }
+  vec3 sum = vec3(0.0);
+  for (int i = 0; i < 16; i++) {
+    sum += data[i];
+  }
+  sum /= vec3(16.0);
+  _GLF_color = vec4(sum, 1.0);
+}

--- a/shaders/src/main/glsl/samples/310es/mandelbrot_fixpoint.json
+++ b/shaders/src/main/glsl/samples/310es/mandelbrot_fixpoint.json
@@ -1,0 +1,9 @@
+{
+    "resolution": {
+        "func":  "glUniform2f",
+        "args": [
+            256.0,
+            256.0
+        ]
+    }
+}


### PR DESCRIPTION
Added variants of the fixed point shaders where the actual fractal calculation is done via fixed point math to avoid floating point issues.

Otherwise the shaders are as before. For fixed point, 8.8 was chosen so that 32 bit integers are enough in all situations (fixed point multiplications and divisions require double the bits of the operands)



