### PR TITLE
Simplify literals more aggressively in the reducer

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/CheckAstFeatureVisitor.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/CheckAstFeatureVisitor.java
@@ -73,6 +73,9 @@ public abstract class CheckAstFeatureVisitor extends ScopeTrackingVisitor {
    * Use this method to register that the feature of interest has been found.
    */
   protected void trigger() {
-    this.triggerFunction = Optional.of(getEnclosingFunction());
+    if (!atGlobalScope()) {
+      // Only set the trigger function if we are in some function.
+      this.triggerFunction = Optional.of(getEnclosingFunction());
+    }
   }
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
@@ -22,10 +22,8 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
-import com.graphicsfuzz.common.ast.expr.ConstantExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
-import com.graphicsfuzz.common.ast.expr.TypeConstructorExpr;
 import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.BreakStmt;
@@ -33,7 +31,6 @@ import com.graphicsfuzz.common.ast.stmt.ExprCaseLabel;
 import com.graphicsfuzz.common.ast.stmt.IfStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
-import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
 import com.graphicsfuzz.common.util.MacroNames;
 import com.graphicsfuzz.common.util.ShaderKind;
@@ -243,26 +240,6 @@ public abstract class ReductionOpportunitiesBase
         (variableDeclInfo.getInitializer()).getExpr(),
         context.getShadingLanguageVersion(),
         shaderKind);
