### PR TITLE
Add parentheses when identities are applied to comma expressions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/FunctionCallExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/FunctionCallExpr.java
@@ -30,6 +30,12 @@ public class FunctionCallExpr extends Expr {
   private List<Expr> args;
 
   public FunctionCallExpr(String callee, List<Expr> args) {
+    for (Expr arg : args) {
+      if (arg instanceof BinaryExpr && ((BinaryExpr) arg).getOp() == BinOp.COMMA) {
+        throw new IllegalArgumentException("Invalid for a comma expression to be a top-level "
+            + "function argument.");
+      }
+    }
     this.callee = callee;
     this.args = new ArrayList<>();
     this.args.addAll(args);

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TypeConstructorExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TypeConstructorExpr.java
@@ -36,6 +36,12 @@ public class TypeConstructorExpr extends Expr {
    * @param args Types of the arguments
    */
   public TypeConstructorExpr(String type, List<Expr> args) {
+    for (Expr arg : args) {
+      if (arg instanceof BinaryExpr && ((BinaryExpr) arg).getOp() == BinOp.COMMA) {
+        throw new IllegalArgumentException("Invalid for a comma expression to be a top-level "
+            + "type constructor argument.");
+      }
+    }
     assert type != null;
     this.type = type;
     this.args = new ArrayList<>();


### PR DESCRIPTION
This PR adds parentheses as needed to comma expressions when they
become arguments to macros or functions, e.g. when the 'e -> min(e,
e)' transformation is applied to the comma expression 'a, b', we want
to end up with 'min((a, b), (a, b))', not 'min(a, b, a, b)'.