### PR TITLE
Const arrays, and fuzzing of array constructors

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
@@ -31,6 +31,10 @@ public class ArrayType extends UnqualifiedType {
   private ArrayInfo arrayInfo;
 
   public ArrayType(Type baseType, ArrayInfo arrayInfo) {
+    if (baseType instanceof QualifiedType) {
+      throw new IllegalArgumentException("Qualifiers should be applied to an array type, not to "
+          + "the array's base type.");
+    }
     this.baseType = baseType;
     this.arrayInfo = arrayInfo;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -16,8 +16,6 @@
 
 package com.graphicsfuzz.common.ast.visitors;
 
-import com.graphicsfuzz.common.ast.IAstNode;
-import com.graphicsfuzz.common.ast.IParentMap;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.decl.Declaration;
@@ -555,8 +553,11 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
         if (declarators.struct_declarator().array_specifier() == null) {
           fieldTypes.addFirst(baseType);
         } else {
-          fieldTypes.addFirst(new ArrayType(baseType,
-              getArrayInfo(declarators.struct_declarator().array_specifier())));
+          final ArrayType arrayType = new ArrayType(baseType.getWithoutQualifiers(),
+              getArrayInfo(declarators.struct_declarator().array_specifier()));
+          fieldTypes.addFirst(baseType instanceof QualifiedType
+              ? new QualifiedType(arrayType, ((QualifiedType) baseType).getQualifiers())
+              : arrayType);
         }
       }
     }

--- a/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
@@ -191,6 +191,25 @@ public class PrettyPrinterVisitorTest {
   }
 
   @Test
