### PR TITLE
Support array parameters

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/decl/ArrayInfo.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/decl/ArrayInfo.java
@@ -93,9 +93,6 @@ public class ArrayInfo implements IAstNode {
     if (hasConstantSize()) {
       return constantSize.get();
     }
-    // TODO(https://github.com/google/graphicsfuzz/issues/784) Until array parameter support
-    //  is overhauled there could be array parameters to which constant folding has not been
-    //  applied.
     throw new UnsupportedLanguageFeatureException("Not a constant expression");
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/decl/ParameterDecl.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/decl/ParameterDecl.java
@@ -52,6 +52,10 @@ public class ParameterDecl implements IAstNode {
     return arrayInfo;
   }
 
+  public boolean hasArrayInfo() {
+    return arrayInfo != null;
+  }
+
   @Override
   public void accept(IAstVisitor visitor) {
     visitor.visitParameterDecl(this);

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/Inliner.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/inliner/Inliner.java
@@ -206,12 +206,12 @@ public class Inliner {
 
   private boolean hasArrayParameter(FunctionDefinition functionDefinition) {
     return functionDefinition.getPrototype().getParameters().stream()
-          .anyMatch(item -> item.getArrayInfo() != null);
+          .anyMatch(ParameterDecl::hasArrayInfo);
   }
 
   private boolean hasOutQualifier(FunctionDefinition functionDefinition) {
     return functionDefinition.getPrototype().getParameters().stream()
-          .map(item -> item.getType())
+          .map(ParameterDecl::getType)
           .anyMatch(item -> item.hasQualifier(TypeQualifier.OUT_PARAM)
                 || item.hasQualifier(TypeQualifier.INOUT_PARAM));
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/ArrayType.java
@@ -23,6 +23,7 @@ import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class ArrayType extends UnqualifiedType {
@@ -60,15 +61,23 @@ public class ArrayType extends UnqualifiedType {
     if (!(that instanceof ArrayType)) {
       return false;
     }
-    ArrayType thatArrayType = (ArrayType) that;
-    return this.baseType.equals(thatArrayType.baseType)
-        && this.arrayInfo.equals(thatArrayType.arrayInfo);
+    final ArrayType thatArrayType = (ArrayType) that;
+    if (!this.baseType.equals(thatArrayType.baseType)) {
+      return false;
+    }
+    if (this.arrayInfo.hasConstantSize()) {
+      return thatArrayType.arrayInfo.hasConstantSize()
+          && this.arrayInfo.getConstantSize().equals(thatArrayType.arrayInfo.getConstantSize());
+    } else {
+      return !thatArrayType.arrayInfo.hasConstantSize();
+    }
   }
 
   @Override
   public int hashCode() {
-    // TODO: revisit if we end up storing large sets of types
-    return baseType.hashCode() + arrayInfo.hashCode();
+    return Objects.hash(baseType, arrayInfo.hasConstantSize()
+        ? arrayInfo.getConstantSize()
+        : arrayInfo.hasConstantSize());
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -209,7 +209,7 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
        * @param expr Expression to fold
        * @return Folded expression
        */
-      public Expr reduce(Expr expr) {
+      private Expr reduce(Expr expr) {
 
         if (expr instanceof IntConstantExpr) {
           return expr;
@@ -337,6 +337,13 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
         }
       }
 
+      @Override
+      public void visitParameterDecl(ParameterDecl parameterDecl) {
+        super.visitParameterDecl(parameterDecl);
+        if (parameterDecl.hasArrayInfo()) {
+          handleArrayInfo(parameterDecl.getArrayInfo());
+        }
+      }
     }.visit(tu);
     return tu;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
@@ -308,7 +308,7 @@ public abstract class StandardVisitor implements IAstVisitor {
   @Override
   public void visitParameterDecl(ParameterDecl parameterDecl) {
     visitChildFromParent(parameterDecl.getType(), parameterDecl);
-    if (parameterDecl.getArrayInfo() != null) {
+    if (parameterDecl.hasArrayInfo()) {
       // Only visit the parameter's array information if there actually is array information.
       visitChildFromParent(this::visitArrayInfo, parameterDecl.getArrayInfo(), parameterDecl);
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitor.java
@@ -225,7 +225,7 @@ public class PrettyPrinterVisitor extends StandardVisitor {
     if (parameterDecl.getName() != null) {
       out.append(" " + parameterDecl.getName());
     }
-    if (parameterDecl.getArrayInfo() != null) {
+    if (parameterDecl.hasArrayInfo()) {
       out.append("[");
       visit(parameterDecl.getArrayInfo().getSizeExpr());
       out.append("]");

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
@@ -127,16 +127,7 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
       if (!addEncounteredParametersToScope || p.getName() == null) {
         continue;
       }
-      Type type;
-      if (p.getArrayInfo() == null) {
-        type = p.getType();
-      } else {
-        final ArrayType arrayType = new ArrayType(p.getType().getWithoutQualifiers(),
-            p.getArrayInfo());
-        type = p.getType() instanceof QualifiedType
-            ? new QualifiedType(arrayType, ((QualifiedType) p.getType()).getQualifiers())
-            : arrayType;
-      }
+      Type type = getTypeForFunctionParameter(p);
       currentScope.add(p.getName(),
           type,
           Optional.of(p));
@@ -348,6 +339,25 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
    */
   protected FunctionDefinition getEnclosingFunction() {
     return enclosingFunction;
+  }
+
+  /**
+   * Helper method to get the type for a parameter declaration, taking account of the fact that the
+   * declaration may have array information attached.
+   * @param param A function parameter.
+   * @return The type of the function parameter.
+   */
+  static Type getTypeForFunctionParameter(ParameterDecl param) {
+    if (!param.hasArrayInfo()) {
+      return param.getType();
+    }
+    // If the parameter has the form e.g. "const int A[3]" then we want to return a type of the form
+    // QualifiedType(ArrayType(int, 3), const), not ArrayType(QualifierdType(int, const), 3).
+    final ArrayType arrayType = new ArrayType(param.getType().getWithoutQualifiers(),
+        param.getArrayInfo());
+    return param.getType() instanceof QualifiedType
+        ? new QualifiedType(arrayType, ((QualifiedType) param.getType()).getQualifiers())
+        : arrayType;
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
@@ -205,13 +205,8 @@ public class Typer extends ScopeTrackingVisitor {
       if (argType == null) {
         return false;
       }
-      // TODO(https://github.com/google/graphicsfuzz/issues/784) Not yet worked out how to deal with
-      //  array info
-      if (prototype.getParameters().get(i).getArrayInfo() != null) {
-        throw new UnsupportedLanguageFeatureException("Array parameters are not yet supported.");
-      }
       if (!argType.getWithoutQualifiers()
-          .equals(prototype.getParameters().get(i).getType().getWithoutQualifiers())) {
+          .equals(getTypeForFunctionParameter(prototype.getParameter(i)).getWithoutQualifiers())) {
         return false;
       }
     }

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/type/ArrayTypeTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/type/ArrayTypeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.common.ast.type;
+
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
+import com.graphicsfuzz.common.ast.expr.BinOp;
+import com.graphicsfuzz.common.ast.expr.BinaryExpr;
+import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ArrayTypeTest {
+
+  @Test
+  public void testEquals() {
+    final ArrayType intArrayNoSize = new ArrayType(BasicType.INT, new ArrayInfo());
+    final ArrayType anotherIntArrayNoSize = new ArrayType(BasicType.INT, new ArrayInfo());
+
+    final ArrayType floatArrayNoSize = new ArrayType(BasicType.FLOAT, new ArrayInfo());
+    final ArrayType anotherFloatArrayNoSize = new ArrayType(BasicType.FLOAT, new ArrayInfo());
+
+    final ArrayType intArraySize2 = new ArrayType(BasicType.INT,
+        new ArrayInfo(new BinaryExpr(new IntConstantExpr("1"), new IntConstantExpr("1"),
+            BinOp.ADD)));
+    intArraySize2.getArrayInfo().setConstantSizeExpr(2);
+
+    final ArrayType intArraySize3 = new ArrayType(BasicType.INT,
+        new ArrayInfo(new BinaryExpr(new IntConstantExpr("2"), new IntConstantExpr("1"),
+            BinOp.ADD)));
+    intArraySize3.getArrayInfo().setConstantSizeExpr(3);
+
+    final ArrayType anotherIntArraySize2 = new ArrayType(BasicType.INT,
+        new ArrayInfo(new IntConstantExpr("2")));
+    anotherIntArraySize2.getArrayInfo().setConstantSizeExpr(2);
+
+    assertEquals(intArrayNoSize, anotherIntArrayNoSize);
+    assertEquals(intArrayNoSize.hashCode(), anotherIntArrayNoSize.hashCode());
+    assertNotEquals(intArrayNoSize, intArraySize2);
+    assertEquals(floatArrayNoSize, anotherFloatArrayNoSize);
+    assertEquals(floatArrayNoSize.hashCode(), anotherFloatArrayNoSize.hashCode());
+    assertNotEquals(intArrayNoSize, floatArrayNoSize);
+    assertEquals(intArraySize2, anotherIntArraySize2);
+    assertEquals(intArraySize2.hashCode(), anotherIntArraySize2.hashCode());
+    assertNotEquals(intArraySize2, intArraySize3);
+
+  }
+
+}

--- a/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
@@ -58,6 +58,21 @@ public class PrettyPrinterVisitorTest {
   }
 
   @Test
+  public void testArraySizeExpressionInParameter() throws Exception {
+    final String program = ""
+        + "void foo(int A[3 + 4])\n"
+        + "{\n"
+        + "}\n"
+        + "void main()\n"
+        + "{\n"
+        + " int a[7];\n"
+        + " foo(a);\n"
+        + "}\n";
+    assertEquals(program, PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program
+    )));
+  }
+
+  @Test
   public void testParseAndPrint() throws Exception {
     final String program = ""
         + "struct A {\n"

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -27,8 +27,6 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.decl.Initializer;
 import com.graphicsfuzz.common.ast.decl.ParameterDecl;
-import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
-import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
@@ -51,6 +49,7 @@ import com.graphicsfuzz.common.ast.type.VoidType;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.ast.visitors.UnsupportedLanguageFeatureException;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.tool.PrettyPrinterVisitor;
 import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.util.ExecHelper.RedirectType;
@@ -72,6 +71,28 @@ public class TyperTest {
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testArrayParameter() throws Exception {
+    final String shader = ""
+        + "int foo(int A[3 + 4])\n"
+        + "{\n"
+        + "  return A[0];\n"
+        + "}\n"
+        + "void main()\n"
+        + "{\n"
+        + " int a[7];\n"
+        + " foo(a);\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(shader);
+    new NullCheckTyper(tu) {
+      @Override
+      public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
+        super.visitFunctionCallExpr(functionCallExpr);
+        assertSame(lookupType(functionCallExpr).getWithoutQualifiers(), BasicType.INT);
+      }
+    }.visit(tu);
+  }
 
   @Test
   public void visitMemberLookupExpr() throws Exception {
@@ -971,8 +992,3 @@ public class TyperTest {
   }
 
 }
-
-
-
-
-

--- a/common/src/main/java/com/graphicsfuzz/common/util/UpgradeShadingLanguageVersion.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/UpgradeShadingLanguageVersion.java
@@ -327,7 +327,7 @@ public class UpgradeShadingLanguageVersion extends ScopeTrackingVisitor {
         parameterDecl.setName(newname);
       }
     }
-    if (parameterDecl.getArrayInfo() != null) {
+    if (parameterDecl.hasArrayInfo()) {
       visit(parameterDecl.getArrayInfo().getSizeExpr());
     }
   }

--- a/common/src/test/java/com/graphicsfuzz/common/util/MakeArrayAccessesInBoundsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/MakeArrayAccessesInBoundsTest.java
@@ -185,9 +185,6 @@ public class MakeArrayAccessesInBoundsTest {
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
-  // TODO(https://github.com/google/graphicsfuzz/issues/784) Enable once array parameter support is
-  //  overhauled.
-  @Ignore
   @Test
   public void testMakeArrayParameterAccessInBounds1() throws Exception {
     final String shader = "#version 310 es\n"
@@ -211,9 +208,6 @@ public class MakeArrayAccessesInBoundsTest {
     CompareAsts.assertEqualAsts(expected, tu);
   }
 
-  // TODO(https://github.com/google/graphicsfuzz/issues/784) Enable once array parameter support is
-  //  overhauled.
-  @Ignore
   @Test
   public void testMakeArrayParameterAccessInBounds2() throws Exception {
     final String shader = "#version 310 es\n"


### PR DESCRIPTION
This change applies constant folding to the sizes of array parameters
during AST construction, refines equality on array types to regard
array types as equal if and only if their base types are equal and
they agree on constant sizes, and adapts the logic to check whether
arguments match a function prototype to allow array types.

Fixes #784.