### PR TITLE
Type-checking for interface blocks

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/decl/InterfaceBlock.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/decl/InterfaceBlock.java
@@ -100,13 +100,13 @@ public class InterfaceBlock extends Declaration {
     return instanceName.get();
   }
 
-  public Type getMemberType(String name) {
+  public Optional<Type> getMemberType(String name) {
     for (int i = 0; i < memberNames.size(); i++) {
       if (memberNames.get(i).equals(name)) {
-        return memberTypes.get(i);
+        return Optional.of(memberTypes.get(i));
       }
     }
-    throw new RuntimeException("Unknown member " + name);
+    return Optional.empty();
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -344,6 +344,16 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
           handleArrayInfo(parameterDecl.getArrayInfo());
         }
       }
+
+      @Override
+      public void visitInterfaceBlock(InterfaceBlock interfaceBlock) {
+        super.visitInterfaceBlock(interfaceBlock);
+        for (Type memberType : interfaceBlock.getMemberTypes()) {
+          if (memberType.getWithoutQualifiers() instanceof ArrayType) {
+            handleArrayInfo(((ArrayType) memberType.getWithoutQualifiers()).getArrayInfo());
+          }
+        }
+      }
     }.visit(tu);
     return tu;
   }
@@ -448,9 +458,10 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     final Basic_interface_blockContext basicCtx = ctx.basic_interface_block();
     final TypeQualifier interfaceQualifier =
         visitInterface_qualifier(basicCtx.interface_qualifier());
-    final Optional<String> maybeInstanceName = basicCtx.instance_name() == null
-        ? Optional.empty()
-        : Optional.of(basicCtx.instance_name().getText());
+    if (basicCtx.instance_name() != null) {
+      throw new UnsupportedLanguageFeatureException("Named interface blocks are not currently "
+          + "supported.");
+    }
     final Pair<List<String>, List<Type>> members = getMembers(basicCtx.member_list());
     return new InterfaceBlock(
         maybeLayoutQualifier,
@@ -458,7 +469,7 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
         basicCtx.IDENTIFIER().getText(),
         members.a,
         members.b,
-        maybeInstanceName);
+        Optional.empty());
   }
 
   @Override

--- a/ast/src/main/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitor.java
@@ -610,9 +610,10 @@ public class PrettyPrinterVisitor extends StandardVisitor {
 
     for (String memberName : interfaceBlock.getMemberNames()) {
       out.append(indent());
-      visit(interfaceBlock.getMemberType(memberName));
+      final Type memberType = interfaceBlock.getMemberType(memberName).get();
+      visit(memberType);
       out.append(" " + memberName);
-      processArrayInfo(interfaceBlock.getMemberType(memberName));
+      processArrayInfo(memberType);
       out.append(";" + newLine());
     }
 

--- a/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
@@ -780,4 +780,25 @@ public class ParseHelperTest {
     }
   }
 
+  @Test
+  public void testUnsupportedNamedInterfaceBlock() throws Exception {
+
+    // Change this test to check for support if it is eventually introduced.
+
+    try {
+      ParseHelper.parse("#version 320 es\n"
+          + "\n"
+          + "layout(std430, binding = 0) buffer doesNotMatter {\n"
+          + "  int x;\n"
+          + "  int data[];\n"
+          + "} block_name_not_currently_supported;\n"
+          + "void main() {\nprecision highp float;\n"
+          + "}\n");
+      fail("Exception was expected");
+    } catch (UnsupportedLanguageFeatureException exception) {
+      assertTrue(exception.getMessage().contains("Named interface blocks are not currently "
+          + "supported"));
+    }
+  }
+
 }


### PR DESCRIPTION
This change formalizes a previously implicit assumption that interface
blocks are not named, adds type-checking for members of interface
blocks, and considers array members of interface blocks when resolving
array sizes.