### PR TITLE
Restrict initializer inlining when preserving semantics

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunities.java
@@ -120,11 +120,9 @@ public class FlattenControlFlowReductionOpportunities
     }
 
     return context.reduceEverywhere()
-          || injectionTracker.enclosedByDeadCodeInjection()
-          || injectionTracker.underUnreachableSwitchCase()
+          || currentProgramPointIsDeadCode()
           || (StmtReductionOpportunities.isLiveCodeInjection(compoundStmt)
                && !isLoopLimiterCheck(compoundStmt))
-          || enclosingFunctionIsDead()
           || SideEffectChecker.isSideEffectFree(compoundStmt, context.getShadingLanguageVersion(),
         shaderKind);
   }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
@@ -74,8 +74,8 @@ abstract class SimplifyExprReductionOpportunities
   boolean allowedToReduceExpr(IAstNode parent, Expr child) {
 
     if (child instanceof VariableIdentifierExpr) {
-      String name = ((VariableIdentifierExpr) child).getName();
-      if (name.startsWith(Constants.LIVE_PREFIX)
+      final String name = ((VariableIdentifierExpr) child).getName();
+      if (isLiveInjectedVariableName(name)
             && !StmtReductionOpportunities.isLooplimiter(name)) {
         return true;
       }
@@ -102,15 +102,11 @@ abstract class SimplifyExprReductionOpportunities
       return true;
     }
 
-    if (enclosingFunctionIsDead()) {
+    if (currentProgramPointIsDeadCode()) {
       return true;
     }
 
     if (injectionTracker.underFuzzedMacro()) {
-      return true;
-    }
-
-    if (injectionTracker.enclosedByDeadCodeInjection()) {
       return true;
     }
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -115,11 +115,7 @@ public class StmtReductionOpportunities
       return true;
     }
 
-    if (injectionTracker.enclosedByDeadCodeInjection()) {
-      return true;
-    }
-
-    if (injectionTracker.underUnreachableSwitchCase() && !isZeroSwitchCase(stmt)) {
+    if (currentProgramPointIsDeadCode()) {
       return true;
     }
 
@@ -135,8 +131,7 @@ public class StmtReductionOpportunities
     }
 
     return context.reduceEverywhere()
-          || (isLiveCodeInjection(stmt) && !referencesLoopLimiter(stmt))
-          || enclosingFunctionIsDead();
+          || (isLiveCodeInjection(stmt) && !referencesLoopLimiter(stmt));
 
   }
 
@@ -173,11 +168,6 @@ public class StmtReductionOpportunities
         }
       }
     }.test(stmt);
