### PR TITLE
Make scopes compulsory when looking for canonical constants

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
@@ -24,7 +24,6 @@ import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public class ArrayType extends UnqualifiedType {
 
@@ -86,12 +85,12 @@ public class ArrayType extends UnqualifiedType {
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope scope) {
     return baseType.hasCanonicalConstant(scope) && arrayInfo.hasConstantSize();
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     final Expr canonicalConstantForBaseType = baseType.getCanonicalConstant(scope);
     final List<Expr> componentConstants = new ArrayList<>();
     for (int i = 0; i < arrayInfo.getConstantSize(); i++) {

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/AtomicIntType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/AtomicIntType.java
@@ -19,7 +19,6 @@ package com.graphicsfuzz.common.ast.type;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.Optional;
 
 public class AtomicIntType extends BuiltinType {
 
@@ -35,12 +34,12 @@ public class AtomicIntType extends BuiltinType {
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope unused) {
     return false;
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
@@ -27,7 +27,6 @@ import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 public class BasicType extends BuiltinType {
 
@@ -148,12 +147,12 @@ public class BasicType extends BuiltinType {
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope unused) {
     return true;
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     if (this == FLOAT) {
       return new FloatConstantExpr("1.0");
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/ImageType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/ImageType.java
@@ -19,7 +19,6 @@ package com.graphicsfuzz.common.ast.type;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.Optional;
 
 public class ImageType extends BuiltinType {
 
@@ -167,13 +166,13 @@ public class ImageType extends BuiltinType {
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope unused) {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/QualifiedType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/QualifiedType.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -166,12 +165,12 @@ public class QualifiedType extends Type {
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope scope) {
     return targetType.hasCanonicalConstant(scope);
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     return targetType.getCanonicalConstant(scope);
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/SamplerType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/SamplerType.java
@@ -19,7 +19,6 @@ package com.graphicsfuzz.common.ast.type;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.Optional;
 
 public class SamplerType extends BuiltinType {
 
@@ -199,13 +198,13 @@ public class SamplerType extends BuiltinType {
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope unused) {
     return false;
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructDefinitionType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructDefinitionType.java
@@ -155,7 +155,7 @@ public class StructDefinitionType extends UnqualifiedType {
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope scope) {
     // To give a constant for a struct, the struct needs to have a name and it must be possible
     // to make a constant for every field of the struct.
     return hasStructNameType() && fieldTypes
@@ -164,7 +164,7 @@ public class StructDefinitionType extends UnqualifiedType {
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
     return new TypeConstructorExpr(getStructNameType().getName(),
         fieldTypes.stream()
             .map(item -> item.getCanonicalConstant(scope))

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructNameType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/StructNameType.java
@@ -19,7 +19,6 @@ package com.graphicsfuzz.common.ast.type;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.Optional;
 
 public final class StructNameType extends UnqualifiedType {
 
@@ -69,19 +68,17 @@ public final class StructNameType extends UnqualifiedType {
   }
 
   @Override
-  public final boolean hasCanonicalConstant(Optional<Scope> scope) {
-    if (!scope.isPresent()) {
-      throw new RuntimeException("A scope must be provided when checking whether a struct type "
-          + "has a canonical constant; the parameter is optional in general to ease the case "
-          + "where a canonical constant is required for a type that is guaranteed not to involve "
-          + "a struct.");
+  public final boolean hasCanonicalConstant(Scope scope) {
+    if (scope.lookupStructName(name) == null) {
+      throw new RuntimeException("Attempt to check whether a struct has a canonical constant when"
+          + " the struct is not in scope.");
     }
-    return scope.get().lookupStructName(name).hasCanonicalConstant(scope);
+    return scope.lookupStructName(name).hasCanonicalConstant(scope);
   }
 
   @Override
-  public final Expr getCanonicalConstant(Optional<Scope> scope) {
-    return scope.get().lookupStructName(name).getCanonicalConstant(scope);
+  public final Expr getCanonicalConstant(Scope scope) {
+    return scope.lookupStructName(name).getCanonicalConstant(scope);
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/Type.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/Type.java
@@ -19,28 +19,38 @@ package com.graphicsfuzz.common.ast.type;
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.List;
-import java.util.Optional;
 
 public abstract class Type implements IAstNode {
 
   @Override
   public abstract Type clone();
 
-  public abstract boolean hasCanonicalConstant(Optional<Scope> scope);
+  /**
+   * Determines whether a canonical constant exists for the type.
+   * @param scope Used to provide details of struct types.
+   * @return true if and only if the type has a canonical constant.
+   */
+  public abstract boolean hasCanonicalConstant(Scope scope);
 
-  public final boolean hasCanonicalConstant() {
-    return hasCanonicalConstant(Optional.empty());
-  }
+  /**
+   * Requires that hasCanonicalConstant(scope) holds.  Returns the canonical constant for this type.
+   * @param scope Used to provide details of struct types.
+   * @return A constant expression of this type.
+   */
+  public abstract Expr getCanonicalConstant(Scope scope);
 
-  public abstract Expr getCanonicalConstant(Optional<Scope> scope);
-
-  public final Expr getCanonicalConstant() {
-    return getCanonicalConstant(Optional.empty());
-  }
-
+  /**
+   * Yields an unqualified version of the type.
+   * @return A type identical to the original type, but with no qualifiers (which will be the
+   *         original type if it was already unqualified.
+   */
   public abstract Type getWithoutQualifiers();
 
+  /**
+   * Returns true if and only if this is a qualified type that has the given qualifier.
+   * @param qualifier A qualifier to be tested for.
+   * @return true if and only if the type has the given qualifier.
+   */
   public abstract boolean hasQualifier(TypeQualifier qualifier);
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/VoidType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/VoidType.java
@@ -19,7 +19,6 @@ package com.graphicsfuzz.common.ast.type;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.Optional;
 
 public class VoidType extends BuiltinType {
 
@@ -35,12 +34,13 @@ public class VoidType extends BuiltinType {
   }
 
   @Override
-  public boolean hasCanonicalConstant(Optional<Scope> scope) {
+  public boolean hasCanonicalConstant(Scope unused) {
     return false;
   }
 
   @Override
-  public Expr getCanonicalConstant(Optional<Scope> scope) {
+  public Expr getCanonicalConstant(Scope scope) {
+    // Sanity-check that there is indeed no canonical constant.
     assert !hasCanonicalConstant(scope);
     throw new RuntimeException("No canonical constant for " + this);
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Scope.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Scope.java
@@ -31,13 +31,19 @@ import java.util.Optional;
 
 public class Scope {
 
-  private final Map<String, ScopeEntry> variableMapping;
-  private final Map<String, StructDefinitionType> structMapping;
+  private final Map<String, ScopeEntry> variableMapping = new HashMap<>();
+  private final Map<String, StructDefinitionType> structMapping = new HashMap<>();
   private final Scope parent;
 
+  public Scope() {
+    this.parent = null;
+  }
+
   public Scope(Scope parent) {
-    this.variableMapping = new HashMap<>();
-    this.structMapping = new HashMap<>();
+    if (parent == null) {
+      throw new IllegalArgumentException("Attempt to create scope with null parent.  Use Scope() "
+          + "constructor to create a global scope.");
+    }
     this.parent = parent;
   }
 
@@ -151,8 +157,7 @@ public class Scope {
   }
 
   public List<String> keys() {
-    List<String> result = new ArrayList<>();
-    result.addAll(variableMapping.keySet());
+    List<String> result = new ArrayList<>(variableMapping.keySet());
     result.sort(String::compareTo);
     return Collections.unmodifiableList(result);
   }
@@ -166,7 +171,7 @@ public class Scope {
    * @return Cloned scope
    */
   public Scope shallowClone() {
-    Scope result = new Scope(parent == null ? null : parent.shallowClone());
+    Scope result = hasParent() ? new Scope(parent.shallowClone()) : new Scope();
     for (Entry<String, ScopeEntry> entry : variableMapping.entrySet()) {
       result.variableMapping.put(entry.getKey(), entry.getValue());
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
@@ -63,7 +63,7 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
   private boolean addEncounteredParametersToScope;
 
   protected ScopeTrackingVisitor() {
-    this.currentScope = new Scope(null);
+    this.currentScope = new Scope();
     this.enclosingFunction = null;
     this.enclosingBlocks = new LinkedList<>();
     this.encounteredFunctionPrototypes = new ArrayList<>();

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/type/BasicTypeTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/type/BasicTypeTest.java
@@ -20,18 +20,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.graphicsfuzz.common.typing.Scope;
 import org.junit.Test;
 
 public class BasicTypeTest {
 
   @Test
   public void testCanonicalConstant() {
-    assertEquals("1", BasicType.INT.getCanonicalConstant().getText());
-    assertEquals("1u", BasicType.UINT.getCanonicalConstant().getText());
-    assertEquals("1.0", BasicType.FLOAT.getCanonicalConstant().getText());
-    assertEquals("true", BasicType.BOOL.getCanonicalConstant().getText());
-    assertEquals("uvec4(1u)", BasicType.UVEC4.getCanonicalConstant().getText());
-    assertEquals("mat2(1.0)", BasicType.MAT2X2.getCanonicalConstant().getText());
+    assertEquals("1", BasicType.INT.getCanonicalConstant(new Scope()).getText());
+    assertEquals("1u", BasicType.UINT.getCanonicalConstant(new Scope()).getText());
+    assertEquals("1.0", BasicType.FLOAT.getCanonicalConstant(new Scope()).getText());
+    assertEquals("true", BasicType.BOOL.getCanonicalConstant(new Scope()).getText());
+    assertEquals("uvec4(1u)", BasicType.UVEC4.getCanonicalConstant(new Scope()).getText());
+    assertEquals("mat2(1.0)", BasicType.MAT2X2.getCanonicalConstant(new Scope()).getText());
   }
 
   @Test

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/type/StructDefinitionTypeTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/type/StructDefinitionTypeTest.java
@@ -16,15 +16,12 @@
 
 package com.graphicsfuzz.common.ast.type;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-
-import com.graphicsfuzz.common.ast.CompareAstsDuplicate;
+import com.graphicsfuzz.common.typing.Scope;
 import java.util.Arrays;
-import java.util.Optional;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StructDefinitionTypeTest {
 
@@ -97,9 +94,9 @@ public class StructDefinitionTypeTest {
     StructDefinitionType t = new StructDefinitionType(new StructNameType("astruct"),
         Arrays.asList("x", "y"),
         Arrays.asList(BasicType.MAT4X4, BasicType.VEC4));
-    assertTrue(t.hasCanonicalConstant());
+    assertTrue(t.hasCanonicalConstant(new Scope()));
     assertEquals("astruct(mat4(1.0), vec4(1.0))",
-        t.getCanonicalConstant().getText());
+        t.getCanonicalConstant(new Scope()).getText());
   }
 
 }

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/type/VoidTypeTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/type/VoidTypeTest.java
@@ -18,18 +18,19 @@ package com.graphicsfuzz.common.ast.type;
 
 import static org.junit.Assert.assertFalse;
 
+import com.graphicsfuzz.common.typing.Scope;
 import org.junit.Test;
 
 public class VoidTypeTest {
 
   @Test
   public void hasCanonicalConstant() {
-    assertFalse(VoidType.VOID.hasCanonicalConstant());
+    assertFalse(VoidType.VOID.hasCanonicalConstant(new Scope()));
   }
 
   @Test(expected = RuntimeException.class)
   public void getCanonicalConstant() {
-    VoidType.VOID.getCanonicalConstant();
+    VoidType.VOID.getCanonicalConstant(new Scope());
   }
 
 }

--- a/common/src/main/java/com/graphicsfuzz/common/util/AddInitializers.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/AddInitializers.java
@@ -25,7 +25,6 @@ import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
-import java.util.Optional;
 
 public class AddInitializers {
 
@@ -63,14 +62,14 @@ public class AddInitializers {
             if (vdi.hasArrayInfo()) {
               variableType = new ArrayType(variableType, vdi.getArrayInfo());
             }
-            if (!variableType.hasCanonicalConstant(Optional.of(getCurrentScope()))) {
+            if (!variableType.hasCanonicalConstant(getCurrentScope())) {
               // We don't know how to make a constant for this type, so we cannot add an
               // initializer.
               return;
             }
             // Add an initializer for this variable.
             vdi.setInitializer(new Initializer(
-                variableType.getCanonicalConstant(Optional.of(getCurrentScope()))));
+                variableType.getCanonicalConstant(getCurrentScope())));
           }
         }
       }.visit(tu);

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/FuzzingContext.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/FuzzingContext.java
@@ -46,7 +46,7 @@ public class FuzzingContext {
   }
 
   public FuzzingContext() {
-    this(new Scope(null));
+    this(new Scope());
   }
 
   public void addGlobal(String name, Type type) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddJumpMutation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddJumpMutation.java
@@ -35,7 +35,6 @@ import com.graphicsfuzz.generator.mutateapi.Mutation;
 import com.graphicsfuzz.generator.transformation.injection.IInjectionPoint;
 import com.graphicsfuzz.generator.util.GenerationParams;
 import java.util.ArrayList;
-import java.util.Optional;
 
 public class AddJumpMutation implements Mutation {
 
@@ -106,8 +105,9 @@ public class AddJumpMutation implements Mutation {
                                    GenerationParams generationParams) {
     Type returnType = injectionPoint.getEnclosingFunction().getPrototype().getReturnType();
     Stmt stmtToInject;
-    if (returnType.hasCanonicalConstant(Optional.of(injectionPoint.scopeAtInjectionPoint()))) {
-      stmtToInject = new ReturnStmt(returnType.getCanonicalConstant());
+    if (returnType.hasCanonicalConstant(injectionPoint.scopeAtInjectionPoint())) {
+      stmtToInject = new ReturnStmt(returnType.getCanonicalConstant(
+          injectionPoint.scopeAtInjectionPoint()));
     } else if (returnType.getWithoutQualifiers() == VoidType.VOID) {
       stmtToInject = new ReturnStmt();
     } else {

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/StructificationMutation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/StructificationMutation.java
@@ -32,6 +32,7 @@ import com.graphicsfuzz.common.ast.type.StructDefinitionType;
 import com.graphicsfuzz.common.ast.type.StructNameType;
 import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.typing.ScopeEntry;
 import com.graphicsfuzz.common.typing.ScopeTrackingVisitor;
 import com.graphicsfuzz.common.typing.SupportedTypes;
@@ -194,7 +195,7 @@ public class StructificationMutation implements Mutation {
         args.add(fieldType instanceof StructNameType
             ? makeInitializationExpr(tu.getStructDefinition((StructNameType) fieldType),
                 originalInitializer)
-            : fieldType.getCanonicalConstant());
+            : fieldType.getCanonicalConstant(new Scope()));
       } else {
         args.add(originalInitializer);
       }

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/FreeVariablesCollector.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/FreeVariablesCollector.java
@@ -47,7 +47,7 @@ public class FreeVariablesCollector extends ScopeTrackingVisitor {
   @Override
   public void visit(IAstNode node) {
     if (node == donorFragment) {
-      enclosingScope = swapCurrentScope(new Scope(null));
+      enclosingScope = swapCurrentScope(new Scope());
     }
     super.visit(node);
     if (node == donorFragment) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RestrictFragmentShaderColors.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RestrictFragmentShaderColors.java
@@ -132,7 +132,7 @@ public class RestrictFragmentShaderColors {
     }
     final FunctionDefinition mainFunction = shaderJob.getFragmentShader().get()
         .getMainFunction();
-    final Scope emptyScope = new Scope(null);
+    final Scope emptyScope = new Scope();
     mainFunction.getBody().insertStmt(0,
         makeOutputVariableWrite(makeColorVector(BasicType.VEC4, emptyScope)));
   }

--- a/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGeneratorTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGeneratorTest.java
@@ -118,10 +118,10 @@ public class OpaqueExpressionGeneratorTest {
       final OpaqueExpressionGenerator opaqueExpressionGenerator =
           new OpaqueExpressionGenerator(generator,
               generationParams, shadingLanguageVersion);
-      final Fuzzer fuzzer = new Fuzzer(new FuzzingContext(new Scope(null)), shadingLanguageVersion,
+      final Fuzzer fuzzer = new Fuzzer(new FuzzingContext(new Scope()), shadingLanguageVersion,
           generator, generationParams);
       final Expr expr =
-          opaqueExpressionGenerator.applyIdentityFunction(basicType.getCanonicalConstant(),
+          opaqueExpressionGenerator.applyIdentityFunction(basicType.getCanonicalConstant(new Scope()),
               basicType, false, 0, fuzzer);
 
       newStmts.add(new ExprStmt(new BinaryExpr(new VariableIdentifierExpr("x"), expr,
@@ -185,7 +185,7 @@ public class OpaqueExpressionGeneratorTest {
     List<Stmt> result = new ArrayList<>();
     for (OpaqueZeroOneFactory factory : factories) {
       final Optional<Expr> expr = factory.tryMakeOpaque(typeToGenerate, constContext, 0,
-          new Fuzzer(new FuzzingContext(new Scope(null)), shadingLanguageVersion,
+          new Fuzzer(new FuzzingContext(new Scope()), shadingLanguageVersion,
           generator, generationParams), makingZero);
       if (expr.isPresent()) {
         final Type baseType = constContext ? new QualifiedType(typeToGenerate,

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/OutlineStatementMutationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/OutlineStatementMutationTest.java
@@ -64,7 +64,7 @@ public class OutlineStatementMutationTest {
             new VariableIdentifierExpr("y"), BinOp.MUL), new VariableIdentifierExpr("z"),
             BinOp.ADD), BinOp.ASSIGN));
 
-    Scope fakeScope = new Scope(null);
+    Scope fakeScope = new Scope();
     fakeScope.add("x", BasicType.VEC2, Optional.empty());
     fakeScope.add("y", BasicType.FLOAT, Optional.empty());
     fakeScope.add("z", BasicType.VEC2, Optional.empty());
@@ -89,7 +89,7 @@ public class OutlineStatementMutationTest {
         new VariableIdentifierExpr("y"),
         BinOp.ASSIGN));
 
-    Scope fakeScope = new Scope(null);
+    Scope fakeScope = new Scope();
     fakeScope.add("x", BasicType.VEC2, Optional.empty());
     fakeScope.add("y", new QualifiedType(BasicType.VEC2, Arrays.asList(TypeQualifier.UNIFORM)), Optional.empty());
 
@@ -116,7 +116,7 @@ public class OutlineStatementMutationTest {
             BinOp.ADD),
         BinOp.ASSIGN));
 
-    Scope fakeScope = new Scope(null);
+    Scope fakeScope = new Scope();
     fakeScope.add("x", BasicType.VEC2, Optional.empty());
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
@@ -142,7 +142,7 @@ public class OutlineStatementMutationTest {
             BinOp.ADD),
         BinOp.ASSIGN));
 
-    Scope fakeScope = new Scope(null);
+    Scope fakeScope = new Scope();
     fakeScope.add("x", new QualifiedType(BasicType.VEC2, Arrays.asList(TypeQualifier.OUT_PARAM)), Optional.empty());
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
@@ -168,7 +168,7 @@ public class OutlineStatementMutationTest {
             BinOp.ADD),
         BinOp.ASSIGN));
 
-    Scope fakeScope = new Scope(null);
+    Scope fakeScope = new Scope();
     fakeScope.add("x", BasicType.FLOAT, Optional.empty());
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/InjectionPointTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/InjectionPointTest.java
@@ -32,7 +32,7 @@ public class InjectionPointTest {
 
     // Simple test written in response to a stack overflow error
 
-    final Scope scope = new Scope(null);
+    final Scope scope = new Scope();
     assertNotNull(
       new InjectionPoint(null, false, false, scope) {
 
@@ -62,7 +62,7 @@ public class InjectionPointTest {
 
   @Test
   public void testThatScopeIsCloned() {
-    Scope s = new Scope(null);
+    Scope s = new Scope();
     s.add("v", BasicType.INT, Optional.empty());
     IInjectionPoint injectionPoint = new InjectionPoint(null, false, false, s) {
       @Override

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunities.java
@@ -44,7 +44,7 @@ public final class ExprToConstantReductionOpportunities extends SimplifyExprRedu
           && !isFullyReducedConstant(child, typer)) {
       addOpportunity(new SimplifyExprReductionOpportunity(
                   parent,
-                  typer.lookupType(child).getCanonicalConstant(Optional.of(getCurrentScope())),
+                  typer.lookupType(child).getCanonicalConstant(getCurrentScope()),
                   child,
                   getVistitationDepth()));
     }
@@ -69,7 +69,7 @@ public final class ExprToConstantReductionOpportunities extends SimplifyExprRedu
   }
 
   private boolean typeIsReducibleToConst(Type type) {
-    return type != null && type.hasCanonicalConstant(Optional.of(getCurrentScope()));
+    return type != null && type.hasCanonicalConstant(getCurrentScope());
   }
 
   private boolean isFullyReducedConstant(Expr expr, Typer typer) {
@@ -77,13 +77,13 @@ public final class ExprToConstantReductionOpportunities extends SimplifyExprRedu
     if (type == null) {
       return false;
     }
-    if (!type.hasCanonicalConstant(Optional.of(getCurrentScope()))) {
+    if (!type.hasCanonicalConstant(getCurrentScope())) {
       return false;
     }
     // To make the reduced shader as clean as possible, we try reducing every constant to
     // something textually equivalent to its canonical constant.
     return expr.getText()
-        .equals(type.getCanonicalConstant(Optional.of(getCurrentScope())).getText());
+        .equals(type.getCanonicalConstant(getCurrentScope()).getText());
   }
 
 }


### PR DESCRIPTION
This change makes the 'scope' parameters of hasCanonicalConstant and
getCanonicalConstant (on Type) compulsory.  An empty scope can be
passed in cases where it would be difficult to get access to a scope
and where it is known that struct name types will not be encountered.

This was motivated by a bug where a scope had been passed in the 'has'
call but not the 'get' call, which this change also fixes.

In the process the change overloads the Scope constructor so that a
global scope (with a null parent) is made from a zero-argument
constructor, rather than by passing in a null parent.  A few other
cleanups suggested by IntelliJ are also applied.