### PR TITLE
Be more liberal with uniform pruning

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
@@ -44,16 +44,17 @@ public final class PruneUniforms {
   }
 
   /**
-   * Prunes uniforms from the shader job, by inlining their values into the shaders, until there
-   * are no more than a given number of uniforms in the shader job.
+   * Prunes uniforms from the shader job, by turning them into global variables initialized to the
+   * value the uniform would take, until there are no more than a given number of uniforms in the
+   * shader job.
    * @param shaderJob A shader job whose uniforms are to be pruned.
    * @param limit The maximum number of uniforms that should remain.
    * @param prefixesForPriorityPruning A list of prefixes, such that uniforms starting with one of
    *                                   the prefixes should be pruned before other uniforms.
    */
-  public static void prune(ShaderJob shaderJob,
-                           int limit,
-                           List<String> prefixesForPriorityPruning) {
+  public static void pruneIfNeeded(ShaderJob shaderJob,
+                                   int limit,
+                                   List<String> prefixesForPriorityPruning) {
 
     // Work out how many uniforms need to be pruned to meet the limit.
     final int numToPrune = shaderJob.getPipelineInfo().getNumUniforms() - limit;

--- a/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
@@ -43,36 +43,51 @@ public final class PruneUniforms {
     // Utility class
   }
 
-  public static boolean prune(ShaderJob shaderJob,
-                              int limit, List<String> prunablePrefixes) {
+  /**
+   * Prunes uniforms from the shader job, by inlining their values into the shaders, until there
+   * are no more than a given number of uniforms in the shader job.
+   * @param shaderJob A shader job whose uniforms are to be pruned.
+   * @param limit The maximum number of uniforms that should remain.
+   * @param prefixesForPriorityPruning A list of prefixes, such that uniforms starting with one of
+   *                                   the prefixes should be pruned before other uniforms.
+   */
+  public static void prune(ShaderJob shaderJob,
+                           int limit,
+                           List<String> prefixesForPriorityPruning) {
+
+    // Work out how many uniforms need to be pruned to meet the limit.
     final int numToPrune = shaderJob.getPipelineInfo().getNumUniforms() - limit;
-    if (numToPrune < 0) {
-      return true;
-    }
-    final List<String> candidatesForPruning = new ArrayList<>();
-    candidatesForPruning.addAll(shaderJob
-        .getPipelineInfo()
-        .getUniformNames()
-        .stream()
-        .filter(item -> isPrunable(prunablePrefixes, item))
-        .collect(Collectors.toList()));
-
-    // Sort in order to ensure determinism.
-    candidatesForPruning.sort(String::compareTo);
-
-    if (candidatesForPruning.size() < numToPrune) {
-      // Too few uniforms meet the criteria for pruning.
-      return false;
+    if (numToPrune <= 0) {
+      // No pruning is required.
+      return;
     }
 
-    for (String uniformName : candidatesForPruning.subList(0, numToPrune)) {
+    // Using the given prefixes, determine those uniforms we would prefer to prune and those
+    // uniforms we will only prune if necessary.
+    final List<String> pruneFirst = new ArrayList<>();
+    final List<String> pruneIfNecessary = new ArrayList<>();
+    for (String uniformName : shaderJob.getPipelineInfo().getUniformNames()) {
+      if (isPrunable(prefixesForPriorityPruning, uniformName)) {
+        pruneFirst.add(uniformName);
+      } else {
+        pruneIfNecessary.add(uniformName);
+      }
+    }
+
+    // Order the uniforms so that the ones we prefer to prune come first.
+    final List<String> orderedForPruning = new ArrayList<>();
+    orderedForPruning.addAll(pruneFirst);
+    orderedForPruning.addAll(pruneIfNecessary);
+
+    // Prune as many uniforms as needed.
+    for (int i = 0; i < numToPrune; i++) {
+      final String uniformName = orderedForPruning.get(i);
       for (TranslationUnit tu : shaderJob.getShaders()) {
         inlineUniform(tu, shaderJob.getPipelineInfo(), uniformName);
       }
       shaderJob.getPipelineInfo().removeUniform(uniformName);
     }
 
-    return true;
   }
 
   private static void inlineUniform(TranslationUnit tu, PipelineInfo pipelineInfo,

--- a/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
@@ -190,10 +190,10 @@ public class PruneUniformsTest {
     final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(), new PipelineInfo(uniforms),
         ParseHelper.parse(program));
 
-    assertTrue(PruneUniforms.prune(
+    PruneUniforms.prune(
         shaderJob,
         limit,
-        prefixList));
+        prefixList);
 
     final File shaderJobFile = temporaryFolder.newFile("shader.json");
 

--- a/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/PruneUniformsTest.java
@@ -190,7 +190,7 @@ public class PruneUniformsTest {
     final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(), new PipelineInfo(uniforms),
         ParseHelper.parse(program));
 
-    PruneUniforms.prune(
+    PruneUniforms.pruneIfNeeded(
         shaderJob,
         limit,
         prefixList);

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
@@ -184,7 +184,7 @@ public class Generate {
 
     if (args.limitUniforms()) {
       // Prune uniforms from the shader job, preferring to prune donated uniforms.
-      PruneUniforms.prune(shaderJob, args.getMaxUniforms(),
+      PruneUniforms.pruneIfNeeded(shaderJob, args.getMaxUniforms(),
           Arrays.asList(Constants.DEAD_PREFIX, Constants.LIVE_PREFIX));
     }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
@@ -183,11 +183,9 @@ public class Generate {
     }
 
     if (args.limitUniforms()) {
-      if (!(PruneUniforms.prune(shaderJob, args.getMaxUniforms(),
-          Arrays.asList(Constants.DEAD_PREFIX, Constants.LIVE_PREFIX)))) {
-        throw new RuntimeException("It was not possible to prune sufficient uniforms from a "
-            + "shader.");
-      }
+      // Prune uniforms from the shader job, preferring to prune donated uniforms.
+      PruneUniforms.prune(shaderJob, args.getMaxUniforms(),
+          Arrays.asList(Constants.DEAD_PREFIX, Constants.LIVE_PREFIX));
     }
 
     if (args.getGenerateUniformBindings()) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/KnownValueShaderGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/KnownValueShaderGenerator.java
@@ -171,7 +171,8 @@ public class KnownValueShaderGenerator {
     final ShaderJob shaderJob = new GlslShaderJob(Optional.empty(), pipelineInfo, tu);
 
     if (maxUniforms > 0) {
-      PruneUniforms.prune(shaderJob, maxUniforms, Arrays.asList(Constants.GLF_UNIFORM));
+      PruneUniforms.pruneIfNeeded(shaderJob, maxUniforms,
+          Collections.singletonList(Constants.GLF_UNIFORM));
     }
     if (generateUniformBindings) {
       shaderJob.makeUniformBindings();

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
@@ -138,9 +138,10 @@ public final class PrepareReference {
     }
 
     if (maxUniforms > 0) {
-      // The reference shader job has more uniforms than the specified limit, so prune some of them
-      // by inlining their values into the shaders.
-      PruneUniforms.prune(shaderJob, maxUniforms, Collections.emptyList());
+      // If the reference shader job has more uniforms than the specified limit, some of them must
+      // be pruned, being replaced with global variables initialized to the value that the uniform
+      // would take.
+      PruneUniforms.pruneIfNeeded(shaderJob, maxUniforms, Collections.emptyList());
     }
 
     if (generateUniformBindings) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/PrepareReference.java
@@ -22,10 +22,12 @@ import com.graphicsfuzz.common.util.AddBraces;
 import com.graphicsfuzz.common.util.GlslParserException;
 import com.graphicsfuzz.common.util.ParseTimeoutException;
 import com.graphicsfuzz.common.util.PipelineInfo;
+import com.graphicsfuzz.common.util.PruneUniforms;
 import com.graphicsfuzz.common.util.ShaderJobFileOperations;
 import com.graphicsfuzz.generator.util.FloatLiteralReplacer;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
@@ -135,8 +137,10 @@ public final class PrepareReference {
           shaderJob.getPipelineInfo());
     }
 
-    if (maxUniforms > 0 && shaderJob.getPipelineInfo().getNumUniforms() > maxUniforms) {
-      throw new RuntimeException("Too many uniforms in reference shader job.");
+    if (maxUniforms > 0) {
+      // The reference shader job has more uniforms than the specified limit, so prune some of them
+      // by inlining their values into the shaders.
+      PruneUniforms.prune(shaderJob, maxUniforms, Collections.emptyList());
     }
 
     if (generateUniformBindings) {


### PR DESCRIPTION
Instead of throwing an exception if a reference shader has too many
uniforms, or if it is not possible to bring the number of uniforms in
a variant shader down to size by pruning injected uniforms, this
change makes uniform pruning more liberal so that shaders are always
pruned down to size by pruning original uniforms if needed.