### PR TITLE
Fix to local variable generation during donation

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformation.java
@@ -101,19 +101,21 @@ public class DonateDeadCodeTransformation extends DonateCodeTransformation {
         String newName = "donor_replacement" + name;
         substitution.put(name, newName);
 
+        final Type typeWithRestrictedQualifiers =
+            dropQualifiersThatCannotBeUsedForLocalVariable(type);
+
         final Initializer initializer = getInitializer(
             injectionPoint,
             donationContext,
-            type,
+            typeWithRestrictedQualifiers,
             type.hasQualifier(TypeQualifier.CONST),
             generator,
             shadingLanguageVersion);
 
         final ImmutablePair<Type, ArrayInfo> baseTypeAndArrayInfo =
-            Typer.getBaseTypeArrayInfo(type);
+            Typer.getBaseTypeArrayInfo(typeWithRestrictedQualifiers);
         donatedStmts.add(new DeclarationStmt(
-            new VariablesDeclaration(dropQualifiersThatCannotBeUsedForLocalVariable(
-                baseTypeAndArrayInfo.left),
+            new VariablesDeclaration(baseTypeAndArrayInfo.left,
                 new VariableDeclInfo(newName, baseTypeAndArrayInfo.right, initializer))));
       }
     }

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
@@ -28,17 +28,24 @@ import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.transformreduce.GlslShaderJob;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.util.IRandom;
 import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.PipelineInfo;
 import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.generator.transformation.donation.DonationContext;
 import com.graphicsfuzz.generator.transformation.injection.IInjectionPoint;
 import com.graphicsfuzz.generator.transformation.injection.InjectionPoints;
 import com.graphicsfuzz.generator.util.GenerationParams;
 import com.graphicsfuzz.generator.util.TransformationProbabilities;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Optional;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -370,6 +377,97 @@ public class DonateDeadCodeTransformationTest {
         }
       }.test(donated));
     }
+  }
+
+  @Test
+  public void testInAndOutParametersDonatedOK() throws Exception {
+    // This checks that donation of code that uses 'in' and 'out' parameters of functions works.
+
+    final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
+
+    final File donors = testFolder.newFolder("donors");
+    final File referenceFile = testFolder.newFile("reference.json");
+
+    {
+      // This donor is designed to have a high chance of leading to an array access getting injected
+      // such that the array indexing expression will be a free variable for which a fuzzed initial
+      // value will be created.
+      final String donorSource =
+          "#version 300 es\n"
+              + "void foo(in int a, out int b, inout int c) {\n"
+              + " {\n"
+              + "  {\n"
+              + "   {\n"
+              + "     b = a;\n"
+              + "     c = c + a;\n"
+              + "   }\n"
+              + "  }\n"
+              + " }\n"
+              + "}\n";
+
+      fileOps.writeShaderJobFile(
+          new GlslShaderJob(
+              Optional.empty(),
+              new PipelineInfo(),
+              ParseHelper.parse(donorSource)),
+          new File(donors, "donor.json")
+      );
+    }
+
+    {
+      final String referenceSource = "#version 300 es\n"
+          + "void main() {\n"
+          + "}\n";
+      fileOps.writeShaderJobFile(
+          new GlslShaderJob(
+              Optional.empty(),
+              new PipelineInfo(),
+              ParseHelper.parse(referenceSource)),
+          referenceFile
+      );
+    }
+
+    int noCodeDonatedCount = 0;
+
+    // Try the following a few times, so that there is a good chance of triggering the issue
+    // this test was used to catch, should it return:
+    for (int seed = 0; seed < 15; seed++) {
+
+      final ShaderJob referenceShaderJob = fileOps.readShaderJobFile(referenceFile);
+
+      // Do live code donation.
+      final DonateDeadCodeTransformation transformation =
+          new DonateDeadCodeTransformation(IRandom::nextBoolean, donors,
+              GenerationParams.normal(ShaderKind.FRAGMENT, true));
+
+      assert referenceShaderJob.getFragmentShader().isPresent();
+
+      final boolean result = transformation.apply(
+          referenceShaderJob.getFragmentShader().get(),
+          TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
+          new RandomWrapper(seed),
+          GenerationParams.normal(ShaderKind.FRAGMENT, true)
+      );
+
+      if (result) {
+        final File tempFile = testFolder.newFile("shader" + seed + ".json");
+        fileOps.writeShaderJobFile(referenceShaderJob, tempFile);
+        // This will fail if the shader job turns out to be invalid.
+        fileOps.areShadersValid(tempFile, true);
+      } else {
+        ++noCodeDonatedCount;
+      }
+
+    }
+
+    // The above code tests donation of dead code, but there is still a chance that no code will
+    // be donated. We assert that this happens < 10 times to ensure that we get some test
+    // coverage, but this could fail due to bad luck.
+    Assert.assertTrue(
+        "Donation failure count should be < 10, " + noCodeDonatedCount,
+        noCodeDonatedCount < 10
+    );
+
   }
 
 }


### PR DESCRIPTION
When generating a local variable for a free variable appearing in a
piece of generated code, we need to strip the variable's type of
qualifiers that don't make sense on local variables (such as 'in',
'out' and 'inout').  A previous change had messed this up.  This adds
tests to expose the problem and fixes the problem.