### PR TITLE
Allow comma as 'then' expression in ternary

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TernaryExpr.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/expr/TernaryExpr.java
@@ -33,7 +33,9 @@ public class TernaryExpr extends Expr {
    * @param elseExpr Result if the boolean is false
    */
   public TernaryExpr(Expr test, Expr thenExpr, Expr elseExpr) {
-    checkNoTopLevelCommaExpression(Arrays.asList(test, thenExpr, elseExpr));
+    // The 'test' and 'else' expressions are not allowed to be top-level instances of the comma
+    // operator, but the 'then' expression is, e.g. 'a ? b, c : d' is legal.
+    checkNoTopLevelCommaExpression(Arrays.asList(test, elseExpr));
     this.test = test;
     this.thenExpr = thenExpr;
     this.elseExpr = elseExpr;

--- a/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/visitors/AstBuilder.java
@@ -1505,10 +1505,6 @@ public class AstBuilder extends GLSLBaseVisitor<Object> {
     for (int i = argsInOrder.size() - 2; i >= 0; i -= 2) {
       assert (i % 2) == 1;
       final Expr thenExpr = argsInOrder.get(i);
-      if (thenExpr instanceof BinaryExpr && ((BinaryExpr) thenExpr).getOp() == BinOp.COMMA) {
-        throw new UnsupportedLanguageFeatureException("The use of a comma in the 'then' "
-            + "expression of a ternary is not currently supported.");
-      }
       result = new TernaryExpr(argsInOrder.get(i - 1), thenExpr, result);
     }
     return result;

--- a/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/util/ParseHelperTest.java
@@ -23,11 +23,16 @@ import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.decl.Initializer;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.ast.expr.BinOp;
+import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.FloatConstantExpr;
 import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
+import com.graphicsfuzz.common.ast.expr.TernaryExpr;
 import com.graphicsfuzz.common.ast.expr.UIntConstantExpr;
+import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
+import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.ReturnStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.type.Type;
@@ -647,6 +652,50 @@ public class ParseHelperTest {
   }
 
   @Test
+  public void testParsingComma1() throws Exception {
+    final TranslationUnit tu = ParseHelper.parse(""
+        + "void main() {\n"
+        + "  bool b, c;\n"
+        + "  int x, y;\n"
+        + "  b, c ? x : y;\n"
+        + "  b ? c, x : y;\n"
+        + "  b ? x : y, c;\n"
+        + "}\n");
+    final BlockStmt block = tu.getMainFunction().getBody();
+    assertTrue(block.getStmt(0) instanceof DeclarationStmt);
+    assertTrue(block.getStmt(1) instanceof DeclarationStmt);
+
+    {
+      final ExprStmt exprStmt = (ExprStmt) block.getStmt(2);
+      assertTrue(exprStmt.getExpr() instanceof BinaryExpr);
+      final BinaryExpr binaryExpr = (BinaryExpr) exprStmt.getExpr();
+      assertEquals(BinOp.COMMA, binaryExpr.getOp());
+      assertTrue(binaryExpr.getLhs() instanceof VariableIdentifierExpr);
+      assertTrue(binaryExpr.getRhs() instanceof TernaryExpr);
+    }
+
+    {
+      final ExprStmt exprStmt = (ExprStmt) block.getStmt(3);
+      assertTrue(exprStmt.getExpr() instanceof TernaryExpr);
+      final TernaryExpr ternaryExpr = (TernaryExpr) exprStmt.getExpr();
+      assertTrue(ternaryExpr.getTest() instanceof VariableIdentifierExpr);
+      assertTrue(ternaryExpr.getThenExpr() instanceof BinaryExpr);
+      assertEquals(BinOp.COMMA, ((BinaryExpr) ternaryExpr.getThenExpr()).getOp());
+      assertTrue(ternaryExpr.getElseExpr() instanceof VariableIdentifierExpr);
+    }
+
+    {
+      final ExprStmt exprStmt = (ExprStmt) block.getStmt(4);
+      assertTrue(exprStmt.getExpr() instanceof BinaryExpr);
+      final BinaryExpr binaryExpr = (BinaryExpr) exprStmt.getExpr();
+      assertEquals(BinOp.COMMA, binaryExpr.getOp());
+      assertTrue(binaryExpr.getLhs() instanceof TernaryExpr);
+      assertTrue(binaryExpr.getRhs() instanceof VariableIdentifierExpr);
+    }
+
+  }
+
+  @Test
   public void testUnsupportedMultiDimensionalArrays() throws Exception {
 
     // Change this test to check for support if it is eventually introduced.
@@ -798,21 +847,6 @@ public class ParseHelperTest {
     } catch (UnsupportedLanguageFeatureException exception) {
       assertTrue(exception.getMessage().contains("Named interface blocks are not currently "
           + "supported"));
-    }
-  }
-
-  @Test
-  public void testUnsupportedCommaInTernary() throws Exception {
-    try {
-      ParseHelper.parse("#version 310 es\n"
-          + "\n"
-          + "void main() {\n"
-          + "  true ? 2, 3 : 4;\n"
-          + "}\n");
-      fail("Exception was expected");
-    } catch (UnsupportedLanguageFeatureException exception) {
-      assertTrue(exception.getMessage().contains("The use of a comma in the 'then' expression of a "
-          + "ternary is not currently supported."));
     }
   }
 


### PR DESCRIPTION
This change adds test to check that ternary expressions that use the
comma operator are correctly parsed, and removes a defensive check
that previously disallowed the use of comma in the 'then' expression
of a ternary.  This means that the idiom 'a ? b, c : d' is now
supported.