### PR TITLE
Get array constructor support right in shading languages

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -44,8 +44,8 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   }
 
   @Override
-  public boolean restrictedArrayIndexing() {
-    return prototype.restrictedArrayIndexing();
+  public boolean supportedArrayConstructors() {
+    return prototype.supportedArrayConstructors();
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -45,8 +45,8 @@ final class Essl100 implements ShadingLanguageVersion {
   }
 
   @Override
-  public boolean restrictedArrayIndexing() {
-    return true;
+  public boolean supportedArrayConstructors() {
+    return false;
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl300.java
@@ -31,6 +31,11 @@ final class Essl300 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedArrayConstructors() {
+    return true;
+  }
+
+  @Override
   public boolean restrictedForLoops() {
     return false;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -45,7 +45,7 @@ final class Glsl110 implements ShadingLanguageVersion {
   }
 
   @Override
-  public boolean restrictedArrayIndexing() {
+  public boolean supportedArrayConstructors() {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl120.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl120.java
@@ -31,6 +31,11 @@ final class Glsl120 extends CompositeShadingLanguageVersion {
   }
 
   @Override
+  public boolean supportedArrayConstructors() {
+    return true;
+  }
+
+  @Override
   public boolean supportedMatrixCompMultNonSquare() {
     return true;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -151,7 +151,11 @@ public interface ShadingLanguageVersion {
 
   boolean isWebGl();
 
-  boolean restrictedArrayIndexing();
+  /**
+   * GLSL versions 1.2+ and ESSL versions 3.0+ support array constructors.
+   * @return true if and only if array constructors are supported.
+   */
+  boolean supportedArrayConstructors();
 
   boolean restrictedForLoops();
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
@@ -174,7 +174,7 @@ public class Fuzzer {
     }
     if (targetType instanceof ArrayType) {
       // TODO: we should use in-scope variables and functions to make arrays
-      if (!shadingLanguageVersion.restrictedArrayIndexing()) {
+      if (shadingLanguageVersion.supportedArrayConstructors()) {
         ArrayType arrayType = (ArrayType) targetType;
         List<Expr> args = new ArrayList<>();
         for (int i = 0; i < arrayType.getArrayInfo().getConstantSize(); i++) {


### PR DESCRIPTION
Fixes an issue where shading language support for array constructors
was incorrect, which was leading to array constructors not being
generated.