### PR TITLE
Make typechecker strict

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -354,6 +354,12 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
           }
         }
       }
+
+      @Override
+      public void visitArrayConstructorExpr(ArrayConstructorExpr arrayConstructorExpr) {
+        super.visitArrayConstructorExpr(arrayConstructorExpr);
+        handleArrayInfo(arrayConstructorExpr.getArrayType().getArrayInfo());
+      }
     }.visit(tu);
     return tu;
   }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
@@ -22,6 +22,7 @@ import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.decl.InterfaceBlock;
 import com.graphicsfuzz.common.ast.decl.ParameterDecl;
+import com.graphicsfuzz.common.ast.expr.ArrayConstructorExpr;
 import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.BoolConstantExpr;
@@ -81,16 +82,15 @@ public class Typer extends ScopeTrackingVisitor {
   @Override
   public void visitParenExpr(ParenExpr parenExpr) {
     super.visitParenExpr(parenExpr);
-    Type type = lookupType(parenExpr.getExpr());
-    if (type != null) {
-      types.put(parenExpr, type);
-    }
+    final Type type = lookupType(parenExpr.getExpr());
+    assert type != null;
+    types.put(parenExpr, type);
   }
 
   @Override
   public void visitFunctionPrototype(FunctionPrototype functionPrototype) {
     super.visitFunctionPrototype(functionPrototype);
-    String name = functionPrototype.getName();
+    final String name = functionPrototype.getName();
     if (!userDefinedFunctions.containsKey(name)) {
       userDefinedFunctions.put(name, new HashSet<>());
     }
@@ -110,6 +110,11 @@ public class Typer extends ScopeTrackingVisitor {
   @Override
   public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
     super.visitFunctionCallExpr(functionCallExpr);
+
+    // Check that types have been found for all arguments to the function.
+    for (Expr arg : functionCallExpr.getArgs()) {
+      assert types.get(arg) != null;
+    }
 
     // First, see whether this is an invocation of a GraphicsFuzz macro.  If it is, we handle it
     // by propagating the type of an appropriate macro argument.
@@ -209,10 +214,8 @@ public class Typer extends ScopeTrackingVisitor {
       return false;
     }
     for (int i = 0; i < prototype.getNumParameters(); i++) {
-      Type argType = lookupType(functionCallExpr.getArg(i));
-      if (argType == null) {
-        return false;
-      }
+      final Type argType = lookupType(functionCallExpr.getArg(i));
+      assert argType != null;
       final ParameterDecl parameter = prototype.getParameter(i);
       if (!argType.getWithoutQualifiers()
           .equals(Typer.combineBaseTypeAndArrayInfo(parameter.getType(), parameter.getArrayInfo())
@@ -226,7 +229,7 @@ public class Typer extends ScopeTrackingVisitor {
   @Override
   public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
     super.visitVariableIdentifierExpr(variableIdentifierExpr);
-    Type type = getCurrentScope().lookupType(variableIdentifierExpr.getName());
+    final Type type = getCurrentScope().lookupType(variableIdentifierExpr.getName());
     if (type != null) {
       types.put(variableIdentifierExpr, type);
       return;
@@ -340,28 +343,17 @@ public class Typer extends ScopeTrackingVisitor {
   @Override
   public void visitUnaryExpr(UnaryExpr unaryExpr) {
     super.visitUnaryExpr(unaryExpr);
-
-    // TODO: need to check, but as a first approximation a unary always returns the same type as
-    // its argument
-
-    Type argType = types.get(unaryExpr.getExpr());
-    if (argType != null) {
-      types.put(unaryExpr, argType);
-    }
+    final Type argType = types.get(unaryExpr.getExpr());
+    assert argType != null;
+    types.put(unaryExpr, argType);
   }
 
   @Override
   public void visitTernaryExpr(TernaryExpr ternaryExpr) {
     super.visitTernaryExpr(ternaryExpr);
-    Type thenType = types.get(ternaryExpr.getThenExpr());
-    if (thenType != null) {
-      types.put(ternaryExpr, thenType);
-    } else {
-      Type elseType = types.get(ternaryExpr.getElseExpr());
-      if (elseType != null) {
-        types.put(ternaryExpr, elseType);
-      }
-    }
+    final Type thenType = types.get(ternaryExpr.getThenExpr());
+    assert thenType != null;
+    types.put(ternaryExpr, thenType);
   }
 
   @Override
@@ -371,10 +363,7 @@ public class Typer extends ScopeTrackingVisitor {
     Type rhsType = types.get(binaryExpr.getRhs()).getWithoutQualifiers();
     switch (binaryExpr.getOp()) {
       case MUL: {
-        Type resolvedType = TyperHelper.resolveTypeOfMul(lhsType, rhsType);
-        if (resolvedType != null) {
-          types.put(binaryExpr, resolvedType);
-        }
+        types.put(binaryExpr, TyperHelper.resolveTypeOfMul(lhsType, rhsType));
         return;
       }
       case ADD:
@@ -391,10 +380,7 @@ public class Typer extends ScopeTrackingVisitor {
       case DIV_ASSIGN:
       case MUL_ASSIGN:
       case SUB_ASSIGN: {
-        Type resolvedType = TyperHelper.resolveTypeOfCommonBinary(lhsType, rhsType);
-        if (resolvedType != null) {
-          types.put(binaryExpr, resolvedType);
-        }
+        types.put(binaryExpr, TyperHelper.resolveTypeOfCommonBinary(lhsType, rhsType));
         return;
       }
       case EQ:
@@ -455,12 +441,8 @@ public class Typer extends ScopeTrackingVisitor {
   @Override
   public void visitMemberLookupExpr(MemberLookupExpr memberLookupExpr) {
     super.visitMemberLookupExpr(memberLookupExpr);
-    Type structureType = lookupType(memberLookupExpr.getStructure());
-
-    if (structureType == null) {
-      // In due course we should extend the typer so that it can type everything.
-      return;
-    }
+    final Type structureType = lookupType(memberLookupExpr.getStructure());
+    assert structureType != null;
 
     // The structure type is either a builtin, like a vector, or an actual struct
 
@@ -501,6 +483,12 @@ public class Typer extends ScopeTrackingVisitor {
     }
   }
 
+  @Override
+  public void visitArrayConstructorExpr(ArrayConstructorExpr arrayConstructorExpr) {
+    super.visitArrayConstructorExpr(arrayConstructorExpr);
+    types.put(arrayConstructorExpr, arrayConstructorExpr.getArrayType());
+  }
+
   public Type lookupType(Expr expr) {
     return types.get(expr);
   }
@@ -510,7 +498,7 @@ public class Typer extends ScopeTrackingVisitor {
   }
 
   public Set<FunctionPrototype> getPrototypes(String name) {
-    Set<FunctionPrototype> result = new HashSet<>();
+    final Set<FunctionPrototype> result = new HashSet<>();
     if (userDefinedFunctions.containsKey(name)) {
       result.addAll(userDefinedFunctions.get(name));
     }
@@ -534,11 +522,7 @@ public class Typer extends ScopeTrackingVisitor {
   @Override
   public void visitArrayIndexExpr(ArrayIndexExpr arrayIndexExpr) {
     super.visitArrayIndexExpr(arrayIndexExpr);
-    Type arrayType = lookupType(arrayIndexExpr.getArray());
-    if (arrayType == null) {
-      return;
-    }
-    arrayType = arrayType.getWithoutQualifiers();
+    final Type arrayType = lookupType(arrayIndexExpr.getArray()).getWithoutQualifiers();
     Type elementType;
     if (BasicType.allVectorTypes().contains(arrayType)) {
       elementType = ((BasicType) arrayType).getElementType();

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/TyperHelper.java
@@ -53,22 +53,18 @@ public final class TyperHelper {
 
   public static Type resolveTypeOfCommonBinary(Type lhsType, Type rhsType) {
     // If they match, the result must be the same
-    if (lhsType == rhsType) {
+    if (lhsType.equals(rhsType)) {
       return lhsType;
     }
     // If one side is scalar and the other side is basic, the result has to be that of the other
     // side
     if (lhsType == BasicType.FLOAT || lhsType == BasicType.INT || lhsType == BasicType.UINT) {
-      if (rhsType instanceof BasicType) {
-        return rhsType;
-      }
-      return null;
+      assert rhsType instanceof BasicType;
+      return rhsType;
     }
     if (rhsType == BasicType.FLOAT || rhsType == BasicType.INT || rhsType == BasicType.UINT) {
-      if (lhsType instanceof BasicType) {
-        return lhsType;
-      }
-      return null;
+      assert lhsType instanceof BasicType;
+      return lhsType;
     }
     // Now we are in a position where if we know that one type is vector
     // or matrix, the other side must be also
@@ -95,6 +91,7 @@ public final class TyperHelper {
         return t;
       }
     }
+    assert false : "Unreachable";
     return null;
   }
 
@@ -107,16 +104,12 @@ public final class TyperHelper {
     // If one side is scalar and the other side is basic, the result has to be that of the other
     // side
     if (lhsType == BasicType.FLOAT || lhsType == BasicType.INT || lhsType == BasicType.UINT) {
-      if (rhsType instanceof BasicType) {
-        return rhsType;
-      }
-      return null;
+      assert rhsType instanceof BasicType;
+      return rhsType;
     }
     if (rhsType == BasicType.FLOAT || rhsType == BasicType.INT || rhsType == BasicType.UINT) {
-      if (lhsType instanceof BasicType) {
-        return lhsType;
-      }
-      return null;
+      assert lhsType instanceof BasicType;
+      return lhsType;
     }
 
     // For integer and unsigned integer vectors, we are now in a position where if we see that
@@ -140,17 +133,9 @@ public final class TyperHelper {
       return BasicType.IVEC4;
     }
 
-    // Now for floating point vectors and matrices we need to be careful,
-    // so we just consider all the cases
-    if (lhsType == BasicType.VEC2 && rhsType == BasicType.VEC2) {
-      return BasicType.VEC2;
-    }
-    if (lhsType == BasicType.VEC3 && rhsType == BasicType.VEC3) {
-      return BasicType.VEC3;
-    }
-    if (lhsType == BasicType.VEC4 && rhsType == BasicType.VEC4) {
-      return BasicType.VEC4;
-    }
+    // Now for floating point vectors and matrices we need to be careful, so we just consider all
+    // the cases of distinct basic types (the cases where basic types are handled at the start of
+    // the method).
     if (lhsType == BasicType.VEC2 && rhsType == BasicType.MAT2X2) {
       return BasicType.VEC2;
     }
@@ -162,9 +147,6 @@ public final class TyperHelper {
     }
     if (lhsType == BasicType.MAT2X2 && rhsType == BasicType.VEC2) {
       return BasicType.VEC2;
-    }
-    if (lhsType == BasicType.MAT2X2 && rhsType == BasicType.MAT2X2) {
-      return BasicType.MAT2X2;
     }
     if (lhsType == BasicType.MAT2X2 && rhsType == BasicType.MAT3X2) {
       return BasicType.MAT3X2;
@@ -286,6 +268,7 @@ public final class TyperHelper {
     if (lhsType == BasicType.MAT4X4 && rhsType == BasicType.MAT4X4) {
       return BasicType.MAT4X4;
     }
+    assert false : "Unreachable";
     return null;
   }
 

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -27,6 +27,7 @@ import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.decl.Initializer;
 import com.graphicsfuzz.common.ast.decl.ParameterDecl;
+import com.graphicsfuzz.common.ast.expr.ArrayConstructorExpr;
 import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
@@ -783,7 +784,7 @@ public class TyperTest {
   @Test
   public void testConstArrayCorrectlyTyped() throws Exception {
     TranslationUnit tu = ParseHelper.parse("#version 310 es\n"
-        + "int main() {\n"
+        + "void main() {\n"
         + "  const int A[2] = int[2](1, 2);\n"
         + "  A;\n"
         + "}\n");
@@ -802,6 +803,24 @@ public class TyperTest {
         } catch (UnsupportedLanguageFeatureException exception) {
           fail();
         }
+      }
+    };
+  }
+
+  @Test
+  public void testArrayConstructorCorrectlyTyped() throws Exception {
+    TranslationUnit tu = ParseHelper.parse("#version 310 es\n"
+        + "void main() {\n"
+        + "  int[2](1, 2);\n"
+        + "}\n");
+    new NullCheckTyper(tu) {
+      @Override
+      public void visitArrayConstructorExpr(ArrayConstructorExpr arrayConstructorExpr) {
+        super.visitArrayConstructorExpr(arrayConstructorExpr);
+        final Type type = lookupType(arrayConstructorExpr);
+        assertTrue(type instanceof ArrayType);
+        assertSame(((ArrayType) type).getBaseType(), BasicType.INT);
+        assertEquals(2, (int) ((ArrayType) type).getArrayInfo().getConstantSize());
       }
     };
   }


### PR DESCRIPTION
The GraphicsFuzz typechecker was originally "best effort", and
tolerated null entries for expressions that could not yet be typed.
This change tightens up the typechecker so that null types are not
tolerated.