### PR TITLE
gfauto: skip ignored_crash_signatures

### DIFF
--- a/gfauto/gfautotests/test_large.py
+++ b/gfauto/gfautotests/test_large.py
@@ -232,9 +232,7 @@ def fuzz_and_reduce_bug(
                             version="6d69aae0e1ab49190ea46cd1c999fd3d02e016b9",
                         ),
                     ],
-                    ignored_crash_signatures=ignored_signatures
-                    if ignored_signatures
-                    else None,
+                    ignored_crash_signatures=ignored_signatures,
                 ),
             ],
         )


### PR DESCRIPTION
When fuzzing, don't create a report (i.e. discard the test) if the crash signature is in ignored_crash_signatures for the device. Also fix minor issue revealed by test -- don't create the crash signature directory until needed; this way we can check that the directory was NOT created as part of the test.