### PR TITLE
Typecheck gl_PointCoord

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
@@ -567,6 +567,8 @@ public class Typer extends ScopeTrackingVisitor {
    */
   public static Optional<Type> maybeGetTypeOfBuiltinVariable(String name) {
     switch (name) {
+      case OpenGlConstants.GL_POINT_COORD:
+        return Optional.of(BasicType.VEC2);
       case OpenGlConstants.GL_FRONT_FACING:
         return Optional.of(BasicType.BOOL);
       case OpenGlConstants.GL_POINT_SIZE:

--- a/ast/src/main/java/com/graphicsfuzz/common/util/OpenGlConstants.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/util/OpenGlConstants.java
@@ -28,6 +28,7 @@ public final class OpenGlConstants {
   public static final String GL_FRONT_FACING = "gl_FrontFacing";
   public static final String GL_POSITION = "gl_Position";
   public static final String GL_POINT_SIZE = "gl_PointSize";
+  public static final String GL_POINT_COORD = "gl_PointCoord";
 
   // Compute shaders
   public static final String GL_NUM_WORK_GROUPS = "gl_NumWorkGroups";

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -438,6 +438,23 @@ public class TyperTest {
   }
 
   @Test
+  public void testGlPointCoordTyped() throws Exception {
+    TranslationUnit tu = ParseHelper.parse("#version 300 es\n"
+        + "void main() { gl_PointCoord; }");
+    Typer typer = new NullCheckTyper(tu);
+    new StandardVisitor() {
+      @Override
+      public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
+        super.visitVariableIdentifierExpr(variableIdentifierExpr);
+        if (variableIdentifierExpr.getName().equals(OpenGlConstants.GL_POINT_COORD)) {
+          assertEquals(BasicType.VEC2, typer.lookupType(variableIdentifierExpr));
+        }
+      }
+    }.visit(tu);
+
+  }
+
+  @Test
   public void testGlNumWorkGroupsTyped() throws Exception {
     checkComputeShaderBuiltin(
         "gl_NumWorkGroups",

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -136,6 +136,9 @@ public abstract class DonateCodeTransformation implements ITransformation {
     // qualifiers.
     if (generationParams.getShaderKind() == ShaderKind.FRAGMENT) {
       tu.addDeclaration(new VariablesDeclaration(
+          new QualifiedType(BasicType.VEC2, Collections.singletonList(TypeQualifier.MEDIUMP)),
+          new VariableDeclInfo(addPrefix(OpenGlConstants.GL_POINT_COORD), null, null)));
+      tu.addDeclaration(new VariablesDeclaration(
           new QualifiedType(BasicType.VEC4, Collections.singletonList(TypeQualifier.MEDIUMP)),
           new VariableDeclInfo(addPrefix(OpenGlConstants.GL_FRAG_COORD), null, null)));
       tu.addDeclaration(new VariablesDeclaration(
@@ -147,6 +150,9 @@ public abstract class DonateCodeTransformation implements ITransformation {
             new VariableDeclInfo(addPrefix(OpenGlConstants.GL_FRAG_COLOR), null, null)));
       }
     } else if (generationParams.getShaderKind() == ShaderKind.VERTEX) {
+      tu.addDeclaration(new VariablesDeclaration(
+          new QualifiedType(BasicType.FLOAT, Collections.singletonList(TypeQualifier.HIGHP)),
+          new VariableDeclInfo(addPrefix(OpenGlConstants.GL_POINT_SIZE), null, null)));
       tu.addDeclaration(new VariablesDeclaration(
           new QualifiedType(BasicType.VEC4, Collections.singletonList(TypeQualifier.HIGHP)),
           new VariableDeclInfo(addPrefix(OpenGlConstants.GL_POSITION), null, null)));


### PR DESCRIPTION
This teaches the typechecker about gl_PointCoord, and also puts
gl_PointSize in scope during code donation (an omission from when
support for gl_PointSize is added).