+  public void testParseAndPrintArrayParameter() throws Exception {
+    final String program = "void foo(int A[2])\n"
+        + "{\n"
+        + "}\n";
+    assertEquals(program, PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program
+    )));
+  }
+
+  @Test
+  public void testParseAndPrintArrayVariable() throws Exception {
+    final String program = "void main()\n"
+        + "{\n"
+        + " int A[2] = int[2](1, 2);\n"
+        + "}\n";
+    assertEquals(program, PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program
+    )));
+  }
+
+  @Test
   public void testParseAndPrintStructs2() throws Exception {
     // This checks exact layout, so will require maintenance if things change.
     // This is expected and deliberate: do the maintenance :)

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
@@ -60,6 +60,7 @@ import com.graphicsfuzz.generator.fuzzer.templates.FunctionCallExprTemplate;
 import com.graphicsfuzz.generator.fuzzer.templates.IExprTemplate;
 import com.graphicsfuzz.generator.fuzzer.templates.VariableIdentifierExprTemplate;
 import com.graphicsfuzz.generator.util.GenerationParams;
+import com.graphicsfuzz.util.Constants;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -174,16 +175,7 @@ public class Fuzzer {
     }
     if (targetType instanceof ArrayType) {
       // TODO: we should use in-scope variables and functions to make arrays
-      if (shadingLanguageVersion.supportedArrayConstructors()) {
-        ArrayType arrayType = (ArrayType) targetType;
-        List<Expr> args = new ArrayList<>();
-        for (int i = 0; i < arrayType.getArrayInfo().getConstantSize(); i++) {
-          args.add(makeExpr(arrayType.getBaseType(), isLValue, constContext, depth + 1));
-        }
-        return new ArrayConstructorExpr((ArrayType) stripQualifiers(targetType), args);
-      } else {
-        throw new FuzzedIntoACornerException();
-      }
+      return generateArrayConstructor(targetType, isLValue, constContext, depth);
     }
     if (targetType instanceof StructNameType) {
       final String structName = ((StructNameType) targetType).getName();
@@ -199,6 +191,64 @@ public class Fuzzer {
     }
     throw new RuntimeException("Do not yet know how to make expr of type " + targetType.getClass());
 
+  }
+
+  private Expr generateArrayConstructor(Type targetType, boolean isLValue, boolean constContext,
+                                        int depth) {
+    if (shadingLanguageVersion.supportedArrayConstructors()) {
+      final ArrayType arrayType = (ArrayType) targetType;
+
+      // We want to generate an expression for each array index.  But if the array is
+      // large, there is a high chance we will fail to generate expressions for some
+      // indices, leading to a "fuzzed into a corner" exception.
+      //
+      // What we do is try SIZE_OF_ARRAY times to generate an expression, storing all the
+      // expressions we successfully generate.  If we fail to generate *any* then we throw a
+      // "fuzzed into a corner" exception.  Otherwise, we re-use the set of expressions we did
+      // manage to generate as much as needed in order to get the required number of expressions.
+      //
+      // However, because SIZE_OF_ARRAY could be very large, we bound the number of expressions
+      // we generate by a constant, and resort to re-use to generate very large arrays.
+
+      // These are the expressions we will initially generate.
+      final List<Expr> generatedExprs = new ArrayList<>();
+      for (int i = 0; i < Math.min(Constants.MAX_GENERATED_EXPRESSIONS_FOR_ARRAY_CONSTRUCTOR,
+          arrayType.getArrayInfo().getConstantSize()); i++) {
+        try {
+          generatedExprs.add(makeExpr(arrayType.getBaseType(), isLValue, constContext, depth + 1));
+        } catch (FuzzedIntoACornerException exception) {
+          // Didn't manage to generate an expression this time; move on.
+        }
+      }
+
+      if (generatedExprs.isEmpty()) {
+        // Nothing worked!  Give up.
+        throw new FuzzedIntoACornerException();
+      }
+
+      // 'args' will have the final list of expressions for the array constructor.  We populate
+      // it by repeatedly removing elements from the sequence of expressions we generated, adding
+      // clones of them to 'args', and then using them again and again until 'args' is full.
+      // 'current' and 'next' support this re-use; we move expressions from 'current' to 'next'
+      // until current is empty, and then swap 'current' with 'next'.
+      final List<Expr> args = new ArrayList<>();
+      List<Expr> current = generatedExprs;
+      List<Expr> next = new ArrayList<>();
+      for (int i = 0; i < arrayType.getArrayInfo().getConstantSize(); i++) {
+        assert (!current.isEmpty());
+        final Expr expr = current.remove(generator.nextInt(current.size()));
+        args.add(expr.clone());
+        next.add(expr);
+        if (current.isEmpty()) {
+          List<Expr> temp = current;
+          current = next;
+          next = temp;
+        }
+      }
+      return new ArrayConstructorExpr((ArrayType) stripQualifiers(targetType), args);
+    } else {
+      throw new FuzzedIntoACornerException();
+    }
   }
 
   private boolean isTooDeep(int depth) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/Expr2ArrayAccessMutationFinder.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/Expr2ArrayAccessMutationFinder.java
@@ -53,9 +53,9 @@ public class Expr2ArrayAccessMutationFinder extends Expr2ExprMutationFinder {
       return;
     }
     ScopeEntry se = getCurrentScope().lookupScopeEntry(declInfo.getName());
-    if (se.getType() instanceof ArrayType) {
-      globalArrays.put(declInfo.getName(), ((ArrayType) se.getType()).getBaseType()
-          .getWithoutQualifiers());
+    if (se.getType().getWithoutQualifiers() instanceof ArrayType) {
+      globalArrays.put(declInfo.getName(), ((ArrayType) se.getType().getWithoutQualifiers())
+          .getBaseType());
     }
   }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -31,7 +31,6 @@ import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
-import com.graphicsfuzz.common.ast.type.ArrayType;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.ast.type.LayoutQualifierSequence;
 import com.graphicsfuzz.common.ast.type.QualifiedType;
@@ -741,12 +740,6 @@ public abstract class DonateCodeTransformation implements ITransformation {
   }
 
   Type dropQualifiersThatCannotBeUsedForLocalVariable(Type type) {
-    if (type instanceof ArrayType) {
-      return new ArrayType(
-          dropQualifiersThatCannotBeUsedForLocalVariable(((ArrayType) type).getBaseType()),
-          ((ArrayType) type).getArrayInfo());
-    }
-
     if (!(type instanceof QualifiedType)) {
       return type;
     }
@@ -776,16 +769,6 @@ public abstract class DonateCodeTransformation implements ITransformation {
 
   String addPrefix(String name) {
     return getPrefix() + translationUnitCount + name;
-  }
-
-  boolean typeRefersToUniform(Type type) {
-    if (type.hasQualifier(TypeQualifier.UNIFORM)) {
-      return true;
-    }
-    if (!(type.getWithoutQualifiers() instanceof ArrayType)) {
-      return false;
-    }
-    return typeRefersToUniform(((ArrayType) type.getWithoutQualifiers()).getBaseType());
   }
 
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformation.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.generator.transformation;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.Initializer;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
@@ -25,6 +26,7 @@ import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
 import com.graphicsfuzz.common.ast.stmt.IfStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
+import com.graphicsfuzz.common.ast.type.ArrayType;
 import com.graphicsfuzz.common.ast.type.QualifiedType;
 import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.ast.type.TypeQualifier;
@@ -103,14 +105,17 @@ public class DonateDeadCodeTransformation extends DonateCodeTransformation {
             injectionPoint,
             donationContext,
             type,
-            type instanceof QualifiedType && ((QualifiedType) type)
-                .hasQualifier(TypeQualifier.CONST),
+            type.hasQualifier(TypeQualifier.CONST),
             generator,
             shadingLanguageVersion);
 
+        final ArrayInfo arrayInfo = type.getWithoutQualifiers() instanceof ArrayType
+            ? ((ArrayType) type.getWithoutQualifiers()).getArrayInfo().clone()
+            : null;
+
         donatedStmts.add(new DeclarationStmt(
             new VariablesDeclaration(dropQualifiersThatCannotBeUsedForLocalVariable(type),
-                new VariableDeclInfo(newName, null,
+                new VariableDeclInfo(newName, arrayInfo,
                     initializer))));
       }
     }

--- a/util/src/main/java/com/graphicsfuzz/util/Constants.java
+++ b/util/src/main/java/com/graphicsfuzz/util/Constants.java
@@ -96,4 +96,8 @@ public final class Constants {
   // Name of the constant storing the total loop bound when using a global loop limiter.
   public static final String GLF_GLOBAL_LOOP_BOUND_NAME = "_GLF_global_loop_bound";
 
+  // We do not want to spend too long generating expressions for array constructors, so we set a
+  // limit on how many distinct expressions we will generate for this purpose.
+  public static final int MAX_GENERATED_EXPRESSIONS_FOR_ARRAY_CONSTRUCTOR = 20;
+
 }


### PR DESCRIPTION
This change does two things:

(1) It corrects the way that qualifiers (in particular const) are
interpreted when applied to array types.  A declaration:

const int v[2] = ...;

should be regarded as having type:

QualifiedType(ArrayType(int, 2), CONST)

but was being regarded as having type:

ArrayType(QualifiedType(int, CONST), 2)

(2) It changes the way array constructor expressions are fuzzed.
Previously, an array constructor for an array of size 256 was fuzzed
by trying to make 256 distinct expressions.  The chances of the fuzzer
getting stuck and generating a "fuzzed into a corner" exception were
very high in such cases.  This change uses an approach with a much
lower probability of failure, whereby a number of element constructor
expressions are generated and then re-used several times at random if
there are not enough to provide a value for every element of the
array.
