### PR TITLE
gfauto: don't download amdllpc by default

### DIFF
--- a/gfauto/gfauto/devices_util.py
+++ b/gfauto/gfauto/devices_util.py
@@ -133,7 +133,7 @@ def get_device_list(
         shader_compiler=DeviceShaderCompiler(
             binary="amdllpc", args=["-gfxip=9.0.0", "-verify-ir", "-auto-layout-desc"]
         ),
-        binaries=[binary_manager.get_binary_path_by_name("amdllpc").binary],
+        binaries=[binary_manager.get_binary_by_name("amdllpc")],
     )
     device_list.devices.extend([device])
     # Don't add to active devices, since this is mostly just an example.


### PR DESCRIPTION
There is no need to download this when generating the settings.json file; we only need the Binary data structure, not the actual binary path (which requires downloading and extracting).