### PR TITLE
gfauto: fix bug report

### DIFF
--- a/gfauto/gfauto/fuzz_glsl_test.py
+++ b/gfauto/gfauto/fuzz_glsl_test.py
@@ -874,7 +874,7 @@ def create_summary_and_reproduce(
         )
 
     if stage_one_reduced:
-        variant_reduced_glsl_result = run_shader_job(
+        run_shader_job(
             source_dir=stage_one_reduced,
             output_dir=(summary_dir / "reduced_stage_one_result"),
             binary_manager=binary_manager,
@@ -925,6 +925,13 @@ def tool_crash_summary_bug_report_dir(  # pylint: disable=too-many-locals;
     bug_report_dir = util.copy_dir(
         variant_reduced_glsl_result_dir, output_dir / "bug_report"
     )
+
+    # Create bug_report.zip.
+    zip_files = [
+        util.ZipEntry(f, f.relative_to(bug_report_dir))
+        for f in sorted(bug_report_dir.rglob(f"*"))
+    ]
+    util.create_zip(bug_report_dir.with_suffix(".zip"), zip_files)
 
     shader_files = sorted(bug_report_dir.rglob("shader.*"))
 

--- a/gfauto/gfauto/util.py
+++ b/gfauto/gfauto/util.py
@@ -328,7 +328,12 @@ def create_zip(output_file_path: Path, entries: List[ZipEntry]) -> Path:
     ) as file_handle:
         for entry in entries:
             file_handle.write(entry.path, entry.path_in_archive)
-            gflogging.log(f"Adding: {entry.path} {entry.path_in_archive or ''}")
+            if entry.path_in_archive:
+                gflogging.log(
+                    f"Adding: {entry.path}\n     -> {entry.path_in_archive}\n"
+                )
+            else:
+                gflogging.log(f"Adding: {entry.path}")
     return output_file_path
 
 

--- a/gfauto/pylintrc
+++ b/gfauto/pylintrc
@@ -86,6 +86,7 @@ disable=C0330,
     cyclic-import,           # We allow cyclic imports, but we should import modules, not functions and variables.
     duplicate-code,          # Unfortunately, disabling this on a case-by-case basis is broken: https://github.com/PyCQA/pylint/issues/214
     unsubscriptable-object,  # False-positives for type hints. E.g. CompletedProcess[Any]. Mypy should cover this.
+    too-many-lines,
 
 
 


### PR DESCRIPTION
Bug report directories were being generated from reduced_stage_one_result due to a copy-paste mistake. Also, create a zip archive of the bug_report dir for convenience.