-  }
-
-  private boolean isZeroSwitchCase(Stmt stmt) {
-    return stmt instanceof ExprCaseLabel
-          && ((IntConstantExpr) ((ExprCaseLabel) stmt).getExpr()).getValue().equals("0");
   }
 
   /**
@@ -257,10 +247,6 @@ public class StmtReductionOpportunities
   private static boolean isLiveCodeVariableDeclaration(VariableDeclInfo vdi) {
     final String name = vdi.getName();
     return isLiveInjectedVariableName(name);
-  }
-
-  private static boolean isLiveInjectedVariableName(String name) {
-    return name.startsWith(Constants.LIVE_PREFIX);
   }
 
   /**

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunities.java
@@ -128,15 +128,10 @@ public class VariableDeclReductionOpportunities
     }
     // Fine to remove if in a dead context, a live context, if no initializer, or if
     // initializer does not have side effects.
-    return context.reduceEverywhere() || enclosingFunctionIsDead()
-        || injectionTracker.enclosedByDeadCodeInjection()
-        || isLiveInjection(variableDeclInfo)
+    return context.reduceEverywhere() || currentProgramPointIsDeadCode()
+        || isLiveInjectedVariableName(variableDeclInfo.getName())
         || !variableDeclInfo.hasInitializer()
         || initializerIsScalarAndSideEffectFree(variableDeclInfo);
-  }
-
-  private boolean isLiveInjection(VariableDeclInfo variableDeclInfo) {
-    return variableDeclInfo.getName().startsWith(Constants.LIVE_PREFIX);
   }
 
   /**

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunitiesTest.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
@@ -24,6 +25,7 @@ import com.graphicsfuzz.common.util.CompareAsts;
 import com.graphicsfuzz.common.util.IdGenerator;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.util.Constants;
 import java.util.List;
 import org.junit.Test;
 
@@ -40,6 +42,10 @@ public class InlineInitializerReductionOpportunitiesTest {
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
     CompareAsts.assertEqualAsts(expected, tu);
+
+    // If we are preserving semantics, we do not want to apply this transformation.
+    assertTrue(InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+        ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator())).isEmpty());
   }
 
   @Test
@@ -86,23 +92,7 @@ public class InlineInitializerReductionOpportunitiesTest {
   }
 
   @Test
-  public void testCanInlineAllExceptLValueIfReducingEverywhere() throws Exception {
-
-    final String program = "void main() { int i = 4 + 2; i += i + i + i; i -= i * i; }";
-    final String expected = "void main() { int i = 4 + 2; i += (4 + 2) + (4 + 2) + (4 + 2); i -= (4 + 2) * (4 + 2); }";
-
-    final TranslationUnit tu = ParseHelper.parse(program);
-
-    List<SimplifyExprReductionOpportunity> ops =
-        InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
-    assertEquals(5, ops.size());
-    ops.forEach(SimplifyExprReductionOpportunity::applyReduction);
-    CompareAsts.assertEqualAsts(expected, tu);
-  }
-
-  @Test
-  public void testNoInliningIfLValueUsageExistsWhenPreservingSemantics() throws Exception {
+  public void testDoNotInlineWhenPreservingSemantics() throws Exception {
 
     final String program = "void main() { int i = 4 + 2; i += i + i + i; i -= i * i; }";
 
@@ -111,18 +101,31 @@ public class InlineInitializerReductionOpportunitiesTest {
     List<SimplifyExprReductionOpportunity> ops =
         InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
             ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
-    assertEquals(0, ops.size());
+    assertTrue(ops.isEmpty());
   }
 
   @Test
-  public void testNoInliningIfPartsOfInitializerAreModifiedWhenPreservingSemantics() throws Exception {
+  public void testDoNotInlineWhenPreservingSemantics2() throws Exception {
+
+    final String program = "void main() { int i = 4 + 2; i += i + i + i; i -= i * i; }";
+
+    final TranslationUnit tu = ParseHelper.parse(program);
+
+    List<SimplifyExprReductionOpportunity> ops =
+        InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+    assertTrue(ops.isEmpty());
+  }
+
+  @Test
+  public void testDoNotInlineWhenPreservingSemantics3() throws Exception {
     final String program  = "void main() { int x = 2; int y = x; x = 3; y; }";
     final TranslationUnit tu = ParseHelper.parse(program);
 
     List<SimplifyExprReductionOpportunity> ops =
         InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
             ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
-    assertEquals(0, ops.size());
+    assertTrue(ops.isEmpty());
   }
 
   @Test
@@ -146,6 +149,59 @@ public class InlineInitializerReductionOpportunitiesTest {
         InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
             ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
+  }
+
+  @Test
+  public void testInliningInDeadCodeWithPreserveSemantics() throws Exception {
+    // We do want to be able to inline an initializer if we are in dead code, when preserving
+    // semantics
+    final String program = "void main() {\n"
+        + "  if(" + Constants.GLF_DEAD + "(" + Constants.GLF_FALSE + "(false, false))) {\n"
+        + "    int do_inline_me = 5 + 2;\n"
+        + "    do_inline_me * do_inline_me;\n"
+        + "  }\n"
+        + "}\n";
+    final String expected = "void main() {\n"
+        + "  if(" + Constants.GLF_DEAD + "(" + Constants.GLF_FALSE + "(false, false))) {\n"
+        + "    int do_inline_me = 5 + 2;\n"
+        + "    (5 + 2) * (5 + 2);\n"
+        + "  }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final List<SimplifyExprReductionOpportunity> ops =
+        InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+    assertEquals(2, ops.size());
+    ops.get(0).applyReduction();
+    ops.get(1).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testInliningInLiveCodeWithPreserveSemantics() throws Exception {
+    // We do want to be able to inline an initializer if we are in live code, when preserving
+    // semantics
+    final String variableName = Constants.LIVE_PREFIX + "do_inline_me";
+    final String program = "void main() {\n"
+        + "  {\n"
+        + "    int " + variableName + " = 5 + 2;\n"
+        + "    " + variableName + " * " + variableName + ";\n"
+        + "  }\n"
+        + "}\n";
+    final String expected = "void main() {\n"
+        + "  {\n"
+        + "    int " + variableName + " = 5 + 2;\n"
+        + "    (5 + 2) * (5 + 2);\n"
+        + "  }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final List<SimplifyExprReductionOpportunity> ops =
+        InlineInitializerReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+    assertEquals(2, ops.size());
+    ops.get(0).applyReduction();
+    ops.get(1).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
   }
 
 }


### PR DESCRIPTION
The reducer tries to be clever and do some initializer inlining when
preserving semantics.  But this can be problematic for a couple of
reasons:

- It can make references and variants hard to compare if initializer
  inlining has been applied to one and not the other

- There are subtle cases where initializer inlining does not preserve
  semantics; for example:

    highp int x = 16777216;
    findLSB(x);

  might not be equivalent to:

    findLSB(16777216);

  since findLSB can operate at low precision when passed a literal
  argument.

This change disables initializer inlining when semantics are being
preserved, unless the initializer occurs in dead code, or is the
initializer for a live-injected variable.

The change contributes some clean-up related to how dead code and
live-injected variables are identified in general.

Partially fixes #639.
Partially fixes #783.