-  }
-
-  boolean typeIsReducibleToConst(Type type) {
-    return type != null && type.hasCanonicalConstant();
-  }
-
-  boolean isFullyReducedConstant(Expr expr) {
-    if (expr instanceof ConstantExpr) {
-      return true;
-    }
-    if (!(expr instanceof TypeConstructorExpr)) {
-      return false;
-    }
-    TypeConstructorExpr tce = (TypeConstructorExpr) expr;
-    for (int i = 0; i < tce.getNumChildren(); i++) {
-      if (!isFullyReducedConstant(tce.getChild(i))) {
-        return false;
-      }
-    }
-    return true;
   }
 
   public final List<ReductionOpportunityT> getOpportunities() {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
@@ -38,7 +38,7 @@ abstract class SimplifyExprReductionOpportunities
 
   private boolean inLiveInjectedStmtOrDeclaration;
 
-  // Tracks whether we are visiting the components of a loop limiter's declaration (Which includes
+  // Tracks whether we are visiting the components of a loop limiter's declaration (which includes
   // its initializer).  We do not wish to mess with these.
   private boolean inLoopLimiterVariableDeclInfo;
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
@@ -619,7 +619,7 @@ public class ReductionDriverTest {
 
     final String expected = "#version 310 es\n"
         + "void main() {\n"
-        + "  mix(0.0, 1.0, 0.0);\n"
+        + "  mix(1.0, 1.0, 1.0);\n"
         + "}\n";
 
     final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(),

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
@@ -86,7 +86,7 @@ public class ExprToConstantReductionOpportunitiesTest {
   public void testSwitch() throws Exception {
     final String program = "#version 310 es\n"
         + "void main() {\n"
-        + "  switch(0) {\n"
+        + "  switch(1) {\n"
         + "    case - 1:\n"
         + "      1;\n"
         + "  }\n"
@@ -96,6 +96,85 @@ public class ExprToConstantReductionOpportunitiesTest {
         new ReducerContext(true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(0, ops.size());
+  }
+
+  @Test
+  public void testSimplifyLiterals() throws Exception {
+    final String program = "#version 310 es\n"
+        + "struct S {\n"
+        + "  int a;\n"
+        + "  float b;\n"
+        + "};\n"
+        + "void main() {\n"
+        + "  100;\n"
+        + "  200.0;\n"
+        + "  300u;\n"
+        + "  false;\n"
+        + "  vec2(10.0, 1.0);\n"
+        + "  vec3(11.0);\n"
+        + "  vec4(2.0, 3.0, 4.0);\n"
+        + "  ivec2(1, 2);\n"
+        + "  ivec3(1, 4, 6);\n"
+        + "  ivec4(1, 8, 9);\n"
+        + "  uvec2(6u);\n"
+        + "  uvec3(7u, 8u);\n"
+        + "  uvec4(9u, 10u, 11u, 12u);\n"
+        + "  bvec2(false, true);\n"
+        + "  bvec3(true, false, true);\n"
+        + "  bvec4(false, true, false, true);\n"
+        + "  mat2x2(10.0, 20.0, 30.0, 40.0);\n"
+        + "  mat2x3(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);\n"
+        + "  mat2x4(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0);\n"
+        + "  mat3x2(10.0, 20.0, 30.0, 40.0, 50.0, 60.0);\n"
+        + "  mat3x3(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0);\n"
+        + "  mat3x4(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0);\n"
+        + "  mat4x2(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0);\n"
+        + "  mat4x3(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0);\n"
+        + "  mat4x4(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, "
+             + "130.0, 140.0, 150.0, 160.0);\n"
+        + "  S(6.0, 2.0);\n"
+        + "}";
+    final String expected = "#version 310 es\n"
+        + "struct S {\n"
+        + "  int a;\n"
+        + "  float b;\n"
+        + "};\n"
+        + "void main() {\n"
+        + "  1;\n"
+        + "  1.0;\n"
+        + "  1u;\n"
+        + "  true;\n"
+        + "  vec2(1.0);\n"
+        + "  vec3(1.0);\n"
+        + "  vec4(1.0);\n"
+        + "  ivec2(1);\n"
+        + "  ivec3(1);\n"
+        + "  ivec4(1);\n"
+        + "  uvec2(1u);\n"
+        + "  uvec3(1u);\n"
+        + "  uvec4(1u);\n"
+        + "  bvec2(true);\n"
+        + "  bvec3(true);\n"
+        + "  bvec4(true);\n"
+        + "  mat2(1.0);\n"
+        + "  mat2x3(1.0);\n"
+        + "  mat2x4(1.0);\n"
+        + "  mat3x2(1.0);\n"
+        + "  mat3(1.0);\n"
+        + "  mat3x4(1.0);\n"
+        + "  mat4x2(1.0);\n"
+        + "  mat4x3(1.0);\n"
+        + "  mat4(1.0);\n"
+        + "  S(1.0, 1.0);\n"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+        new ReducerContext(true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+            new IdGenerator()));
+    for (SimplifyExprReductionOpportunity op : ops) {
+      op.applyReduction();
+    }
+    CompareAsts.assertEqualAsts(expected, tu);
   }
 
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
@@ -132,7 +132,7 @@ public class ExprToConstantReductionOpportunitiesTest {
         + "  mat4x3(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0);\n"
         + "  mat4x4(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, "
              + "130.0, 140.0, 150.0, 160.0);\n"
-        + "  S(6.0, 2.0);\n"
+        + "  S(6, 2.0);\n"
         + "}";
     final String expected = "#version 310 es\n"
         + "struct S {\n"
@@ -165,7 +165,7 @@ public class ExprToConstantReductionOpportunitiesTest {
         + "  mat4x2(1.0);\n"
         + "  mat4x3(1.0);\n"
         + "  mat4(1.0);\n"
-        + "  S(1.0, 1.0);\n"
+        + "  S(1, 1.0);\n"
         + "}";
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
@@ -99,6 +99,24 @@ public class ExprToConstantReductionOpportunitiesTest {
   }
 
   @Test
+  public void testSwitchMultipleCases() throws Exception {
+    final String program = "#version 310 es\n"
+        + "void main() {\n"
+        + "  switch(1) {\n"
+        + "    case 1:\n"
+        + "    case 2:\n"
+        + "    case 3:\n"
+        + "      1;\n"
+        + "  }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+        new ReducerContext(true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+            new IdGenerator()));
+    assertEquals(0, ops.size());
+  }
+
+  @Test
   public void testSimplifyLiterals() throws Exception {
     final String program = "#version 310 es\n"
         + "struct S {\n"

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
@@ -100,6 +100,8 @@ public class ExprToConstantReductionOpportunitiesTest {
 
   @Test
   public void testSwitchMultipleCases() throws Exception {
+    // This test checks that switch cases are not simplified to canonical literals, because in the
+    // following we do not want multiple identical cases:
     final String program = "#version 310 es\n"
         + "void main() {\n"
         + "  switch(1) {\n"

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
@@ -551,7 +551,7 @@ public class ReductionOpportunitiesTest {
   @Test
   public void testReduceToConstantInLiveCode() throws Exception {
     TranslationUnit tu = ParseHelper.parse("void main() {"
-          + "  float GLF_live3x = sin(4.0);"
+          + "  float GLF_live3x = sin(1.0);"
           + "  float GLF_live3y = GLF_live3x + GLF_live3x;"
           + "}");
     List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
@@ -589,7 +589,7 @@ public class ReductionOpportunitiesTest {
     final String expected = "void main() {"
           + "    int GLF_live3_looplimiter0 = 0;\n"
           + "    for(\n"
-          + "      float GLF_live3sphereNo = 0.0;\n"
+          + "      float GLF_live3sphereNo = 1.0;\n"
           + "      1.0 < 10.0;\n"
           + "      GLF_live3sphereNo ++\n"
           + "  )\n"
@@ -601,8 +601,7 @@ public class ReductionOpportunitiesTest {
           + "    GLF_live3_looplimiter0 ++;\n"
           + "  }"
           + "}\n";
-    assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
-          PrettyPrinterVisitor.prettyPrintAsString(tu));
+    CompareAsts.assertEqualAsts(expected, tu);
 
   }
 


### PR DESCRIPTION
Before this change, the reducer would not attempt to simplify
literals, so that e.g. 8092.6 would remain in a reduced shader, even
if in dead code. This was based on the assumption that the exact form
of final literals would not really be important. However, having
worked a lot with the reducer it is certainly the case that a final
shader that does not involve weird literal values is easier to
understand than one that does. This change allows the reducer to
simplify any literal that is not in canonical form to one that is.

We should keep an eye on the knock-on effect this has on reducer
performance; by creating more reduction opportunities we could see a
performance drop.