### PR TITLE
Fixed bug in vectorizer related to single statement for loops.

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
@@ -90,7 +90,7 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
     //
     // because it declares 'i' twice in the same scope.
     //
-    // Furthermore, a 'while' statement introduces a new scope regardless of whether its body is
+    // Furthermore, a 'for' statement introduces a new scope regardless of whether its body is
     // a block or a single statement.
     //
     // We thus have to push a new scope before traversing a 'for' statement and pop it afterwards,

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
@@ -90,7 +90,11 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
     //
     // because it declares 'i' twice in the same scope.
     //
-    // We thus have to push a new scope before traversing a 'for' statement and pop it afterwards.
+    // Furthermore, a 'while' statement introduces a new scope regardless of whether its body is
+    // a block or a single statement.
+    //
+    // We thus have to push a new scope before traversing a 'for' statement and pop it afterwards,
+    // and we do this regardless of whether the body is a block.
     pushScope();
     super.visitForStmt(forStmt);
     popScope();
@@ -171,8 +175,11 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
     //
     // because it declares 'b' twice in the same scope.
     //
+    // Furthermore, a 'while' statement introduces a new scope regardless of whether its body is
+    // a block or a single statement.
+    //
     // We thus have to push a new scope before traversing a 'while' statement and pop it
-    // afterwards.
+    // afterwards, and we do this regardless of whether the body is a block.
     pushScope();
     super.visitWhileStmt(whileStmt);
     popScope();

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/VectorizeMutationFinderTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/VectorizeMutationFinderTest.java
@@ -21,6 +21,7 @@ import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.util.CannedRandom;
 import com.graphicsfuzz.common.util.CompareAsts;
 import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.RandomWrapper;
 import com.graphicsfuzz.generator.semanticspreserving.VectorizeMutationFinder;
 import com.graphicsfuzz.generator.semanticspreserving.VectorizeMutation;
 import java.util.List;
@@ -154,9 +155,9 @@ public class VectorizeMutationFinderTest {
     final String program =
           "float f()\n"
                 + "{\n"
-                + "    float a = 1;"
-                + "    float b = 2;"
-                + "    float c = 3;"
+                + "    float a = 1.0;"
+                + "    float b = 2.0;"
+                + "    float c = 3.0;"
                 + "    return a;\n"
                 + "}\n";
 
@@ -164,11 +165,11 @@ public class VectorizeMutationFinderTest {
           "float f()\n"
                 + "{\n"
                 + "    vec3 GLF_merged3_0_1_1_1_1_1_2_1_1abc;\n"
-                + "    float a = 1;\n"
+                + "    float a = 1.0;\n"
                 + "    GLF_merged3_0_1_1_1_1_1_2_1_1abc.x = a;\n"
-                + "    float b = 2;\n"
+                + "    float b = 2.0;\n"
                 + "    GLF_merged3_0_1_1_1_1_1_2_1_1abc.y = b;\n"
-                + "    float c = 3;\n"
+                + "    float c = 3.0;\n"
                 + "    GLF_merged3_0_1_1_1_1_1_2_1_1abc.z = c;\n"
                 + "    return GLF_merged3_0_1_1_1_1_1_2_1_1abc.x;\n"
                 + "}\n";
@@ -179,12 +180,12 @@ public class VectorizeMutationFinderTest {
                 + "    vec4 GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca;\n"
                 + "    vec3 GLF_merged3_0_1_1_1_1_1_2_1_1abc;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz = GLF_merged3_0_1_1_1_1_1_2_1_1abc;\n"
-                + "    float a = 1;\n"
+                + "    float a = 1.0;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.w = a;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.x = GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.w;\n"
-                + "    float b = 2;\n"
+                + "    float b = 2.0;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.y = b;\n"
-                + "    float c = 3;\n"
+                + "    float c = 3.0;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.z = c;\n"
                 + "    return GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.x;\n"
                 + "}\n";
@@ -196,13 +197,13 @@ public class VectorizeMutationFinderTest {
                 + "    vec4 GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca;\n"
                 + "    vec3 GLF_merged3_0_1_1_1_1_1_2_1_1abc;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz = GLF_merged3_0_1_1_1_1_1_2_1_1abc;\n"
-                + "    float a = 1;\n"
+                + "    float a = 1.0;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.w = a;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.x = GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.w;\n"
-                + "    float b = 2;\n"
+                + "    float b = 2.0;\n"
                 + "    GLF_merged2_0_1_1_1_1_1bc.x = b;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.y = GLF_merged2_0_1_1_1_1_1bc.x;\n"
-                + "    float c = 3;\n"
+                + "    float c = 3.0;\n"
                 + "    GLF_merged2_0_1_1_1_1_1bc.y = c;\n"
                 + "    GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.z = GLF_merged2_0_1_1_1_1_1bc.y;\n"
                 + "    return GLF_merged2_0_3_32_3_1_1GLF_merged3_0_1_1_1_1_1_2_1_1abca.xyz.x;\n"
@@ -226,6 +227,45 @@ public class VectorizeMutationFinderTest {
     ops.get(1).apply();
     CompareAsts.assertEqualAsts(expectedThird, tu);
 
+  }
+
+  @Test
+  public void testVectorizationOpportunitiesWithSingleStatementLoops() throws Exception {
+    // This checks that the vectorizer does not fall over when presented with loops containing
+    // single statments.
+    final String program =
+        "float f()\n"
+            + "{\n"
+            + "    float a = 1.0;"
+            + "    while (a > 2.0) float z = 3.0;"
+            + "    float b = 2.0;"
+            + "    float c = 3.0;"
+            + "    for (int i = 0; i < 100; i++) float w = 10.0;"
+            + "    return a;\n"
+            + "}\n";
+
+    final String expectedFirst =
+        "float f()\n"
+            + "{\n"
+            + "    vec3 GLF_merged3_0_1_1_1_1_1_2_1_1abc;\n"
+            + "    float a = 1.0;\n"
+            + "    GLF_merged3_0_1_1_1_1_1_2_1_1abc.x = a;\n"
+            + "    while (GLF_merged3_0_1_1_1_1_1_2_1_1abc.x > 2.0) float z = 3.0;"
+            + "    float b = 2.0;\n"
+            + "    GLF_merged3_0_1_1_1_1_1_2_1_1abc.y = b;\n"
+            + "    float c = 3.0;\n"
+            + "    GLF_merged3_0_1_1_1_1_1_2_1_1abc.z = c;\n"
+            + "    for (int i = 0; i < 100; i++) float w = 10.0;"
+            + "    return GLF_merged3_0_1_1_1_1_1_2_1_1abc.x;\n"
+            + "}\n";
+
+    TranslationUnit tu = ParseHelper.parse(program);
+    List<VectorizeMutation> ops =
+        new VectorizeMutationFinder(tu,
+            new CannedRandom(0, 0, 0, 0, 0, 0, 0)).findMutations();
+    assertEquals(1, ops.size());
+    ops.get(0).apply();
+    CompareAsts.assertEqualAsts(expectedFirst, tu);
   }
 
 }


### PR DESCRIPTION
Fixes a problem where the tracking of scopes by the vectorizer was not working properly for single-statement for (and while) loops, which introduce new scopes even though they do not have blocks as bodies.