### PR TITLE
gfauto: catch sigint to allow graceful exit

### DIFF
--- a/gfauto/gfauto/fuzz.py
+++ b/gfauto/gfauto/fuzz.py
@@ -34,6 +34,7 @@ from gfauto import (
     fuzz_glsl_test,
     fuzz_spirv_test,
     gflogging,
+    interrupt_util,
     settings_util,
     shader_job_util,
     test_util,
@@ -182,6 +183,8 @@ def main_helper(  # pylint: disable=too-many-locals, too-many-branches, too-many
 
     util.update_gcov_environment_variable_if_needed()
 
+    interrupt_util.override_sigint()
+
     try:
         artifact_util.artifact_path_get_root()
     except FileNotFoundError:
@@ -233,6 +236,8 @@ def main_helper(  # pylint: disable=too-many-locals, too-many-branches, too-many
     ).get_child_binary_manager(list(settings.custom_binaries), prepend=True)
 
     while True:
+
+        interrupt_util.interrupt_if_needed()
 
         # We have to use "is not None" because the seed could be 0.
         if iteration_seed_override is not None:

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -29,6 +29,7 @@ from gfauto import (
     fuzz,
     fuzz_glsl_test,
     gflogging,
+    interrupt_util,
     result_util,
     shader_job_util,
     signature_util,
@@ -376,8 +377,13 @@ def handle_test(
             fuzz.STATUS_UNRESPONSIVE,
         ):
             issue_found = True
+
+        # No need to run further on real devices if the pre-processing step failed.
         if status == fuzz.STATUS_TOOL_CRASH:
-            # No need to run further on real devices if the pre-processing step failed.
+            break
+
+        # Skip devices if interrupted, but finish reductions, if needed.
+        if interrupt_util.interrupted():
             break
 
     # For each device that saw a crash, copy the test to reports_dir, adding the signature and device info to the test
@@ -484,6 +490,7 @@ def fuzz_spirv(
     ]
 
     for test_dir in test_dirs:
+        interrupt_util.interrupt_if_needed()
         if handle_test(test_dir, reports_dir, active_devices, binary_manager, settings):
             # If we generated a report, don't bother trying other optimization combinations.
             break

--- a/gfauto/gfauto/interrupt_util.py
+++ b/gfauto/gfauto/interrupt_util.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 The GraphicsFuzz Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interrupt utility module.
+
+Used to override the SIGINT signals and exit gracefully.
+"""
+import signal
+import sys
+from typing import Any
+
+from gfauto import util
+from gfauto.gflogging import log
+
+exit_triggered = False  # pylint: disable=invalid-name;
+original_sigint_handler: Any = None  # pylint: disable=invalid-name;
+
+
+def interrupt_if_needed() -> None:
+    if exit_triggered:
+        raise KeyboardInterrupt()
+
+
+def interrupted() -> bool:
+    return exit_triggered
+
+
+def _sigint_handler(signum: int, _: Any) -> None:
+    global exit_triggered  # pylint: disable=invalid-name,global-statement;
+    msg = f"\nCaught signal {signum}. Terminating at next safe point.\n"
+    log(msg)
+    print(msg, flush=True, file=sys.stderr)  # noqa: T001
+    exit_triggered = True
+    # Restore signal handler.
+    signal.signal(signal.SIGINT, original_sigint_handler)
+
+
+def override_sigint() -> None:
+    global original_sigint_handler  # pylint: disable=invalid-name,global-statement;
+    util.check(
+        original_sigint_handler is None,
+        AssertionError("Called override_sig_int more than once"),
+    )
+    original_sigint_handler = signal.signal(signal.SIGINT, _sigint_handler)

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -233,3 +233,6 @@ arg1
 hashlib
 sha256
 hexdigest
+sigint
+SIGINT
+signum


### PR DESCRIPTION
When running many instances of gfauto, it can be useful to trigger termination of the instances, but allow the final steps (including reduction) of processing a report to complete. This change overrides sigint to allow for termination at "safe points". A second sigint is not ignored.