### PR TITLE
Array/struct canonical constants + variable initialization utility

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
@@ -17,8 +17,13 @@
 package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.decl.ArrayInfo;
+import com.graphicsfuzz.common.ast.expr.ArrayConstructorExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 public class ArrayType extends UnqualifiedType {
 
@@ -68,13 +73,18 @@ public class ArrayType extends UnqualifiedType {
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
-    return false;
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+    return baseType.hasCanonicalConstant(scope) && arrayInfo.hasConstantSize();
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    throw new RuntimeException("No canonical constant for ArrayType");
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    final Expr canonicalConstantForBaseType = baseType.getCanonicalConstant(scope);
+    final List<Expr> componentConstants = new ArrayList<>();
+    for (int i = 0; i < arrayInfo.getConstantSize(); i++) {
+      componentConstants.add(canonicalConstantForBaseType.clone());
+    }
+    return new ArrayConstructorExpr(this.clone(), componentConstants);
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/AtomicIntType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/AtomicIntType.java
@@ -18,6 +18,8 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import java.util.Optional;
 
 public class AtomicIntType extends BuiltinType {
 
@@ -33,13 +35,13 @@ public class AtomicIntType extends BuiltinType {
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
     return false;
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    assert !hasCanonicalConstant();
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
@@ -23,9 +23,11 @@ import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
 import com.graphicsfuzz.common.ast.expr.TypeConstructorExpr;
 import com.graphicsfuzz.common.ast.expr.UIntConstantExpr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class BasicType extends BuiltinType {
 
@@ -146,12 +148,12 @@ public class BasicType extends BuiltinType {
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
     return true;
   }
 
   @Override
-  public Expr getCanonicalConstant() {
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
     if (this == FLOAT) {
       return new FloatConstantExpr("1.0");
     }
@@ -164,7 +166,8 @@ public class BasicType extends BuiltinType {
     if (this == BOOL) {
       return new BoolConstantExpr(true);
     }
-    return new TypeConstructorExpr(toString().toString(), getElementType().getCanonicalConstant());
+    return new TypeConstructorExpr(toString(),
+        getElementType().getCanonicalConstant(scope));
   }
 
   public BasicType getElementType() {

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/ImageType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/ImageType.java
@@ -18,6 +18,8 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import java.util.Optional;
 
 public class ImageType extends BuiltinType {
 
@@ -165,13 +167,13 @@ public class ImageType extends BuiltinType {
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    assert !hasCanonicalConstant();
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/QualifiedType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/QualifiedType.java
@@ -18,10 +18,12 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -164,13 +166,13 @@ public class QualifiedType extends Type {
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
-    return targetType.hasCanonicalConstant();
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+    return targetType.hasCanonicalConstant(scope);
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    return targetType.getCanonicalConstant();
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    return targetType.getCanonicalConstant(scope);
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/SamplerType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/SamplerType.java
@@ -18,6 +18,8 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import java.util.Optional;
 
 public class SamplerType extends BuiltinType {
 
@@ -197,13 +199,13 @@ public class SamplerType extends BuiltinType {
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    assert !hasCanonicalConstant();
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructDefinitionType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructDefinitionType.java
@@ -17,7 +17,9 @@
 package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
+import com.graphicsfuzz.common.ast.expr.TypeConstructorExpr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -153,15 +155,20 @@ public class StructDefinitionType extends UnqualifiedType {
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
-    // TODO: add generation of canonical constants.
-    return false;
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+    // To give a constant for a struct, the struct needs to have a name and it must be possible
+    // to make a constant for every field of the struct.
+    return hasStructNameType() && fieldTypes
+        .stream()
+        .allMatch(item -> item.hasCanonicalConstant(scope));
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    throw new UnsupportedOperationException("Support for canonical struct constants not yet added"
-        + ".");
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    return new TypeConstructorExpr(getStructNameType().getName(),
+        fieldTypes.stream()
+            .map(item -> item.getCanonicalConstant(scope))
+            .collect(Collectors.toList()));
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructNameType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructNameType.java
@@ -18,6 +18,8 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import java.util.Optional;
 
 public final class StructNameType extends UnqualifiedType {
 
@@ -67,13 +69,19 @@ public final class StructNameType extends UnqualifiedType {
   }
 
   @Override
-  public final boolean hasCanonicalConstant() {
-    return false;
+  public final boolean hasCanonicalConstant(Optional<Scope> scope) {
+    if (!scope.isPresent()) {
+      throw new RuntimeException("A scope must be provided when checking whether a struct type "
+          + "has a canonical constant; the parameter is optional in general to ease the case "
+          + "where a canonical constant is required for a type that is guaranteed not to involve "
+          + "a struct.");
+    }
+    return scope.get().lookupStructName(name).hasCanonicalConstant(scope);
   }
 
   @Override
-  public final Expr getCanonicalConstant() {
-    throw new UnsupportedOperationException("Canonical constants not yet supported for structs.");
+  public final Expr getCanonicalConstant(Optional<Scope> scope) {
+    return scope.get().lookupStructName(name).getCanonicalConstant(scope);
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/Type.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/Type.java
@@ -18,16 +18,26 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.expr.Expr;
+import com.graphicsfuzz.common.typing.Scope;
 import java.util.List;
+import java.util.Optional;
 
 public abstract class Type implements IAstNode {
 
   @Override
   public abstract Type clone();
 
-  public abstract boolean hasCanonicalConstant();
+  public abstract boolean hasCanonicalConstant(Optional<Scope> scope);
 
-  public abstract Expr getCanonicalConstant();
+  public final boolean hasCanonicalConstant() {
+    return hasCanonicalConstant(Optional.empty());
+  }
+
+  public abstract Expr getCanonicalConstant(Optional<Scope> scope);
+
+  public final Expr getCanonicalConstant() {
+    return getCanonicalConstant(Optional.empty());
+  }
 
   public abstract Type getWithoutQualifiers();
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/VoidType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/VoidType.java
@@ -18,6 +18,8 @@ package com.graphicsfuzz.common.ast.type;
 
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import java.util.Optional;
 
 public class VoidType extends BuiltinType {
 
@@ -33,13 +35,13 @@ public class VoidType extends BuiltinType {
   }
 
   @Override
-  public boolean hasCanonicalConstant() {
+  public boolean hasCanonicalConstant(Optional<Scope> scope) {
     return false;
   }
 
   @Override
-  public Expr getCanonicalConstant() {
-    assert !hasCanonicalConstant();
+  public Expr getCanonicalConstant(Optional<Scope> scope) {
+    assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }
 

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/type/StructDefinitionTypeTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/type/StructDefinitionTypeTest.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.graphicsfuzz.common.ast.CompareAstsDuplicate;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.Test;
 
 public class StructDefinitionTypeTest {
@@ -95,7 +97,9 @@ public class StructDefinitionTypeTest {
     StructDefinitionType t = new StructDefinitionType(new StructNameType("astruct"),
         Arrays.asList("x", "y"),
         Arrays.asList(BasicType.MAT4X4, BasicType.VEC4));
-    assertFalse(t.getStructNameType().hasCanonicalConstant());
+    assertTrue(t.hasCanonicalConstant());
+    assertEquals("astruct(mat4(1.0), vec4(1.0))",
+        t.getCanonicalConstant().getText());
   }
 
 }

--- a/common/src/main/java/com/graphicsfuzz/common/util/AddInitializers.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/AddInitializers.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.common.util;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.Initializer;
+import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
+import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.ast.type.ArrayType;
+import com.graphicsfuzz.common.ast.type.Type;
+import com.graphicsfuzz.common.ast.type.TypeQualifier;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
+import java.util.Optional;
+
+public class AddInitializers {
+
+  /**
+   * Adds an at-declaration initializer to every uninitialized variable in the given shader job,
+   * unless it is not legitimate to initialize a variable (e.g. this is true for a uniform), or if
+   * there is no way to make a canonical constant for the the variable's type (e.g., there is no
+   * way to initialize a nameless struct at declaration).
+   * @param shaderJob The shader job in which variables are to be initialized.
+   */
+  public static void addInitializers(ShaderJob shaderJob) {
+
+    // Consider every shader in the shader job.
+    for (TranslationUnit tu : shaderJob.getShaders()) {
+
+      new ScopeTrackingVisitor() {
+
+        @Override
+        public void visitVariablesDeclaration(VariablesDeclaration variablesDeclaration) {
+          super.visitVariablesDeclaration(variablesDeclaration);
+
+          // Do not initialize shader input/output variables, or uniforms.
+          if (variablesDeclaration.getBaseType().hasQualifier(TypeQualifier.SHADER_INPUT)
+              || variablesDeclaration.getBaseType().hasQualifier(TypeQualifier.SHADER_OUTPUT)
+              || variablesDeclaration.getBaseType().hasQualifier(TypeQualifier.UNIFORM)) {
+            return;
+          }
+          for (VariableDeclInfo vdi : variablesDeclaration.getDeclInfos()) {
+            if (vdi.hasInitializer()) {
+              // There is already an initializer; nothing to do.
+              continue;
+            }
+            // Work out the type of the variable.
+            Type variableType = variablesDeclaration.getBaseType().getWithoutQualifiers();
+            if (vdi.hasArrayInfo()) {
+              variableType = new ArrayType(variableType, vdi.getArrayInfo());
+            }
+            if (!variableType.hasCanonicalConstant(Optional.of(getCurrentScope()))) {
+              // We don't know how to make a constant for this type, so we cannot add an
+              // initializer.
+              return;
+            }
+            // Add an initializer for this variable.
+            vdi.setInitializer(new Initializer(
+                variableType.getCanonicalConstant(Optional.of(getCurrentScope()))));
+          }
+        }
+      }.visit(tu);
+
+    }
+
+  }
+
+}

--- a/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/ShaderJobFileOperations.java
@@ -321,7 +321,7 @@ public class ShaderJobFileOperations {
   }
 
   /**
-   * This the given shaderJob a compute shader job?
+   * Is the given shaderJob a compute shader job?
    * @param shaderJobFile A shader job to check.
    * @return true if and only if this is a compute shader job.
    */

--- a/common/src/test/java/com/graphicsfuzz/common/util/AddInitializersTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/AddInitializersTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.common.util;
+
+import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import java.util.Optional;
+import org.junit.Test;
+
+public class AddInitializersTest {
+
+  @Test
+  public void basicTest() throws Exception {
+    final String shader = "#version 310 es\n"
+        + "precision highp float;\n"
+        + "uniform float time;\n"
+        + "layout(location = 0) out vec4 _GLF_color;\n"
+        + "struct S {\n"
+        + "  int a;\n"
+        + "  float b[3];\n"
+        + "} myS;\n"
+        + "S anotherS;\n"
+        + "const int g;\n"
+        + "const int h = 2;\n"
+        + "void main() {"
+        + "  vec2 v;\n"
+        + "  mat2x3 m;\n"
+        + "  bvec4 b;\n"
+        + "}\n";
+    final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(), new PipelineInfo(),
+        ParseHelper.parse(shader, ShaderKind.FRAGMENT));
+    AddInitializers.addInitializers(shaderJob);
+
+    final String expected = "#version 310 es\n"
+        + "precision highp float;\n"
+        + "uniform float time;\n"
+        + "layout(location = 0) out vec4 _GLF_color;\n"
+        + "struct S {\n"
+        + "  int a;\n"
+        + "  float b[3];\n"
+        + "} myS = S(1, float[3](1.0, 1.0, 1.0));\n"
+        + "S anotherS = S(1, float[3](1.0, 1.0, 1.0));\n"
+        + "const int g = 1;\n"
+        + "const int h = 2;\n"
+        + "void main() {"
+        + "  vec2 v = vec2(1.0);\n"
+        + "  mat2x3 m = mat2x3(1.0);\n"
+        + "  bvec4 b = bvec4(true);\n"
+        + "}\n";
+    CompareAsts.assertEqualAsts(expected, shaderJob.getFragmentShader().get());
+
+
+
+  }
+
+}

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddJumpMutation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddJumpMutation.java
@@ -35,6 +35,7 @@ import com.graphicsfuzz.generator.mutateapi.Mutation;
 import com.graphicsfuzz.generator.transformation.injection.IInjectionPoint;
 import com.graphicsfuzz.generator.util.GenerationParams;
 import java.util.ArrayList;
+import java.util.Optional;
 
 public class AddJumpMutation implements Mutation {
 
@@ -105,7 +106,7 @@ public class AddJumpMutation implements Mutation {
                                    GenerationParams generationParams) {
     Type returnType = injectionPoint.getEnclosingFunction().getPrototype().getReturnType();
     Stmt stmtToInject;
-    if (returnType.hasCanonicalConstant()) {
+    if (returnType.hasCanonicalConstant(Optional.of(injectionPoint.scopeAtInjectionPoint()))) {
       stmtToInject = new ReturnStmt(returnType.getCanonicalConstant());
     } else if (returnType.getWithoutQualifiers() == VoidType.VOID) {
       stmtToInject = new ReturnStmt();


### PR DESCRIPTION
Adds a utility for adding initializers to all variables in a shader
job, and in the process adds support for generation of canonical
constants for arrays and structs.  The latter requires passing a scope
around during canonical constant generation, to look up the
definitions of named structs.