### PR TITLE
gfauto: improve "error:" crash signature

### DIFF
--- a/gfauto/gfauto/signature_util.py
+++ b/gfauto/gfauto/signature_util.py
@@ -106,7 +106,7 @@ PATTERN_SWIFT_SHADER_ABORT = re.compile(r":\d+ ABORT:(.*)")
 
 PATTERN_SWIFT_SHADER_WARNING = re.compile(r":\d+ WARNING:(.*)")
 
-PATTERN_CATCH_ALL_ERROR = re.compile(r"\nERROR: (.*)")
+PATTERN_CATCH_ALL_ERROR = re.compile(r"\nERROR: (.*)", flags=re.IGNORECASE)
 
 # [\s\S] matches anything, including newlines.
 PATTERN_LLVM_FATAL_ERROR = re.compile(


### PR DESCRIPTION
Make the "ERROR: blah" pattern case insensitive, which should help catch NIR error messages.