### PR TITLE
Change vulkan layer common module library type

### DIFF
--- a/third_party/vulkan_layers/common/CMakeLists.txt
+++ b/third_party/vulkan_layers/common/CMakeLists.txt
@@ -19,7 +19,7 @@ set(VULKAN_LAYERS_COMMON_SOURCES
         spirv_util.cpp
         )
 
-add_library(vulkan_layers_common STATIC ${VULKAN_LAYERS_COMMON_SOURCES})
+add_library(vulkan_layers_common SHARED ${VULKAN_LAYERS_COMMON_SOURCES})
 
 target_include_directories(vulkan_layers_common
         PRIVATE ../external/SPIRV-Tools


### PR DESCRIPTION
Changes the vulkan layers' common module's library type from STATIC to SHARED.
Using static causes some linker error. This is just a workaround.

Using static library causes following linker error when building amber-scoop and shader-fuzzer vulkan layer:
```
/usr/bin/ld: ../common/libvulkan_layers_common.a(spirv_util.cpp.o): relocation R_X86_64_PC32 against symbol `_ZNSt4pairIb14spv_target_envEC1IbRS0_Lb1EEEOT_OT0_' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
```