### PR TITLE
Add support for spirv-fuzz donors to gfauto

### DIFF
--- a/gfauto/.idea/inspectionProfiles/profiles_settings.xml
+++ b/gfauto/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <settings>
     <option name="PROJECT_PROFILE" value="gfauto_inspections" />
+    <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>
 </component>

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -420,19 +420,6 @@ def fuzz_spirv(  # pylint: disable=too-many-locals;
         language_suffix=shader_job_util.SUFFIXES_SPIRV_FUZZ_INPUT,
     )
 
-    # Create list of donor file names from the given shaders
-    donor_shaders = []
-    for donor_shader_job in spirv_fuzz_shaders:
-        for suffix in shader_job_util.get_related_suffixes_that_exist(
-            donor_shader_job, shader_job_util.EXT_ALL, [shader_job_util.SUFFIX_SPIRV],
-        ):
-            donor_shaders.append(str(donor_shader_job.with_suffix(suffix)) + "\n")
-
-    donors_list = staging_dir / "donors.txt"
-    with util.file_open_text(donors_list, "w") as donors_file:
-        donors_file.writelines(donor_shaders)
-
-    # TODO: Allow using downloaded spirv-fuzz.
     try:
         with util.file_open_text(staging_dir / "log.txt", "w") as log_file:
             try:
@@ -441,8 +428,8 @@ def fuzz_spirv(  # pylint: disable=too-many-locals;
                     binary_manager.get_binary_path_by_name("spirv-fuzz").path,
                     reference_spirv_shader_job,
                     template_source_dir / test_util.VARIANT_DIR / test_util.SHADER_JOB,
+                    donor_shader_job_paths=spirv_fuzz_shaders,
                     seed=str(random.getrandbits(spirv_fuzz_util.GENERATE_SEED_BITS)),
-                    other_args=["--donors=" + str(donors_list)],
                 )
             finally:
                 gflogging.pop_stream_for_logging()

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -400,7 +400,7 @@ def handle_test(
     return issue_found
 
 
-def fuzz_spirv(
+def fuzz_spirv(  # pylint: disable=too-many-locals;
     staging_dir: Path,
     reports_dir: Path,
     fuzz_failures_dir: Path,
@@ -421,16 +421,16 @@ def fuzz_spirv(
     )
 
     # Create list of donor file names from the given shaders
+    donor_shaders = []
+    for donor_shader_job in spirv_fuzz_shaders:
+        for suffix in shader_job_util.get_related_suffixes_that_exist(
+            donor_shader_job, shader_job_util.EXT_ALL, [shader_job_util.SUFFIX_SPIRV],
+        ):
+            donor_shaders.append(str(donor_shader_job.with_suffix(suffix)))
+
     donors_list = staging_dir / "donors.txt"
-    print(spirv_fuzz_shaders[0].with_suffix(shader_job_util.SUFFIX_SPIRV))
     with util.file_open_text(donors_list, "w") as donors_file:
-        donors_file.write("\n".join(
-            ["\n".join([str(donor_shader_job.with_suffix(suffix)) for suffix in
-                        shader_job_util.get_related_suffixes_that_exist(
-                                      donor_shader_job,
-                                      shader_job_util.EXT_ALL,
-                                      [shader_job_util.SUFFIX_SPIRV])
-                        ]) for donor_shader_job in spirv_fuzz_shaders]))
+        donors_file.writelines(donor_shaders)
 
     # TODO: Allow using downloaded spirv-fuzz.
     try:

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -420,6 +420,12 @@ def fuzz_spirv(
         language_suffix=shader_job_util.SUFFIXES_SPIRV_FUZZ_INPUT,
     )
 
+    # Create list of donor file names from the given shaders
+    donors_list = staging_dir / "donors.txt"
+    with util.file_open_text(donors_list, "w") as donors_file:
+        donors_file.write("\n".join([str(donor_path.with_suffix(shader_job_util.SUFFIX_SPIRV))
+                                     for donor_path in spirv_fuzz_shaders]))
+
     # TODO: Allow using downloaded spirv-fuzz.
     try:
         with util.file_open_text(staging_dir / "log.txt", "w") as log_file:
@@ -430,6 +436,7 @@ def fuzz_spirv(
                     reference_spirv_shader_job,
                     template_source_dir / test_util.VARIANT_DIR / test_util.SHADER_JOB,
                     seed=str(random.getrandbits(spirv_fuzz_util.GENERATE_SEED_BITS)),
+                    other_args=["--donors=" + str(donors_list)],
                 )
             finally:
                 gflogging.pop_stream_for_logging()

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -426,7 +426,7 @@ def fuzz_spirv(  # pylint: disable=too-many-locals;
         for suffix in shader_job_util.get_related_suffixes_that_exist(
             donor_shader_job, shader_job_util.EXT_ALL, [shader_job_util.SUFFIX_SPIRV],
         ):
-            donor_shaders.append(str(donor_shader_job.with_suffix(suffix)))
+            donor_shaders.append(str(donor_shader_job.with_suffix(suffix)) + "\n")
 
     donors_list = staging_dir / "donors.txt"
     with util.file_open_text(donors_list, "w") as donors_file:

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -422,9 +422,15 @@ def fuzz_spirv(
 
     # Create list of donor file names from the given shaders
     donors_list = staging_dir / "donors.txt"
+    print(spirv_fuzz_shaders[0].with_suffix(shader_job_util.SUFFIX_SPIRV))
     with util.file_open_text(donors_list, "w") as donors_file:
-        donors_file.write("\n".join([str(donor_path.with_suffix(shader_job_util.SUFFIX_SPIRV))
-                                     for donor_path in spirv_fuzz_shaders]))
+        donors_file.write("\n".join(
+            ["\n".join([str(donor_shader_job.with_suffix(suffix)) for suffix in
+                        shader_job_util.get_related_suffixes_that_exist(
+                                      donor_shader_job,
+                                      shader_job_util.EXT_ALL,
+                                      [shader_job_util.SUFFIX_SPIRV])
+                        ]) for donor_shader_job in spirv_fuzz_shaders]))
 
     # TODO: Allow using downloaded spirv-fuzz.
     try:

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -238,3 +238,4 @@ SIGINT
 signum
 pathsep
 cts
+writelines


### PR DESCRIPTION
gfauto will now populate, per test, a list of donor shaders based on
the corpus of SPIR-V shaders provided.