### PR TITLE
Do not allow local structs during donation

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -379,9 +379,11 @@ public abstract class DonateCodeTransformation implements ITransformation {
               + maybeDonor.get().getShaderKind());
         }
       }
-      DonationContext donationContext = new DonationContextFinder(maybeDonor.get(), generator)
+      Optional<DonationContext> donationContext = new DonationContextFinder(maybeDonor.get(),
+          generator)
           .getDonationContext();
-      if (incompatible(injectionPoint, donationContext, shadingLanguageVersion)) {
+      if (!donationContext.isPresent() || incompatible(injectionPoint, donationContext.get(),
+          shadingLanguageVersion)) {
         tries++;
         if (tries == maxTries) {
           // We have tried and tried to find something compatible to inject but not managed;
@@ -389,7 +391,7 @@ public abstract class DonateCodeTransformation implements ITransformation {
           return new NullStmt();
         }
       } else {
-        return prepareStatementToDonate(injectionPoint, donationContext, probabilities,
+        return prepareStatementToDonate(injectionPoint, donationContext.get(), probabilities,
             generator,
             shadingLanguageVersion);
       }


### PR DESCRIPTION
Local structs are complex when performing code donation.  For
simplicity, this change means that functions that introduce local
structs are not considered when choosing fragments of code to donate.