### PR TITLE
Avoid use of comma operator as type constructor parameter

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -1360,8 +1360,9 @@ public final class OpaqueExpressionGenerator {
           index = applyIdentityFunction(index, type.getElementType(), constContext, depth, fuzzer);
         }
 
-        xElements.add(decision ? something : index);
-        yElements.add(decision ? index : something);
+        // Avoid top-level occurrences of the comma operator as type constructor parameters.
+        xElements.add(addParenthesesIfCommaExpr(decision ? something : index));
+        yElements.add(addParenthesesIfCommaExpr(decision ? index : something));
       }
       return identityConstructor(
           expr,


### PR DESCRIPTION
Fixes an issue where an identity function that uses the 'mix' builtin
could create a type constructor expression with a comma expression as
a top-level argument.