### PR TITLE
Add line "precision highp int" to stable shaders

### DIFF
--- a/shaders/src/main/glsl/samples/310es/stable_bifurcation.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_bifurcation.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;

--- a/shaders/src/main/glsl/samples/310es/stable_binarysearch_tree.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_binarysearch_tree.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 

--- a/shaders/src/main/glsl/samples/310es/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_bubblesort_flag.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 

--- a/shaders/src/main/glsl/samples/310es/stable_collatz.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_collatz.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;

--- a/shaders/src/main/glsl/samples/310es/stable_colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_colorgrid_modulo.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 

--- a/shaders/src/main/glsl/samples/310es/stable_maze.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_maze.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;

--- a/shaders/src/main/glsl/samples/310es/stable_mergesort.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_mergesort.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 

--- a/shaders/src/main/glsl/samples/310es/stable_orbit.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_orbit.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;

--- a/shaders/src/main/glsl/samples/310es/stable_pillars.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_pillars.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;

--- a/shaders/src/main/glsl/samples/310es/stable_quicksort.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_quicksort.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 

--- a/shaders/src/main/glsl/samples/310es/stable_rects.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_rects.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;

--- a/shaders/src/main/glsl/samples/310es/stable_triangle.frag
+++ b/shaders/src/main/glsl/samples/310es/stable_triangle.frag
@@ -17,6 +17,7 @@
  */
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _GLF_color;
 uniform vec2 resolution;


### PR DESCRIPTION
Added line `precision highp int` to all shaders in `graphicsfuzz/shaders/src/main/glsl/samples/310es` that have a `stable_` prefix in the name. This way all drivers must use the same level of precision.