### PR TITLE
Account for void parameters

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -509,6 +509,9 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     while (fhp.function_header_with_parameters() != null) {
       final ParameterDecl parameterDecl = visitParameter_declaration(fhp.parameter_declaration());
       if (parameterDecl.getType().getWithoutQualifiers() == VoidType.VOID) {
+        // This is a 'void' parameter, and it is not the final parameter under consideration.
+        // That's illegal, because 'void' can only be used in isolation, to indicate that there
+        // are no parameters.
         throw new RuntimeException(badUseOfVoidMessage);
       }
       parameters.add(0, parameterDecl);
@@ -516,6 +519,8 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     }
     final ParameterDecl parameterDecl = visitParameter_declaration(fhp.parameter_declaration());
     if (parameterDecl.getType().getWithoutQualifiers() == VoidType.VOID) {
+      // If this 'void' parameter is the *only* parameter that's OK; we just ignore it.  Otherwise
+      // it is not OK, as we cannot use 'void' in the context of multiple parameters.
       if (!parameters.isEmpty()) {
         throw new RuntimeException(badUseOfVoidMessage);
       }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -502,11 +502,26 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     Function_header_with_parametersContext fhp = ctx.function_declarator()
         .function_header_with_parameters();
     List<ParameterDecl> parameters = new LinkedList<>();
+
+    final String badUseOfVoidMessage = "Unexpected use of 'void' in a list of parameters; void "
+        + "should be the only parameter if used to indicate absence of parameters.";
+
     while (fhp.function_header_with_parameters() != null) {
-      parameters.add(0, visitParameter_declaration(fhp.parameter_declaration()));
+      final ParameterDecl parameterDecl = visitParameter_declaration(fhp.parameter_declaration());
+      if (parameterDecl.getType().getWithoutQualifiers() == VoidType.VOID) {
+        throw new RuntimeException(badUseOfVoidMessage);
+      }
+      parameters.add(0, parameterDecl);
       fhp = fhp.function_header_with_parameters();
     }
-    parameters.add(0, visitParameter_declaration(fhp.parameter_declaration()));
+    final ParameterDecl parameterDecl = visitParameter_declaration(fhp.parameter_declaration());
+    if (parameterDecl.getType().getWithoutQualifiers() == VoidType.VOID) {
+      if (!parameters.isEmpty()) {
+        throw new RuntimeException(badUseOfVoidMessage);
+      }
+    } else {
+      parameters.add(0, parameterDecl);
+    }
     header = fhp.function_header();
     Type returnType =
         visitFully_specified_type(header.fully_specified_type());

--- a/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
@@ -497,4 +497,30 @@ public class PrettyPrinterVisitorTest {
         + "}").contains(ParseHelper.END_OF_GRAPHICSFUZZ_DEFINES));
   }
 
+  @Test
+  public void testParseAndPrintVoidParameter() throws Exception {
+
+    // For simplicity, we deliberately chuck away "void" in function arguments; this test captures
+    // that intent.
+
+    final String program = ""
+        + "int foo(void)\n"
+        + "{\n"
+        + " return 2;\n"
+        + "}\n"
+        + "void main(void)\n"
+        + "{\n"
+        + "}\n";
+    final String expected = ""
+        + "int foo()\n"
+        + "{\n"
+        + " return 2;\n"
+        + "}\n"
+        + "void main()\n"
+        + "{\n"
+        + "}\n";
+    assertEquals(expected, PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program
+    )));
+  }
+
 }

--- a/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitorTest.java
@@ -498,10 +498,10 @@ public class PrettyPrinterVisitorTest {
   }
 
   @Test
-  public void testParseAndPrintVoidParameter() throws Exception {
+  public void testParseAndPrintVoidFormalParameter() throws Exception {
 
-    // For simplicity, we deliberately chuck away "void" in function arguments; this test captures
-    // that intent.
+    // For simplicity, we deliberately chuck away "void" in function formal parameters; this test
+    // captures that intent.
 
     final String program = ""
         + "int foo(void)\n"
@@ -518,6 +518,34 @@ public class PrettyPrinterVisitorTest {
         + "}\n"
         + "void main()\n"
         + "{\n"
+        + "}\n";
+    assertEquals(expected, PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program
+    )));
+  }
+
+  @Test
+  public void testParseAndPrintVoidActualParameter() throws Exception {
+
+    // For simplicity, we deliberately chuck away "void" in function actual parameters; this test
+    // captures that intent.
+
+    final String program = ""
+        + "void foo()\n"
+        + "{\n"
+        + " return 2;\n"
+        + "}\n"
+        + "void main()\n"
+        + "{\n"
+        + " foo(void);\n"
+        + "}\n";
+    final String expected = ""
+        + "void foo()\n"
+        + "{\n"
+        + " return 2;\n"
+        + "}\n"
+        + "void main()\n"
+        + "{\n"
+        + " foo();\n"
         + "}\n";
     assertEquals(expected, PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(program
     )));


### PR DESCRIPTION
Some shaders in the wild use (void) to indicate no arguments to a
function; this change handles this by turning such declarations into
zero-argument functions when building the AST.