### PR TITLE
Teach the typechecker about atomic memory functions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/CompositeShadingLanguageVersion.java
@@ -307,4 +307,10 @@ abstract class CompositeShadingLanguageVersion implements ShadingLanguageVersion
   public boolean supportedLdexp() {
     return prototype.supportedLdexp();
   }
+
+  @Override
+  public boolean supportedAtomicMemoryFunctions() {
+    return prototype.supportedAtomicMemoryFunctions();
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl100.java
@@ -308,4 +308,10 @@ final class Essl100 implements ShadingLanguageVersion {
   public boolean supportedLdexp() {
     return false;
   }
+
+  @Override
+  public boolean supportedAtomicMemoryFunctions() {
+    return false;
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Essl310.java
@@ -75,4 +75,9 @@ final class Essl310 extends CompositeShadingLanguageVersion {
     return true;
   }
 
+  @Override
+  public boolean supportedAtomicMemoryFunctions() {
+    return true;
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl110.java
@@ -311,4 +311,9 @@ final class Glsl110 implements ShadingLanguageVersion {
   public boolean supportedLdexp() {
     return false;
   }
+
+  @Override
+  public boolean supportedAtomicMemoryFunctions() {
+    return false;
+  }
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl430.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/Glsl430.java
@@ -35,4 +35,9 @@ final class Glsl430 extends CompositeShadingLanguageVersion {
     return true;
   }
 
+  @Override
+  public boolean supportedAtomicMemoryFunctions() {
+    return true;
+  }
+
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/glslversion/ShadingLanguageVersion.java
@@ -333,4 +333,15 @@ public interface ShadingLanguageVersion {
    * @return true if Hyperbolic Angle and Trigonometric Functions are supported - false otherwise.
    */
   boolean supportedHyperbolicAngleAndTrigonometricFunctions();
+
+  /**
+   * Atomic Memory Functions are a set of built-in functions that perform read-modify-write atomic
+   * operations.  For example, atomicAdd() - atomically increment an integer and return its old
+   * value.
+   * GLSL versions 4.3+ and ESSL versions 3.1+ support these functions.
+   *
+   * @return true if Atomic Memory Functions are supported - false otherwise.
+   */
+  boolean supportedAtomicMemoryFunctions();
+
 }


### PR DESCRIPTION
This change provides the typechecker with knowledge of the atomic
memory functions that are available to compute shaders.