### PR TITLE
Use proper literal names when inlining bool uniforms

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
@@ -23,6 +23,7 @@ import com.graphicsfuzz.common.ast.decl.Initializer;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.expr.ArrayConstructorExpr;
+import com.graphicsfuzz.common.ast.expr.BoolConstantExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FloatConstantExpr;
 import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
@@ -139,7 +140,10 @@ public final class PruneUniforms {
 
   public static Expr getBasicTypeLiteralExpr(BasicType baseType, List<Number> args) {
     List<Expr> argExprs;
-    if (baseType.getElementType() == BasicType.FLOAT) {
+    if (baseType.getElementType() == BasicType.BOOL) {
+      argExprs = args.stream().map(item -> new BoolConstantExpr(item.intValue() == 1))
+          .collect(Collectors.toList());
+    } else if (baseType.getElementType() == BasicType.FLOAT) {
       argExprs = args.stream().map(item -> new FloatConstantExpr(item.toString()))
           .collect(Collectors.toList());
     } else if (baseType.getElementType() == BasicType.UINT) {

--- a/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
@@ -89,7 +90,7 @@ public class PruneUniformsTest {
           + "  }\n"
           + "}\n";
 
-    List<String> prefixList = Arrays.asList("prune");
+    List<String> prefixList = Collections.singletonList("prune");
     int limit = 2;
 
     doPruneTest(program, uniforms, expectedProgram, expectedUniforms, prefixList, limit);
@@ -105,6 +106,7 @@ public class PruneUniformsTest {
           + "uniform vec2 liveG, deadH;"
           + "uniform uint liveA, liveB;"
           + "uniform bvec3 liveC[3];"
+          + "uniform bool liveZ;"
           + "void main() {"
           + "}";
     final String uniforms = "{\n"
@@ -149,6 +151,12 @@ public class PruneUniformsTest {
           + "    \"args\": [\n"
           + "      0, 1, 0, 1, 0, 1, 0, 1, 0\n"
           + "    ]\n"
+          + "  },\n"
+          + "  \"liveZ\": {\n"
+          + "    \"func\": \"glUniform1i\",\n"
+          + "    \"args\": [\n"
+          + "      1\n"
+          + "    ]\n"
           + "  }\n"
           + "}\n";
 
@@ -160,7 +168,9 @@ public class PruneUniformsTest {
           + "vec2 liveG = vec2(256.0, 257.0);"
           + "uint liveA = 25u;"
           + "uint liveB = 26u;"
-          + "bvec3 liveC[3] = bvec3[3](bvec3(0, 1, 0), bvec3(1, 0, 1), bvec3(0, 1, 0));"
+          + "bvec3 liveC[3] = bvec3[3](bvec3(false, true, false), bvec3(true, false, true), "
+                  + "bvec3(false, true, false));"
+          + "bool liveZ = true;"
           + "void main() {"
           + "}";
     final String expectedUniforms = "{\n"


### PR DESCRIPTION
Bool uniforms are represented as integers at the API level, and were
being inlined into shaders as integer literals.  This change addresses
this, so that they are inlined as bool literals.