### PR TITLE
Support multiple uniforms per variables declaration

### DIFF
--- a/common/src/test/java/com/graphicsfuzz/common/transformreduce/GlslShaderJobTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/transformreduce/GlslShaderJobTest.java
@@ -174,8 +174,8 @@ public class GlslShaderJobTest {
 
     job.makeUniformBindings();
 
-    CompareAsts.assertEqualAsts(VERT_SHADER_WITH_BINDINGS, job.getShaders().get(0));
-    CompareAsts.assertEqualAsts(FRAG_SHADER_WITH_BINDINGS, job.getShaders().get(1));
+    CompareAsts.assertEqualAsts(VERT_SHADER_WITH_BINDINGS, job.getVertexShader().get());
+    CompareAsts.assertEqualAsts(FRAG_SHADER_WITH_BINDINGS, job.getFragmentShader().get());
     assertEquals(new PipelineInfo(JSON_WITH_BINDINGS).toString(), job.getPipelineInfo().toString());
   }
 
@@ -190,10 +190,172 @@ public class GlslShaderJobTest {
 
     job.removeUniformBindings();
 
-    CompareAsts.assertEqualAsts(VERT_SHADER_NO_BINDINGS, job.getShaders().get(0));
-    CompareAsts.assertEqualAsts(FRAG_SHADER_NO_BINDINGS, job.getShaders().get(1));
+    CompareAsts.assertEqualAsts(VERT_SHADER_NO_BINDINGS, job.getVertexShader().get());
+    CompareAsts.assertEqualAsts(FRAG_SHADER_NO_BINDINGS, job.getFragmentShader().get());
     assertEquals(new PipelineInfo(JSON_NO_BINDINGS).toString(), job.getPipelineInfo().toString());
 
+  }
+
+  private static final String VERT_SHADER_NO_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION =
+      "uniform float a, b;"
+          + "uniform int c, d;"
+          + "uniform vec2 e;"
+          + "void main() { }";
+
+  private static final String FRAG_SHADER_NO_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION = "" +
+      "uniform float b, f;"
+      + "uniform int c, d, h;"
+      + "uniform vec2 e, i;"
+      + "void main() { }";
+
+  private static final String JSON_NO_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION = "{" +
+      "  \"a\": {" +
+      "    \"args\": [" +
+      "      1.0" +
+      "    ], " +
+      "    \"func\": \"glUniform1f\"" +
+      "  }, " +
+      "  \"b\": {" +
+      "    \"args\": [" +
+      "      0.0" +
+      "    ], " +
+      "    \"func\": \"glUniform1f\"" +
+      "  }, " +
+      "  \"c\": {" +
+      "    \"args\": [" +
+      "      2" +
+      "    ], " +
+      "    \"func\": \"glUniform1i\"" +
+      "  }, " +
+      "  \"d\": {" +
+      "    \"args\": [" +
+      "      5" +
+      "    ], " +
+      "    \"func\": \"glUniform1i\"" +
+      "  }, " +
+      "  \"e\": {" +
+      "    \"args\": [" +
+      "      12.0," +
+      "      13.0" +
+      "    ], " +
+      "    \"func\": \"glUniform2f\"" +
+      "  }, " +
+      "  \"f\": {" +
+      "    \"args\": [" +
+      "      6.6" +
+      "    ], " +
+      "    \"func\": \"glUniform1f\"" +
+      "  }, " +
+      "  \"h\": {" +
+      "    \"args\": [" +
+      "      18" +
+      "    ], " +
+      "    \"func\": \"glUniform1i\"" +
+      "  }, " +
+      "  \"i\": {" +
+      "    \"args\": [" +
+      "      129.0," +
+      "      138.0" +
+      "    ], " +
+      "    \"func\": \"glUniform2f\"" +
+      "  } " +
+      "}";
+
+  private static final String VERT_SHADER_WITH_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION = ""
+      + "layout(set = 0, binding = 0) uniform buf0 { float a; };\n"
+      + "layout(set = 0, binding = 1) uniform buf1 { float b; };\n"
+      + "layout(set = 0, binding = 2) uniform buf2 { int c; };\n"
+      + "layout(set = 0, binding = 3) uniform buf3 { int d; };\n"
+      + "layout(set = 0, binding = 4) uniform buf4 { vec2 e; };\n"
+      + "void main() { }\n";
+
+  private static final String FRAG_SHADER_WITH_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION = ""
+      + "layout(set = 0, binding = 1) uniform buf1 { float b; };\n"
+      + "layout(set = 0, binding = 5) uniform buf5 { float f; };\n"
+      + "layout(set = 0, binding = 2) uniform buf2 { int c; };\n"
+      + "layout(set = 0, binding = 3) uniform buf3 { int d; };\n"
+      + "layout(set = 0, binding = 6) uniform buf6 { int h; };\n"
+      + "layout(set = 0, binding = 4) uniform buf4 { vec2 e; };\n"
+      + "layout(set = 0, binding = 7) uniform buf7 { vec2 i; };\n"
+      + "void main() { }";
+
+  private static final String JSON_WITH_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION = "{" +
+      "  \"a\": {" +
+      "    \"args\": [" +
+      "      1.0" +
+      "    ], " +
+      "    \"func\": \"glUniform1f\"," +
+      "    \"binding\": 0" +
+      "  }, " +
+      "  \"b\": {" +
+      "    \"args\": [" +
+      "      0.0" +
+      "    ], " +
+      "    \"func\": \"glUniform1f\"," +
+      "    \"binding\": 1" +
+      "  }, " +
+      "  \"c\": {" +
+      "    \"args\": [" +
+      "      2" +
+      "    ], " +
+      "    \"func\": \"glUniform1i\"," +
+      "    \"binding\": 2" +
+      "  }, " +
+      "  \"d\": {" +
+      "    \"args\": [" +
+      "      5" +
+      "    ], " +
+      "    \"func\": \"glUniform1i\"," +
+      "    \"binding\": 3" +
+      "  }, " +
+      "  \"e\": {" +
+      "    \"args\": [" +
+      "      12.0," +
+      "      13.0" +
+      "    ], " +
+      "    \"func\": \"glUniform2f\"," +
+      "    \"binding\": 4" +
+      "  }, " +
+      "  \"f\": {" +
+      "    \"args\": [" +
+      "      6.6" +
+      "    ], " +
+      "    \"func\": \"glUniform1f\"," +
+      "    \"binding\": 5" +
+      "  }, " +
+      "  \"h\": {" +
+      "    \"args\": [" +
+      "      18" +
+      "    ], " +
+      "    \"func\": \"glUniform1i\"," +
+      "    \"binding\": 6" +
+      "  }, " +
+      "  \"i\": {" +
+      "    \"args\": [" +
+      "      129.0," +
+      "      138.0" +
+      "    ], " +
+      "    \"func\": \"glUniform2f\"," +
+      "    \"binding\": 7" +
+      "  } " +
+      "}";
+
+  @Test
+  public void testMakeUniformBindingsMultipleVariablesInSingleDeclaration() throws Exception {
+
+    final GlslShaderJob job = new GlslShaderJob(
+        Optional.empty(),
+        new PipelineInfo(JSON_NO_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION),
+        ParseHelper.parse(getShaderFile("vert", VERT_SHADER_NO_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION)),
+        ParseHelper.parse(getShaderFile("frag", FRAG_SHADER_NO_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION)));
+
+    job.makeUniformBindings();
+
+    CompareAsts.assertEqualAsts(VERT_SHADER_WITH_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION,
+        job.getVertexShader().get());
+    CompareAsts.assertEqualAsts(FRAG_SHADER_WITH_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION,
+        job.getFragmentShader().get());
+    assertEquals(new PipelineInfo(JSON_WITH_BINDINGS_MULTIPLE_VARIABLES_PER_DECLARATION).toString(), job.getPipelineInfo().toString());
   }
 
   private File getShaderFile(String extension, String content) throws IOException {


### PR DESCRIPTION
Some shaders in the wild declare several uniforms in a single
variables declaration statement, which was not supported when adding
uniform bindings; this PR adds support.