### PR TITLE
gfauto: alternating glsl- and spirv-fuzz

### DIFF
--- a/gfauto/gfautotests/test_fuzz.py
+++ b/gfauto/gfautotests/test_fuzz.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 The GraphicsFuzz Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gfauto import fuzz
+
+
+def test_get_fuzzing_tool_pattern() -> None:
+    assert fuzz.get_fuzzing_tool_pattern(0, 0) == [fuzz.FuzzingTool.GLSL_FUZZ]
+    assert fuzz.get_fuzzing_tool_pattern(1, 0) == [fuzz.FuzzingTool.GLSL_FUZZ]
+    assert fuzz.get_fuzzing_tool_pattern(0, 1) == [fuzz.FuzzingTool.SPIRV_FUZZ]
+    assert fuzz.get_fuzzing_tool_pattern(1, 1) == [
+        fuzz.FuzzingTool.GLSL_FUZZ,
+        fuzz.FuzzingTool.SPIRV_FUZZ,
+    ]
+
+    assert fuzz.get_fuzzing_tool_pattern(2, 1) == [
+        fuzz.FuzzingTool.GLSL_FUZZ,
+        fuzz.FuzzingTool.GLSL_FUZZ,
+        fuzz.FuzzingTool.SPIRV_FUZZ,
+    ]
+
+    assert fuzz.get_fuzzing_tool_pattern(1, 2) == [
+        fuzz.FuzzingTool.GLSL_FUZZ,
+        fuzz.FuzzingTool.SPIRV_FUZZ,
+        fuzz.FuzzingTool.SPIRV_FUZZ,
+    ]


### PR DESCRIPTION
Add --spirv_fuzz_iterations S and --glsl_fuzz_iterations G for specifying the number of times to run each tool. E.g. G=2,S=1 will run glsl-fuzz twice, then spirv-fuzz once, then repeat. The default is just glsl-fuzz.