### PR TITLE
Guard against undefined behaviour in the reducer

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/GloballyTruncateLoops.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/GloballyTruncateLoops.java
@@ -159,12 +159,12 @@ public class GloballyTruncateLoops {
         assert firstNonPrecisionDeclaration != null;
         // Add loop bound variable.
         tu.addDeclarationBefore(new VariablesDeclaration(new QualifiedType(BasicType.INT,
-                Arrays.asList(TypeQualifier.CONST)), new VariableDeclInfo(loopBoundName,null,
+                Arrays.asList(TypeQualifier.CONST)), new VariableDeclInfo(loopBoundName, null,
                 new Initializer(new IntConstantExpr(new Integer(loopLimit).toString())))),
             firstNonPrecisionDeclaration);
         // Add loop count variable.
         tu.addDeclarationBefore(new VariablesDeclaration(BasicType.INT,
-                new VariableDeclInfo(loopCountName,null,
+                new VariableDeclInfo(loopCountName, null,
                     new Initializer(new IntConstantExpr("0")))),
             firstNonPrecisionDeclaration);
 

--- a/common/src/main/java/com/graphicsfuzz/common/util/MakeArrayAccessesInBounds.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/MakeArrayAccessesInBounds.java
@@ -14,31 +14,26 @@
  * limitations under the License.
  */
 
-package com.graphicsfuzz.generator.transformation.donation;
+package com.graphicsfuzz.common.util;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.TranslationUnit;
-import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
-import com.graphicsfuzz.common.ast.expr.BinOp;
-import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
 import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
-import com.graphicsfuzz.common.ast.expr.ParenExpr;
-import com.graphicsfuzz.common.ast.expr.TernaryExpr;
 import com.graphicsfuzz.common.ast.expr.UIntConstantExpr;
 import com.graphicsfuzz.common.ast.type.ArrayType;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.ast.type.Type;
-import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
 import com.graphicsfuzz.common.typing.Typer;
 import com.graphicsfuzz.util.Constants;
 
 public class MakeArrayAccessesInBounds extends ScopeTrackingVisitor {
 
-  private Typer typer;
+  private final Typer typer;
 
   private MakeArrayAccessesInBounds(Typer typer) {
     this.typer = typer;
@@ -46,12 +41,18 @@ public class MakeArrayAccessesInBounds extends ScopeTrackingVisitor {
 
   /**
    * Clamp array / vector / matrix accesses to ensure they will be in-bounds.
-   * @param node AST node under which accesses should be made in bound.
-   * @param typer Type info for the AST.
-   * @param tu The translation unit in which node is contained.
+   * @param tu The translation unit in which accesses are to be made in-bounds.
    */
-  public static void makeInBounds(IAstNode node, Typer typer, TranslationUnit tu) {
-    new MakeArrayAccessesInBounds(typer).visit(node);
+  public static void makeInBounds(TranslationUnit tu) {
+    new MakeArrayAccessesInBounds(new Typer(tu)).visit(tu);
+  }
+
+  /**
+   * Clamp accesses in all shaders in a shader job.
+   * @param shaderJob The shader job to be made in-bounds.
+   */
+  public static void makeInBounds(ShaderJob shaderJob) {
+    shaderJob.getShaders().forEach(MakeArrayAccessesInBounds::makeInBounds);
   }
 
   @Override

--- a/common/src/test/java/com/graphicsfuzz/common/util/GloballyTruncateLoopsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/GloballyTruncateLoopsTest.java
@@ -20,7 +20,6 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import java.util.Optional;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class GloballyTruncateLoopsTest {
@@ -94,6 +93,30 @@ public class GloballyTruncateLoopsTest {
 
     for (TranslationUnit tu : shaderJob.getShaders()) {
       CompareAsts.assertEqualAsts(expectedShader, tu);
+    }
+
+  }
+
+  @Test
+  public void doNotAddDeclarationsIfNothingToTruncate() throws Exception {
+
+    // If no loop truncation is required, the loop bound and loop count declarations
+    // should not be emitted.
+
+    final String shader = "#version 310 es\n"
+        + "void main() {\n"
+        + "  do {\n"
+        + "  } while(false);\n"
+        + "}\n";
+
+    final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(),
+        new PipelineInfo(), ParseHelper.parse(shader, ShaderKind.VERTEX),
+        ParseHelper.parse(shader, ShaderKind.FRAGMENT));
+
+    GloballyTruncateLoops.truncate(shaderJob, 100, "LOOP_COUNT", "LOOP_BOUND");
+
+    for (TranslationUnit tu : shaderJob.getShaders()) {
+      CompareAsts.assertEqualAsts(shader, tu);
     }
 
   }

--- a/common/src/test/java/com/graphicsfuzz/common/util/MakeArrayAccessesInBoundsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/MakeArrayAccessesInBoundsTest.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package com.graphicsfuzz.generator.transformation.donation;
+package com.graphicsfuzz.common.util;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
-import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
-import com.graphicsfuzz.common.typing.Typer;
-import com.graphicsfuzz.common.util.CompareAsts;
-import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.util.Constants;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -36,8 +32,7 @@ public class MakeArrayAccessesInBoundsTest {
     final String expected = "#version 300 es\nvoid main() { int A[5]; int x = 17; A["
     + Constants.GLF_MAKE_IN_BOUNDS_INT + "(x, 5)] = 2; }";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu);
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -50,8 +45,7 @@ public class MakeArrayAccessesInBoundsTest {
           + "  /* column */ [" + Constants.GLF_MAKE_IN_BOUNDS_INT + "(y, 4)]"
           + "  /* row */ [" + Constants.GLF_MAKE_IN_BOUNDS_INT + "(z, 2)] = 2.0; }";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu);
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -81,8 +75,7 @@ public class MakeArrayAccessesInBoundsTest {
           + "  f = v[" + Constants.GLF_MAKE_IN_BOUNDS_INT + "(z, 4)];"
           + "}";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu);
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -100,8 +93,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "  vec3 f = stuff[" + Constants.GLF_MAKE_IN_BOUNDS_UINT + "(x, 16u)];"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu);
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -120,8 +112,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "uselessOut), 16u)];"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu);
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -133,8 +124,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "  stuff[3u] = 1.0;"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    final Typer typer = new Typer(tu);
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(shader)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
   }
@@ -162,7 +152,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "  myS.A[" + Constants.GLF_MAKE_IN_BOUNDS_INT + "(x, 3)] = 6;\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    MakeArrayAccessesInBounds.makeInBounds(tu, new Typer(tu), tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
@@ -191,7 +181,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "  myS.A[" + Constants.GLF_MAKE_IN_BOUNDS_INT + "(x, 3)] = 6;\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    MakeArrayAccessesInBounds.makeInBounds(tu, new Typer(tu), tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
@@ -217,7 +207,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "  foo(A, 7);\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    MakeArrayAccessesInBounds.makeInBounds(tu, new Typer(tu), tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
@@ -245,7 +235,7 @@ public class MakeArrayAccessesInBoundsTest {
         + "  foo(A, 7);\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(shader);
-    MakeArrayAccessesInBounds.makeInBounds(tu, new Typer(tu), tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     CompareAsts.assertEqualAsts(expected, tu);
   }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -43,10 +43,10 @@ import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
-import com.graphicsfuzz.common.typing.Typer;
 import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ListConcat;
+import com.graphicsfuzz.common.util.MakeArrayAccessesInBounds;
 import com.graphicsfuzz.common.util.OpenGlConstants;
 import com.graphicsfuzz.common.util.ParseHelper;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
@@ -58,7 +58,6 @@ import com.graphicsfuzz.generator.fuzzer.OpaqueExpressionGenerator;
 import com.graphicsfuzz.generator.transformation.donation.DonationContext;
 import com.graphicsfuzz.generator.transformation.donation.DonationContextFinder;
 import com.graphicsfuzz.generator.transformation.donation.IncompatibleDonorException;
-import com.graphicsfuzz.generator.transformation.donation.MakeArrayAccessesInBounds;
 import com.graphicsfuzz.generator.transformation.injection.IInjectionPoint;
 import com.graphicsfuzz.generator.transformation.injection.InjectionPoints;
 import com.graphicsfuzz.generator.util.GenerationParams;
@@ -128,9 +127,8 @@ public abstract class DonateCodeTransformation implements ITransformation {
   private TranslationUnit prepareTranslationUnit(File donorFile, IRandom generator)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     final TranslationUnit tu = ParseHelper.parse(donorFile);
-    final Typer typer = new Typer(tu);
     // To avoid undefined behaviours, make all array access in bounds for every donor.
-    MakeArrayAccessesInBounds.makeInBounds(tu, typer, tu);
+    MakeArrayAccessesInBounds.makeInBounds(tu);
     addPrefixes(tu, getDeclaredFunctionNames(tu));
     // Add prefixed versions of these builtins, in case they are used.
     // Use explicit precision qualifier to avoid introducing errors if there are no float precision

--- a/util/src/main/java/com/graphicsfuzz/util/Constants.java
+++ b/util/src/main/java/com/graphicsfuzz/util/Constants.java
@@ -87,4 +87,13 @@ public final class Constants {
   // the buffer.
   public static final String COMPUTE_FIELDS = "fields";
 
+  // The maximum number of total loop iterations when using a global loop limiter.
+  public static final int GLF_GLOBAL_LOOP_BOUND_VALUE = 100;
+
+  // Name of the global loop counter variable when using a global loop limiter.
+  public static final String GLF_GLOBAL_LOOP_COUNT_NAME = "_GLF_global_loop_count";
+
+  // Name of the constant storing the total loop bound when using a global loop limiter.
+  public static final String GLF_GLOBAL_LOOP_BOUND_NAME = "_GLF_global_loop_bound";
+
 }


### PR DESCRIPTION
This change leverages two existing pieces of functionality, for adding
global loop limiting to a shader, and making array accesses in-bounds,
to make a semantics-changing reduction less prone to undefined
behaviour due to long-running loops or out-of-bounds
array/vector/matrix accesses.