### PR TITLE
gfauto: fix logcat clearing

### DIFF
--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -240,3 +240,4 @@ pathsep
 cts
 writelines
 colorgrid
+logd


### PR DESCRIPTION
`adb logcat -c` does not always seem to clear the log of an Android device. This can cause old log events to be interpreted as recent errors, causing reduction steps to incorrectly fail. Thus, we now attempt to clear the log (as before) and then make a note of the last visible timestamp. This timestamp is then used to ignore old log events when we next capture the log.