### PR TITLE
Detect array bounds clamping macros

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/util/MacroNames.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/util/MacroNames.java
@@ -38,7 +38,9 @@ public class MacroNames {
         || isLoopWrapper(expr)
         || isIfWrapperTrue(expr)
         || isIfWrapperFalse(expr)
-        || isSwitch(expr);
+        || isSwitch(expr)
+        || isMakeInBoundsInt(expr)
+        || isMakeInBoundsUint(expr);
   }
 
   public static boolean isIdentity(Expr expr) {

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
@@ -849,6 +849,59 @@ public class ReductionDriverTest {
 
   }
 
+  @Test
+  public void testMakingArrayAccessesInBoundsIsValid() throws Exception {
+
+    // Checks that the shaders to which the interestingness test is applied are always valid.  In
+    // particular, this is designed to check that the shader with in-bounds array indices that is
+    // tried at the start of the reduction process, is valid.
+
+    final String shaderSwitch = "#version 310 es\n"
+        + "precision highp float;\n"
+        + "void main() {\n"
+        + "  int A[3];\n"
+        + "  for (int i = 0; i < 12; i++) {\n"
+        + "    A[i] = i;\n"
+        + "  }\n"
+        + "}\n";
+
+    final String expected = "#version 310 es\n"
+        + "void main() {\n"
+        + "  0;\n"
+        + "}\n";
+
+    final IFileJudge customFileJudge = new IFileJudge() {
+      @Override
+      public boolean isInteresting(File shaderJobFile, File shaderResultFileOutput) throws FileJudgeException {
+        try {
+          fileOps.areShadersValid(shaderJobFile, true);
+        } catch (IOException | InterruptedException exception) {
+          throw new FileJudgeException(exception);
+        }
+        return true;
+      }
+    };
+
+    final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(),
+        new PipelineInfo(),
+        ParseHelper.parse(shaderSwitch));
+
+    final File workDir = testFolder.getRoot();
+    final File tempShaderJobFile = new File(workDir, "temp.json");
+    fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
+
+    new ReductionDriver(new ReducerContext(true,
+        ShadingLanguageVersion.ESSL_310,
+        new RandomWrapper(0),
+        new IdGenerator()),
+        false,
+        fileOps,
+        customFileJudge,
+        workDir)
+        .doReduction(shaderJob, "temp", 0, 100);
+
+  }
+
   private String getPrefix(File tempFile) {
     return FilenameUtils.removeExtension(tempFile.getName());
   }


### PR DESCRIPTION
When deciding whether to emit GraphicsFuzz macros, the presence of
macros to clamp arrays into bounds was not being checked.  This change
fixes this.