### PR TITLE
gfauto: cache runs of glslangValidator and spirv-opt

### DIFF
--- a/gfauto/gfauto/fuzz_glsl_test.py
+++ b/gfauto/gfauto/fuzz_glsl_test.py
@@ -193,6 +193,7 @@ def run(
     test_dir: Path,
     binary_manager: binaries_util.BinaryManager,
     device: Optional[Device] = None,
+    preprocessor_cache: Optional[util.CommandCache] = None,
 ) -> str:
 
     test: Test = test_util.metadata_read(test_dir)
@@ -204,6 +205,7 @@ def run(
         output_dir=test_util.get_results_directory(test_dir, device.name),
         binary_manager=binary_manager,
         device=device,
+        preprocessor_cache=preprocessor_cache,
     )
 
     return result_util.get_status(result_output_dir)
@@ -378,10 +380,13 @@ def handle_test(
 
     report_paths: List[Path] = []
     issue_found = False
+    preprocessor_cache = util.CommandCache()
 
     # Run on all devices.
     for device in active_devices:
-        status = run(test_dir, binary_manager, device)
+        status = run(
+            test_dir, binary_manager, device, preprocessor_cache=preprocessor_cache
+        )
         if status in (
             fuzz.STATUS_CRASH,
             fuzz.STATUS_TOOL_CRASH,
@@ -424,6 +429,7 @@ def run_shader_job(  # pylint: disable=too-many-return-statements,too-many-branc
     shader_job_shader_overrides: Optional[
         tool.ShaderJobNameToShaderOverridesMap
     ] = None,
+    preprocessor_cache: Optional[util.CommandCache] = None,
 ) -> Path:
 
     if not shader_job_shader_overrides:
@@ -489,6 +495,7 @@ def run_shader_job(  # pylint: disable=too-many-return-statements,too-many-branc
                             binary_paths=binary_manager,
                             spirv_opt_args=spirv_opt_args,
                             shader_overrides=shader_overrides,
+                            preprocessor_cache=preprocessor_cache,
                         )
                     )
                 except subprocess.CalledProcessError:

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -70,6 +70,7 @@ def run(
     test_dir: Path,
     binary_manager: binaries_util.BinaryManager,
     device: Optional[Device] = None,
+    preprocessor_cache: Optional[util.CommandCache] = None,
 ) -> str:
 
     test: Test = test_util.metadata_read(test_dir)
@@ -81,6 +82,7 @@ def run(
         output_dir=test_util.get_results_directory(test_dir, device.name),
         binary_manager=binary_manager,
         device=device,
+        preprocessor_cache=preprocessor_cache,
     )
 
     return result_util.get_status(result_output_dir)
@@ -361,10 +363,13 @@ def handle_test(
 ) -> bool:
     report_paths: List[Path] = []
     issue_found = False
+    preprocessor_cache = util.CommandCache()
 
     # Run on all devices.
     for device in active_devices:
-        status = run(test_dir, binary_manager, device)
+        status = run(
+            test_dir, binary_manager, device, preprocessor_cache=preprocessor_cache
+        )
         if status in (
             fuzz.STATUS_CRASH,
             fuzz.STATUS_TOOL_CRASH,

--- a/gfauto/gfauto/tool.py
+++ b/gfauto/gfauto/tool.py
@@ -121,6 +121,7 @@ def spirv_opt_shader_job(
     spirv_opt_args: List[str],
     output_json: Path,
     binary_paths: binaries_util.BinaryGetter,
+    preprocessor_cache: Optional[util.CommandCache] = None,
 ) -> Path:
     spirv_opt_binary = binary_paths.get_binary_path_by_name(
         binaries_util.SPIRV_OPT_NAME
@@ -132,16 +133,21 @@ def spirv_opt_shader_job(
         spirv_opt_binary.path,
         binaries_util.SPIRV_OPT_NO_VALIDATE_AFTER_ALL_TAG
         in spirv_opt_binary.binary.tags,
+        preprocessor_cache=preprocessor_cache,
     )
 
 
 def glslang_glsl_shader_job_to_spirv(
-    input_json: Path, output_json: Path, binary_paths: binaries_util.BinaryGetter
+    input_json: Path,
+    output_json: Path,
+    binary_paths: binaries_util.BinaryGetter,
+    preprocessor_cache: Optional[util.CommandCache] = None,
 ) -> Path:
     return glslang_validator_util.run_glslang_glsl_to_spirv_job(
         input_json,
         output_json,
         binary_paths.get_binary_path_by_name(binaries_util.GLSLANG_VALIDATOR_NAME).path,
+        preprocessor_cache=preprocessor_cache,
     )
 
 
@@ -179,13 +185,14 @@ class SpirvCombinedShaderJob:
         return iter((self.spirv_asm_shader_job, self.spirv_shader_job))
 
 
-def compile_shader_job(
+def compile_shader_job(  # pylint: disable=too-many-locals;
     name: str,
     input_json: Path,
     work_dir: Path,
     binary_paths: binaries_util.BinaryGetter,
     spirv_opt_args: Optional[List[str]] = None,
     shader_overrides: Optional[ShaderSuffixToShaderOverride] = None,
+    preprocessor_cache: Optional[util.CommandCache] = None,
 ) -> SpirvCombinedShaderJob:
 
     result = input_json
@@ -210,7 +217,10 @@ def compile_shader_job(
             raise AssertionError("Shader overrides are not supported for GLSL")
 
         result = glslang_glsl_shader_job_to_spirv(
-            result, work_dir / "1_spirv" / result.name, binary_paths
+            result,
+            work_dir / "1_spirv" / result.name,
+            binary_paths,
+            preprocessor_cache=preprocessor_cache,
         )
     # If SPIR-V:
     elif spirv_suffixes:
@@ -275,7 +285,11 @@ def compile_shader_job(
     if spirv_opt_args:
         result = result_spirv
         result = spirv_opt_shader_job(
-            result, spirv_opt_args, work_dir / "2_spirv_opt" / result.name, binary_paths
+            result,
+            spirv_opt_args,
+            work_dir / "2_spirv_opt" / result.name,
+            binary_paths,
+            preprocessor_cache=preprocessor_cache,
         )
         result_spirv = result
         result = spirv_dis_shader_job(

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -230,3 +230,6 @@ getpid
 shlex
 apk
 arg1
+hashlib
+sha256
+hexdigest


### PR DESCRIPTION
We run glslangValidator and spirv-opt multiple times on the same files redundantly when testing multiple devices (in particular, host_preprocessor followed by a real device). This change adds a cache to avoid this expensive re-running.