### PR TITLE
Guard against occurrences of comma in most expressions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/ArrayIndexExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/ArrayIndexExpr.java
@@ -25,13 +25,15 @@ public class ArrayIndexExpr extends Expr {
   private Expr index;
 
   public ArrayIndexExpr(Expr array, Expr index) {
-    // Motivation for this assertion:
+    // Motivation for this exception:
     // vec2 v;
     // v[0]; // fine
     // v + vec2(0.0)[0]; // not fine - the following was probably intended:
     // (v + vec2(0.0))[0]; // fine
-    assert !(array instanceof BinaryExpr) :
-        "Array index into binary expression " + array.getText() + " not allowed.";
+    if (array instanceof BinaryExpr) {
+      throw new IllegalArgumentException("Array index into binary expression "
+          + array.getText() + " not allowed.");
+    }
     this.array = array;
     this.index = index;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/BinaryExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/BinaryExpr.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.ast.expr;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import java.util.Arrays;
 
 public class BinaryExpr extends Expr {
 
@@ -35,6 +36,9 @@ public class BinaryExpr extends Expr {
   public BinaryExpr(Expr lhs, Expr rhs, BinOp op) {
     assert lhs != null;
     assert rhs != null;
+    if (op != BinOp.COMMA) {
+      checkNoTopLevelCommaExpression(Arrays.asList(lhs, rhs));
+    }
     this.lhs = lhs;
     this.rhs = rhs;
     this.op = op;

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/Expr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/Expr.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.ast.expr;
 
 import com.graphicsfuzz.common.ast.ChildDoesNotExistException;
 import com.graphicsfuzz.common.ast.IAstNode;
+import java.util.List;
 
 public abstract class Expr implements IAstNode {
 
@@ -45,5 +46,13 @@ public abstract class Expr implements IAstNode {
   }
 
   public abstract boolean hasChild(IAstNode child);
+
+  public static void checkNoTopLevelCommaExpression(List<Expr> args) {
+    for (Expr arg : args) {
+      if (arg instanceof BinaryExpr && ((BinaryExpr) arg).getOp() == BinOp.COMMA) {
+        throw new IllegalArgumentException("Invalid use of comma expression.");
+      }
+    }
+  }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/FunctionCallExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/FunctionCallExpr.java
@@ -30,12 +30,7 @@ public class FunctionCallExpr extends Expr {
   private List<Expr> args;
 
   public FunctionCallExpr(String callee, List<Expr> args) {
-    for (Expr arg : args) {
-      if (arg instanceof BinaryExpr && ((BinaryExpr) arg).getOp() == BinOp.COMMA) {
-        throw new IllegalArgumentException("Invalid for a comma expression to be a top-level "
-            + "function argument.");
-      }
-    }
+    checkNoTopLevelCommaExpression(args);
     this.callee = callee;
     this.args = new ArrayList<>();
     this.args.addAll(args);

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/MemberLookupExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/MemberLookupExpr.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.ast.expr;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import java.util.Collections;
 
 public class MemberLookupExpr extends Expr {
 
@@ -25,6 +26,7 @@ public class MemberLookupExpr extends Expr {
   private String member;
 
   public MemberLookupExpr(Expr structure, String member) {
+    checkNoTopLevelCommaExpression(Collections.singletonList(structure));
     setStructure(structure);
     this.member = member;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TernaryExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TernaryExpr.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.ast.expr;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import java.util.Arrays;
 
 public class TernaryExpr extends Expr {
 
@@ -32,6 +33,7 @@ public class TernaryExpr extends Expr {
    * @param elseExpr Result if the boolean is false
    */
   public TernaryExpr(Expr test, Expr thenExpr, Expr elseExpr) {
+    checkNoTopLevelCommaExpression(Arrays.asList(test, thenExpr, elseExpr));
     this.test = test;
     this.thenExpr = thenExpr;
     this.elseExpr = elseExpr;

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TypeConstructorExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TypeConstructorExpr.java
@@ -36,12 +36,7 @@ public class TypeConstructorExpr extends Expr {
    * @param args Types of the arguments
    */
   public TypeConstructorExpr(String type, List<Expr> args) {
-    for (Expr arg : args) {
-      if (arg instanceof BinaryExpr && ((BinaryExpr) arg).getOp() == BinOp.COMMA) {
-        throw new IllegalArgumentException("Invalid for a comma expression to be a top-level "
-            + "type constructor argument.");
-      }
-    }
+    checkNoTopLevelCommaExpression(args);
     assert type != null;
     this.type = type;
     this.args = new ArrayList<>();

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/UnaryExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/UnaryExpr.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.ast.expr;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
+import java.util.Collections;
 
 public class UnaryExpr extends Expr {
 
@@ -25,6 +26,7 @@ public class UnaryExpr extends Expr {
   private UnOp op;
 
   public UnaryExpr(Expr expr, UnOp op) {
+    checkNoTopLevelCommaExpression(Collections.singletonList(expr));
     this.expr = expr;
     this.op = op;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -1504,7 +1504,12 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     Expr result = argsInOrder.get(argsInOrder.size() - 1);
     for (int i = argsInOrder.size() - 2; i >= 0; i -= 2) {
       assert (i % 2) == 1;
-      result = new TernaryExpr(argsInOrder.get(i - 1), argsInOrder.get(i), result);
+      final Expr thenExpr = argsInOrder.get(i);
+      if (thenExpr instanceof BinaryExpr && ((BinaryExpr) thenExpr).getOp() == BinOp.COMMA) {
+        throw new UnsupportedLanguageFeatureException("The use of a comma in the 'then' "
+            + "expression of a ternary is not currently supported.");
+      }
+      result = new TernaryExpr(argsInOrder.get(i - 1), thenExpr, result);
     }
     return result;
   }

--- a/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
@@ -801,4 +801,19 @@ public class ParseHelperTest {
     }
   }
 
+  @Test
+  public void testUnsupportedCommaInTernary() throws Exception {
+    try {
+      ParseHelper.parse("#version 310 es\n"
+          + "\n"
+          + "void main() {\n"
+          + "  true ? 2, 3 : 4;\n"
+          + "}\n");
+      fail("Exception was expected");
+    } catch (UnsupportedLanguageFeatureException exception) {
+      assertTrue(exception.getMessage().contains("The use of a comma in the 'then' expression of a "
+          + "ternary is not currently supported."));
+    }
+  }
+
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -1118,13 +1118,13 @@ public final class OpaqueExpressionGenerator {
       if (generator.nextBoolean()) {
         return identityConstructor(expr,
             ternary(makeOpaqueBoolean(false, BasicType.BOOL, constContext, depth, fuzzer),
-                something,
-                exprWithIdentityApplied));
+                addParenthesesIfCommaExpr(something),
+                addParenthesesIfCommaExpr(exprWithIdentityApplied)));
       }
       return identityConstructor(expr,
           ternary(makeOpaqueBoolean(true, BasicType.BOOL, constContext, depth, fuzzer),
-              exprWithIdentityApplied,
-              something));
+              addParenthesesIfCommaExpr(exprWithIdentityApplied),
+              addParenthesesIfCommaExpr(something)));
     }
 
   }


### PR DESCRIPTION
The comma operator should never occur as the top-level argument to an
expression such as a binary or unary expression, with few exceptions
(e.g. a parentheses expression).  This change introduces checks to
guard against this, and to make it clear that using a comma in the
'then' expression of a ternary is not supported (even though it is
allowed in GLSL).