### PR TITLE
gfauto: improve download/run_cts...

### DIFF
--- a/gfauto/README.md
+++ b/gfauto/README.md
@@ -44,65 +44,7 @@ Install and configure plugins:
 
 Add `whitelist.dic` as a custom dictionary (search for "Spelling" in Actions). Do not add words via PyCharm's "Quick Fixes" feature, as the word will only be added to your personal dictionary. Instead, manually add the word to `whitelist.dic`.
 
-## Imports
-
-We use the `black` Python code formatter and `isort` for sorting imports.
-
-We also use the following import style, which is not automatically checked: use the package name (e.g. `gfauto`) and only import modules, not functions. For example:
-
-
-```python
-# Good: importing a module
-from gfauto import binaries_util
-
-binaries_util.add_common_tags_from_platform_suffix(...)  # using a function
-b = binaries_util.BinaryManager()  # using a class
-d = binaries_util.DEFAULT_BINARIES  # using a variable
-
-
-# Bad: directly importing a function, class, variable
-from gfauto.binaries_util import add_common_tags_from_platform_suffix, BinaryManager, DEFAULT_BINARIES
-
-add_common_tags_from_platform_suffix(...)
-b = BinaryManager()
-d = DEFAULT_BINARIES
-
-
-# Bad: importing from "."
-from . import binaries_util
-
-
-# Bad: import from "." AND importing a function
-from .binaries_util import add_common_tags_from_platform_suffix
-
-
-# OK: importing "check" and "log" functions directly
-from gfauto.gflogging import log
-from gfauto.util import check
-
-log("Running")
-check(1 + 1 == 2, AssertionError("1 + 1 should be 2"))
-
-
-# OK: importing types for type annotations
-from typing import Dict, List, Optional, Union
-
-def prepend_catchsegv_if_available(cmd: List[str]) -> List[str]:
-    ...
-
-
-# OK: importing Path
-from pathlib import Path
-
-def tool_path(tool: str) -> Path:
-    return Path(tool)
-
-
-# OK: importing generated protobuf types
-from gfauto.settings_pb2 import Settings
-
-DEFAULT_SETTINGS = Settings()
-```
+## [Coding conventions](docs/conventions.md)
 
 ## Symlinking other scripts
 

--- a/gfauto/docs/conventions.md
+++ b/gfauto/docs/conventions.md
@@ -1,0 +1,47 @@
+# Coding conventions
+
+* Functions will often return their `output_dir` parameter. This allows for concise pipelining e.g.
+
+```python
+temp = f(input_dir=temp, output_dir=work_dir / "1")
+temp = f(input_dir=temp, output_dir=work_dir / "2")
+temp = f(input_dir=temp, output_dir=work_dir / "3")
+```
+
+* Imports:
+  * We use the `black` Python code formatter and `isort` for sorting imports.
+  * We also use the following import style, which is not automatically checked:
+
+```python
+import random  # Standard modules come first (isort takes care of this).
+import re      # Import the module only, not classes or functions.
+import subprocess
+from pathlib import Path  # Exception: Path.
+from typing import Iterable, List, Optional # Exception: typing.
+
+from gfauto import (  # Use "from gfauto import MODULE".
+    amber_converter,
+    android_device,
+    binaries_util,
+    fuzz,
+    gflogging,
+    glsl_generate_util,
+    host_device_util,
+    interrupt_util,
+    result_util,
+    shader_compiler_util,
+    shader_job_util,
+    signature_util,
+    spirv_opt_util,
+    subprocess_util,
+    test_util,
+    tool,
+    util,
+)
+from gfauto.device_pb2 import Device  # Exception: protobuf classes.
+from gfauto.gflogging import log  # Exception: log.
+from gfauto.settings_pb2 import Settings
+from gfauto.test_pb2 import Test, TestGlsl
+from gfauto.util import check  # Exception: check.
+```
+

