### PR TITLE
gfauto: use Amber apk

### DIFF
--- a/gfauto/gfauto/android_device.py
+++ b/gfauto/gfauto/android_device.py
@@ -432,8 +432,8 @@ def run_amber_on_device_helper(
 
     result: Optional[types.CompletedProcess] = None
 
-    # Before running, make sure the app is not already running.
-    adb_can_fail(serial, ["am", "force-stop", "com.google.amber"])
+    # Before running, try to ensure the app is not already running.
+    adb_can_fail(serial, ["shell", "am force-stop com.google.amber"])
 
     try:
         result = adb_can_fail(
@@ -441,7 +441,7 @@ def run_amber_on_device_helper(
         )
     except subprocess.TimeoutExpired:
         status = fuzz.STATUS_TIMEOUT
-        adb_can_fail(serial, ["am", "force-stop", "com.google.amber"])
+        adb_can_fail(serial, ["shell", "am force-stop com.google.amber"])
 
     try:
         if result:

--- a/gfauto/gfauto/android_device.py
+++ b/gfauto/gfauto/android_device.py
@@ -20,6 +20,7 @@ Provides functions for interacting with Android devices.
 """
 
 import os
+import shlex
 import shutil
 import subprocess
 import time
@@ -34,14 +35,13 @@ from gfauto import (
     subprocess_util,
     types,
     util,
+    binaries_util,
 )
 from gfauto.device_pb2 import Device, DeviceAndroid
 from gfauto.gflogging import log
 from gfauto.util import check, file_open_text, file_write_text
 
-ANDROID_DEVICE_DIR = "/data/local/tmp"
-ANDROID_AMBER_NDK = "amber_ndk"
-ANDROID_DEVICE_AMBER = ANDROID_DEVICE_DIR + "/" + ANDROID_AMBER_NDK
+ANDROID_DEVICE_DIR = "/sdcard/Android/data/com.google.amber/cache/"
 
 ANDROID_DEVICE_GRAPHICSFUZZ_DIR = ANDROID_DEVICE_DIR + "/graphicsfuzz"
 ANDROID_DEVICE_RESULT_DIR = ANDROID_DEVICE_GRAPHICSFUZZ_DIR + "/result"
@@ -166,7 +166,21 @@ def get_device_driver_details(serial: str) -> str:
     return match.group(1)
 
 
-def get_all_android_devices() -> List[Device]:
+def ensure_amber_installed(
+    device_serial: Optional[str], binary_manager: binaries_util.BinaryManager
+) -> None:
+    amber_apk_binary = binary_manager.get_binary_path_by_name("amber_apk")
+    amber_apk_test_binary = binary_manager.get_binary_path_by_name("amber_apk_test")
+
+    adb_can_fail(device_serial, ["uninstall", "com.google.amber"])
+    adb_can_fail(device_serial, ["uninstall", "com.google.amber.test"])
+    adb_check(device_serial, ["install", "-r", str(amber_apk_binary.path)])
+    adb_check(device_serial, ["install", "-r", str(amber_apk_test_binary.path)])
+
+
+def get_all_android_devices(
+    binary_manager: binaries_util.BinaryManager
+) -> List[Device]:
     result: List[Device] = []
 
     log("Getting the list of connected Android devices via adb\n")
@@ -198,12 +212,14 @@ def get_all_android_devices() -> List[Device]:
         build_fingerprint: str = ""
         try:
             adb_fingerprint_result = adb_check(
-                device_serial, ["adb", "shell", "getprop ro.build.fingerprint"]
+                device_serial, ["shell", "getprop ro.build.fingerprint"]
             )
             build_fingerprint = adb_fingerprint_result.stdout
             build_fingerprint = build_fingerprint.strip()
         except subprocess.CalledProcessError:
             log("Failed to get device fingerprint")
+
+        ensure_amber_installed(device_serial, binary_manager)
 
         driver_details = ""
         try:
@@ -292,12 +308,6 @@ def prepare_device(wait_for_screen: bool, serial: Optional[str] = None) -> None:
     log("Clearing logcat.")
     adb_check(serial, ["logcat", "-c"])
 
-    res = adb_can_fail(serial, ["shell", "test -e " + ANDROID_DEVICE_AMBER])
-    check(
-        res.returncode == 0,
-        AssertionError("Failed to find amber on device at: " + ANDROID_DEVICE_AMBER),
-    )
-
     adb_check(
         serial,
         [
@@ -353,22 +363,59 @@ def run_amber_on_device_helper(
         serial, ["push", str(amber_script_file), ANDROID_DEVICE_AMBER_SCRIPT_FILE]
     )
 
-    amber_flags = "--log-graphics-calls-time --disable-spirv-val"
+    amber_args = [
+        "-d",  # Disables validation layers.
+        ANDROID_DEVICE_AMBER_SCRIPT_FILE,
+        "--log-graphics-calls-time",
+        "--disable-spirv-val",
+    ]
     if skip_render:
         # -ps tells amber to stop after pipeline creation
-        amber_flags += " -ps"
+        amber_args.append("-ps")
     else:
         if dump_image:
-            amber_flags += f" -I variant_framebuffer -i {fuzz.VARIANT_IMAGE_FILE_NAME} -I reference_framebuffer -i {fuzz.REFERENCE_IMAGE_FILE_NAME}"
+            amber_args += [
+                "-I",
+                "variant_framebuffer",
+                "-i",
+                fuzz.VARIANT_IMAGE_FILE_NAME,
+                "-I",
+                "reference_framebuffer",
+                "-i",
+                fuzz.REFERENCE_IMAGE_FILE_NAME,
+            ]
         if dump_buffer:
-            amber_flags += f" -b {fuzz.BUFFER_FILE_NAME} -B 0"
+            amber_args += ["-b", fuzz.BUFFER_FILE_NAME, "-B", "0"]
+
+    shell_command = [
+        "am",
+        "instrument",
+        "-w",
+        "-e",
+        "stdout",
+        f"{ANDROID_DEVICE_RESULT_DIR}/amber_stdout.txt",
+        "-e",
+        "stderr" f"{ANDROID_DEVICE_RESULT_DIR}/amber_stderr.txt",
+    ]
+
+    # Amber arguments are passed as key-value pairs via -e. E.g. for "-d": -e arg1 -d
+    arg_index = 1
+    for amber_arg in amber_args:
+        shell_command.append("-e")
+        shell_command.append(f"arg{arg_index}")
+        shell_command.append(amber_arg)
+
+    shell_command.append(
+        "com.google.amber.test/androidx.test.runner.AndroidJUnitRunner"
+    )
+
+    shell_command = [shlex.quote(c) for c in shell_command]
+    shell_command_str = " ".join(shell_command)
 
     cmd = [
         "shell",
         # The following is a single string:
-        f"cd {ANDROID_DEVICE_RESULT_DIR} && "
-        # -d disables Vulkan validation layers.
-        f"{ANDROID_DEVICE_AMBER} -d {ANDROID_DEVICE_AMBER_SCRIPT_FILE} {amber_flags}",
+        f"cd {ANDROID_DEVICE_RESULT_DIR} && {shell_command_str}",
     ]
 
     status = "UNEXPECTED_ERROR"

--- a/gfauto/gfauto/binaries_util.py
+++ b/gfauto/gfauto/binaries_util.py
@@ -553,6 +553,7 @@ def get_github_release_recipe(  # pylint: disable=too-many-branches;
         # Special case:
         platform = util.get_platform()  # Not used.
         tags = PLATFORMS[:]  # All host platforms.
+        tags.append("Debug")
         repo_name = f"gfbuild-{project_name}"
         version = binary.version
         artifact_name = f"gfbuild-{project_name}-{version}-android_apk"

--- a/gfauto/gfauto/devices_util.py
+++ b/gfauto/gfauto/devices_util.py
@@ -118,7 +118,7 @@ def get_device_list(
 
     try:
         # Android devices.
-        android_devices = android_device.get_all_android_devices()
+        android_devices = android_device.get_all_android_devices(binary_manager)
         device_list.devices.extend(android_devices)
         device_list.active_device_names.extend([d.name for d in android_devices])
     except ToolNotOnPathError:

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -227,3 +227,6 @@ listdir
 RNG
 toplevel
 getpid
+shlex
+apk
+arg1


### PR DESCRIPTION
We previously used the "amber_ndk" binary that could be pushed to a phone and executed via `adb shell ./amber_ndk`. Although this is convenient, it is not clearly supported. We now install the new Amber APK and Amber test APK, and use `adb shell am instrument ...` to run Amber. Files are now written to `/sdcard/Android/data/com.google.amber/cache/graphicsfuzz` instead of `/data/local/tmp/graphicsfuzz`.