### PR TITLE
Update Fuzzer API

### DIFF
--- a/third_party/vulkan_layers/.gitignore
+++ b/third_party/vulkan_layers/.gitignore
@@ -1,2 +1,4 @@
 cmake-build-debug
 .idea
+
+build/

--- a/third_party/vulkan_layers/shader_fuzzer/layer_impl.cpp
+++ b/third_party/vulkan_layers/shader_fuzzer/layer_impl.cpp
@@ -113,17 +113,15 @@ TryFuzzingShader(VkShaderModuleCreateInfo const *pCreateInfo) {
   }
 
   // Create a fuzzer and the various parameters required for fuzzing.
-  spvtools::fuzz::Fuzzer fuzzer(target_env);
+  spvtools::fuzz::Fuzzer fuzzer(target_env, shader_module_id, false);
   std::vector<uint32_t> binary_in(pCreateInfo->pCode,
                                   pCreateInfo->pCode + code_size_in_words);
   std::vector<uint32_t> result;
   spvtools::fuzz::protobufs::FactSequence no_facts;
   spvtools::fuzz::protobufs::TransformationSequence transformation_sequence;
-  spvtools::FuzzerOptions fuzzer_options;
-  fuzzer_options.set_random_seed(shader_module_id);
 
   // Fuzz the shader into |result|.
-  auto fuzzer_result_status = fuzzer.Run(binary_in, no_facts, fuzzer_options,
+  auto fuzzer_result_status = fuzzer.Run(binary_in, no_facts, {},
                                          &result, &transformation_sequence);
 
   if (fuzzer_result_status !=

--- a/vulkan-worker/.gitignore
+++ b/vulkan-worker/.gitignore
@@ -7,6 +7,8 @@ gradle.properties
 .gradle/
 .idea/
 *.iml
+.project
+.settings/
 GPATH
 GTAGS
 GRTAGS


### PR DESCRIPTION
Fixes #922.
Note that I experienced compilation issues with `protobuf` library.
It looks like `protobuf` adds debug postfix to its target so that we are getting `libprotobufd.a` instead of `libprotobuf.a`. This causes build script to crash saying that the latter target is undefined. To fix use:
```
$ mkdir build && cd build
$ cmake -Dprotobuf_DEBUG_POSTFIX="" ..
```