--- a/gfauto/gfauto/download_cts_gf_tests.py
+++ b/gfauto/gfauto/download_cts_gf_tests.py
@@ -35,8 +35,8 @@ from gfauto import (
 
 
 def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
-    git_tool: Path, cookie: str, binaries: binaries_util.BinaryManager
-) -> None:
+    git_tool: Path, cookie: str, output_shaders_dir: Path,
+) -> Path:
     work_dir = Path() / "temp" / ("cts_" + fuzz.get_random_name())
 
     latest_change = gerrit_util.get_latest_deqp_change(cookie)
@@ -99,7 +99,7 @@ def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
 
     subprocess_util.run(cmd, verbose=True, working_dir=work_dir)
 
-    shader_dir = util.copy_dir(
+    return util.copy_dir(
         cts_out
         / "external"
         / "vulkancts"
@@ -107,9 +107,18 @@ def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
         / "vulkan"
         / "amber"
         / "graphicsfuzz",
-        Path() / "graphicsfuzz",
+        output_shaders_dir,
     )
 
+
+GERRIT_COOKIE_ARGUMENT_DESCRIPTION = (
+    "The Gerrit cookie used for authentication. To get this, log in to the Khronos Gerrit page in your "
+    "browser and paste the following into the JavaScript console (F12) to copy the cookie to your clipboard: "
+    "copy(document.cookie.match(/GerritAccount=([^;]*)/)[1])"
+)
+
+
+def extract_shaders(shader_dir: Path, binaries: binaries_util.BinaryManager) -> None:
     for amber_file in shader_dir.glob("*.amber"):
         amber_converter.extract_shaders(
             amber_file, output_dir=amber_file.parent, binaries=binaries
@@ -121,13 +130,6 @@ def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
         ]
 
         util.create_zip(amber_file.with_suffix(".zip"), zip_files)
-
-
-GERRIT_COOKIE_ARGUMENT_DESCRIPTION = (
-    "The Gerrit cookie used for authentication. To get this, log in to the Khronos Gerrit page in your "
-    "browser and paste the following into the JavaScript console (F12) to copy the cookie to your clipboard: "
-    "copy(document.cookie.match(/GerritAccount=([^;]*)/)[1])"
-)
 
 
 def main() -> None:
@@ -157,7 +159,9 @@ def main() -> None:
 
     binaries = binaries_util.get_default_binary_manager(settings=settings)
 
-    download_cts_graphicsfuzz_tests(git_tool, cookie, binaries)
+    shaders_dir = Path() / "graphicsfuzz"
+    download_cts_graphicsfuzz_tests(git_tool, cookie, shaders_dir)
+    extract_shaders(shaders_dir, binaries)
 
 
 if __name__ == "__main__":

--- a/gfauto/gfauto/download_cts_gf_tests.py
+++ b/gfauto/gfauto/download_cts_gf_tests.py
@@ -112,7 +112,8 @@ def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
 
 
 GERRIT_COOKIE_ARGUMENT_DESCRIPTION = (
-    "The Gerrit cookie used for authentication. To get this, log in to the Khronos Gerrit page in your "
+    "The Gerrit cookie used for authentication. Requires Khronos membership. "
+    "To get this, log in to the Khronos Gerrit page in your "
     "browser and paste the following into the JavaScript console (F12) to copy the cookie to your clipboard: "
     "copy(document.cookie.match(/GerritAccount=([^;]*)/)[1])"
 )
@@ -136,7 +137,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Downloads the latest GraphicsFuzz AmberScript tests from vk-gl-cts, "
         "including those in pending CLs. "
-        "Requires Git."
+        "Requires Git. Requires Khronos membership."
     )
 
     parser.add_argument("gerrit_cookie", help=GERRIT_COOKIE_ARGUMENT_DESCRIPTION)


### PR DESCRIPTION
Improve `run_cts_gf_tests` and `download_cts_gf_tests`. Now runs spirv-opt with -O, -Os, and a custom, longer set of arguments.

Refactored to allow extracting shaders from .amber files without having to download the .amber files from CTS. Useful if you want to manually add some .amber files that are not yet submitted to the CTS.