### PR TITLE
debian package manager optimization

### DIFF
--- a/graphicsfuzz/src/main/scripts/Dockerfile
+++ b/graphicsfuzz/src/main/scripts/Dockerfile
@@ -17,10 +17,10 @@ FROM ubuntu:16.04
 
 RUN \
   apt-get update && \
-  apt-get -y install software-properties-common && \
+  apt-get --no-install-recommends -y install software-properties-common && \
   add-apt-repository ppa:orangain/opencv && \
   apt-get update && \
-  apt-get -y install openjdk-8-jdk python python-opencv ipython python-six && \
+  apt-get --no-install-recommends -y install openjdk-8-jdk python python-opencv ipython python-six && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY . /data/server/


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>