### PR TITLE
Only use donors of the same shader kind as the reference

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -45,6 +45,7 @@ import com.graphicsfuzz.generator.util.RemoveReturnStatements;
 import com.graphicsfuzz.generator.util.TransformationProbabilities;
 import com.graphicsfuzz.util.Constants;
 import java.io.File;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -45,7 +45,6 @@ import com.graphicsfuzz.generator.util.RemoveReturnStatements;
 import com.graphicsfuzz.generator.util.TransformationProbabilities;
 import com.graphicsfuzz.util.Constants;
 import java.io.File;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/donation/CheckDonorVersionMatchesTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/donation/CheckDonorVersionMatchesTest.java
@@ -79,41 +79,4 @@ public class CheckDonorVersionMatchesTest {
     }
   }
 
-    @Test
-    public void testShaderKindMismatch() throws Exception {
-      final File donors = temporaryFolder.newFolder();
-      final File exampleDonor = new File(donors, "donor.json");
-      final ShaderJobFileOperations fileOperations = new ShaderJobFileOperations();
-      final ShaderJob es100ShaderJob = new GlslShaderJob(Optional.empty(),
-          new PipelineInfo(), ParseHelper.parse("#version 310 es\nvec4 foo(bool t) {\nif (t) "
-          + "return vec4(1,0,1,1);\nreturn vec4(0,1,1,1);\n}\nout vec4 fc;\nvoid main() "
-          + "{\nfc = foo(true);\n "
-          + "}\n"));
-      fileOperations.writeShaderJobFile(es100ShaderJob, exampleDonor);
-
-      final ShaderJob es310ShaderJob = new GlslShaderJob(Optional.empty(),
-          new PipelineInfo(), ParseHelper.parse("#version 310 es\nout vec4 pix;\nvoid main() { "
-          + "pix = vec4(1,0,0,1);}\n"));
-      final File reference = temporaryFolder.newFile("reference.json");
-      fileOperations.writeShaderJobFile(es310ShaderJob, reference);
-
-      final GenerationParams normalGenerationParams = GenerationParams.normal(ShaderKind.VERTEX,
-          false);
-      final DonateLiveCodeTransformation transformation = new DonateLiveCodeTransformation(
-          TransformationProbabilities.ALWAYS::donateLiveCodeAtStmt,
-          donors,
-          normalGenerationParams,
-          false);
-
-      TranslationUnit tu = es310ShaderJob.getFragmentShader().get();
-      try {
-        transformation.apply(tu,
-            TransformationProbabilities.ALWAYS,
-            new RandomWrapper(0), normalGenerationParams);
-        fail("An exception should have been thrown");
-      } catch (RuntimeException runtimeException)
-      {
-        assertTrue(runtimeException.getMessage().startsWith("Incompatible shader types"));
-      }
-    }
 }

--- a/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
@@ -140,7 +140,8 @@ public class GeneratorUnitTest {
     testTransformationMultiVersions(() -> new DonateDeadCodeTransformation(
         TransformationProbabilities.likelyDonateDeadCode()::donateDeadCodeAtStmt,
             Util.getDonorsFolder(),
-            GenerationParams.normal(ShaderKind.FRAGMENT, true)), TransformationProbabilities.likelyDonateDeadCode(),
+            GenerationParams.normal(ShaderKind.FRAGMENT, true)),
+        TransformationProbabilities.likelyDonateDeadCode(),
         "donatedead",
         Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_zoom.json"),
         Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_zoom.json"));

--- a/util/src/main/java/com/graphicsfuzz/util/Constants.java
+++ b/util/src/main/java/com/graphicsfuzz/util/Constants.java
@@ -100,4 +100,10 @@ public final class Constants {
   // limit on how many distinct expressions we will generate for this purpose.
   public static final int MAX_GENERATED_EXPRESSIONS_FOR_ARRAY_CONSTRUCTOR = 20;
 
+  // When donating one compute shader to another, we may need to donate an unsized array that
+  // appeared in an SSBO of the donor.  We handle this by declaring a sized array, and this
+  // constant provides a size for said array.
+  public static final int DUMMY_SIZE_FOR_UNSIZED_ARRAY_DONATION = 10;
+
+
 }


### PR DESCRIPTION
Before this change, only .frag shaders were being used as donors, and
they were being used as donors for .vert and .comp shaders.

This change forces the generator to consider only shaders of the same
kind as the reference for donation into the reference.

Because this allows .comp shaders to be donated into .comp shaders,
which was not happening before, it exposed some limitations relating
to compute shader donation, specifically that the various compute
shader builtin variables were not being handled correctly, and that
interface blocks were not being handled in donation.  A similar issue,
with builtin variables, applied to vertex shaders.

This change introduces solutions to those problems.