### PR TITLE
Visit size expressions of ArrayInfo nodes

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/ParentMap.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/ParentMap.java
@@ -16,7 +16,6 @@
 
 package com.graphicsfuzz.common.ast;
 
-import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
 import java.util.HashMap;
@@ -49,7 +48,6 @@ class ParentMap extends StandardVisitor implements IParentMap {
     // TODO(279): right now there are deliberately cases where a child can have a non-unique parent.
     // We may want to reconsider this.
     assert child instanceof Type
-        || child instanceof ArrayInfo
         || !childToParent.containsKey(child) : "There should be no "
         + "aliasing in the AST with the exception of types; found multiple parents for '" + child
         + "' which has class " + child.getClass() + ".";

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/decl/ArrayInfo.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/decl/ArrayInfo.java
@@ -128,17 +128,7 @@ public class ArrayInfo implements IAstNode {
 
   @Override
   public ArrayInfo clone() {
-    return new ArrayInfo(constantSize, sizeExpr);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    return obj instanceof ArrayInfo && sizeExpr.equals(((ArrayInfo) obj).sizeExpr);
-  }
-
-  @Override
-  public int hashCode() {
-    return sizeExpr.hashCode();
+    return new ArrayInfo(constantSize, sizeExpr.flatMap(item -> Optional.of(item.clone())));
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/StandardVisitor.java
@@ -293,6 +293,9 @@ public abstract class StandardVisitor implements IAstVisitor {
 
   @Override
   public void visitArrayInfo(ArrayInfo arrayInfo) {
+    if (arrayInfo.hasSizeExpr()) {
+      visitChildFromParent(arrayInfo.getSizeExpr(), arrayInfo);
+    }
   }
 
   @Override

--- a/ast/src/test/java/com/graphicsfuzz/common/ast/decl/ArrayInfoTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/ast/decl/ArrayInfoTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.common.ast.decl;
+
+import com.graphicsfuzz.common.ast.expr.Expr;
+import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class ArrayInfoTest {
+
+  @Test
+  public void testClone() {
+    final Expr sizeExpr = new IntConstantExpr("1");
+    final ArrayInfo arrayInfo1 = new ArrayInfo(sizeExpr);
+    final ArrayInfo arrayInfo2 = arrayInfo1.clone();
+    assertNotSame(arrayInfo1, arrayInfo2);
+    assertSame(sizeExpr, arrayInfo1.getSizeExpr());
+    assertNotSame(sizeExpr, arrayInfo2.getSizeExpr());
+    assertEquals(sizeExpr.getText(), arrayInfo2.getSizeExpr().getText());
+  }
+
+}

--- a/common/src/test/java/com/graphicsfuzz/common/util/StripUnusedGlobalsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/StripUnusedGlobalsTest.java
@@ -82,4 +82,17 @@ public class StripUnusedGlobalsTest {
     CompareAsts.assertEqualAsts(original, tu);
   }
 
+  @Test
+  public void testDoNotStripConstantUsedToInitializeArray() throws Exception {
+    final String original = ""
+        + "const int N = 5;\n"
+        + "int A[N];\n"
+        + "void main() {"
+        + "  A[0] = 1;\n"
+        + "}";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    StripUnusedGlobals.strip(tu);
+    CompareAsts.assertEqualAsts(original, tu);
+  }
+
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/mutateapi/MutationFinderBase.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/mutateapi/MutationFinderBase.java
@@ -17,6 +17,7 @@
 package com.graphicsfuzz.generator.mutateapi;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.BoolConstantExpr;
@@ -243,5 +244,10 @@ public abstract class MutationFinderBase<MutationT extends Mutation>
     underForLoopHeader = false;
     visitChildFromParent(forStmt.getBody(), forStmt);
     popScope();
+  }
+
+  @Override
+  public void visitArrayInfo(ArrayInfo arrayInfo) {
+    // Do nothing: we do not want to mutate array size expressions.
   }
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -16,7 +16,6 @@
 
 package com.graphicsfuzz.generator.transformation;
 
-import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.decl.Declaration;
@@ -444,8 +443,6 @@ public abstract class DonateCodeTransformation implements ITransformation {
       tu.addDeclaration(maybeInjectionSwitch.get());
     }
 
-
-
     eliminateUsedDonors();
     return !injectionPoints.isEmpty();
 
@@ -513,25 +510,6 @@ public abstract class DonateCodeTransformation implements ITransformation {
       // We simply make do without an initializer, as we didn't manage to fuzz one.
       return null;
     }
-  }
-
-  private Set<String> getCalledFunctions(final IAstNode node) {
-    return new StandardVisitor() {
-
-      private final Set<String> calledFunctions = new HashSet<String>();
-
-      @Override
-      public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
-        super.visitFunctionCallExpr(functionCallExpr);
-        calledFunctions.add(functionCallExpr.getCallee());
-      }
-
-      private Set<String> calledFunctions() {
-        visit(node);
-        return calledFunctions;
-      }
-
-    }.calledFunctions();
   }
 
   private Optional<TranslationUnit> chooseDonor(IRandom generator,

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/FreeVariablesCollector.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/FreeVariablesCollector.java
@@ -130,7 +130,9 @@ public class FreeVariablesCollector extends ScopeTrackingVisitor {
         throw new RuntimeException(
             "Found variable '" + name + "' that is not typed in the current scope.");
       }
-      freeVariables.put(name, type);
+      // Clone the type so that we can do what we want with it when we go on to process the free
+      // variables.
+      freeVariables.put(name, type.clone());
     }
   }
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/SimplifyExprReductionOpportunities.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.expr.Expr;
@@ -87,6 +88,11 @@ abstract class SimplifyExprReductionOpportunities
       assert inLoopLimiterVariableDeclInfo;
       inLoopLimiterVariableDeclInfo = false;
     }
+  }
+
+  @Override
+  public void visitArrayInfo(ArrayInfo arrayInfo) {
+    // Do nothing: we do not want to simplify array size expressions.
   }
 
   boolean allowedToReduceExpr(IAstNode parent, Expr child) {

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunitiesTest.java
@@ -91,4 +91,32 @@ public class VariableDeclReductionOpportunitiesTest {
     assertEquals(0, ops.size());
   }
 
+  @Test
+  public void testDoNotRemoveConstantUsedToInitializeArray() throws Exception {
+    final String program = ""
+        + "#version 310 es\n"
+        + "const int N = 5;\n"
+        + "const int M = 6;\n"
+        + "int A[N];\n"
+        + "void main() {\n"
+        + "  int B[M];\n"
+        + "  const int P = 7;\n"
+        + "  int C[P];\n"
+        + "  A[0] = 1;\n"
+        + "  B[0] = 2;\n"
+        + "  C[0] = 3;\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(program);
+    List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
+        .findOpportunities(
+            MakeShaderJobFromFragmentShader.make(tu),
+            new ReducerContext(
+                false,
+                ShadingLanguageVersion.ESSL_310,
+                new RandomWrapper(0),
+                new IdGenerator())
+        );
+    assertEquals(0, ops.size());
+  }
+
 }


### PR DESCRIPTION
We recently added the notion of a size expression to an ArrayInfo
node.  This change enhances StandardVisitor to visit size expressions,
so that they are considered when walking the AST.  Sometimes we don't
want them to be visited, so some visitors have been adapted to
override this method in order to block it.  We also now want to avoid
any sharing of ArrayInfo nodes in the AST, so the change removes its
equals and hashCode methods and adds clonability.