### PR TITLE
Do not apply identity mutations to constant expressions

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -227,8 +227,8 @@ public final class OpaqueExpressionGenerator {
   private Optional<Expr> opaqueZeroOrOneMatrixDet(BasicType type, boolean constContext,
                                                      final int depth, Fuzzer fuzzer,
                                                      boolean isZero) {
-    // TODO(https://github.com/KhronosGroup/glslang/issues/1865): Workaround for glslangvalidator.
-    //     Remove when #653 is fixed.
+    // As discussed in https://github.com/KhronosGroup/glslang/issues/1865, the determinant function
+    // is not deemed to be compile-time constant.
     if (constContext) {
       return Optional.empty();
     }
@@ -1546,8 +1546,8 @@ public final class OpaqueExpressionGenerator {
 
     @Override
     public boolean preconditionHolds(Expr expr, BasicType basicType, boolean constContext) {
-      // TODO(https://github.com/KhronosGroup/glslang/issues/1865): Workaround for glslangValidator
-      //     issue, remove constContext check when fixed.
+      // As discussed in https://github.com/KhronosGroup/glslang/issues/1865, the transpose
+      // function is not deemed to be compile-time constant.
       return super.preconditionHolds(expr, basicType, constContext)
           && !constContext;
     }

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/IdentityMutationFinder.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/IdentityMutationFinder.java
@@ -28,7 +28,6 @@ import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
 import com.graphicsfuzz.common.ast.type.BasicType;
-import com.graphicsfuzz.common.ast.type.QualifiedType;
 import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.ast.type.TypeQualifier;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
@@ -84,7 +83,13 @@ public class IdentityMutationFinder extends Expr2ExprMutationFinder {
     }
     if (basicType.isScalar() || basicType.isVector()
         || BasicType.allSquareMatrixTypes().contains(basicType)) {
+
       // TODO: add support for non-square matrices.
+
+      // Record whether we are currently in a const context, and pass this fact into the lambda
+      // below (otherwise the lambda would query whether the state the finder ends up in is a
+      // const context, which is not right).
+      final boolean isCurrentContextConst = isConstContext();
       addMutation(new Expr2ExprMutation(parentMap.getParent(expr),
           expr,
           () -> new OpaqueExpressionGenerator(
@@ -94,7 +99,7 @@ public class IdentityMutationFinder extends Expr2ExprMutationFinder {
               .applyIdentityFunction(
                   expr,
                   basicType,
-                  isConstContext(),
+                  isCurrentContextConst,
                   0,
                   new Fuzzer(
                       new FuzzingContext(clonedScope),

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/GeneratorArguments.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/GeneratorArguments.java
@@ -16,7 +16,6 @@
 
 package com.graphicsfuzz.generator.tool;
 
-import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import java.io.File;
 
 public class GeneratorArguments {


### PR DESCRIPTION
Fixes an issue where identity mutations were wrongly being applied to constant expressions, leading to invalid code.