### PR TITLE
Reducer: limit constant folding when preserving semantics

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunities.java
@@ -52,6 +52,10 @@ public final class FoldConstantReductionOpportunities extends SimplifyExprReduct
   @Override
   void identifyReductionOpportunitiesForChild(IAstNode parent, Expr child) {
 
+    if (!allowedToReduceExpr(parent, child)) {
+      return;
+    }
+
     Optional<FunctionCallExpr> maybeFce = asFunctionCallExpr(child);
     if (maybeFce.isPresent()) {
       switch (maybeFce.get().getCallee()) {

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunitiesTest.java
@@ -628,7 +628,7 @@ public class FoldConstantReductionOpportunitiesTest {
       ParseTimeoutException, InterruptedException, GlslParserException {
     final TranslationUnit tu = ParseHelper.parse(before);
     final List<SimplifyExprReductionOpportunity> ops = FoldConstantReductionOpportunities
-        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
             ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     ops.forEach(item -> item.applyReduction());
     CompareAsts.assertEqualAsts(after, tu);


### PR DESCRIPTION
To make references and reduced variants easier to compare, this change
supresses constant folding in non-injected code when semantics are
being preserved.