### PR TITLE
gfauto: do not generate Amber text for uniforms if there are none

### DIFF
--- a/gfauto/gfauto/amber_converter.py
+++ b/gfauto/gfauto/amber_converter.py
@@ -267,11 +267,16 @@ def amberscript_uniform_buffer_def(uniform_json_contents: str, prefix: str) -> s
         "glUniformMatrix4fv": "mat4x4<float>",
     }
 
+    uniforms = json.loads(uniform_json_contents)
+
+    # Do not generate anything if there are no uniforms.
+    if not uniforms:
+        return ""
+
     result = f"# uniforms for {prefix}\n"
 
     result += "\n"
 
-    uniforms = json.loads(uniform_json_contents)
     for name, entry in uniforms.items():
 
         if name == "$compute":

--- a/gfauto/gfauto/amber_converter.py
+++ b/gfauto/gfauto/amber_converter.py
@@ -269,7 +269,7 @@ def amberscript_uniform_buffer_def(uniform_json_contents: str, prefix: str) -> s
 
     uniforms = json.loads(uniform_json_contents)
 
-    # Do not generate anything if there are no uniforms.
+    # If there are no uniforms, do not generate anything.
     if not uniforms:
         return ""
 


### PR DESCRIPTION
If a shader has no uniforms, this change avoids generating "uniforms
for ..." followed by no uniform information.  This was motivated by
such redundant text in Amber files being flagged up in Vulkan CTS
reviews.