### PR TITLE
gfauto: allow longer CTS test names

### DIFF
--- a/gfauto/gfauto/add_amber_tests_to_cts.py
+++ b/gfauto/gfauto/add_amber_tests_to_cts.py
@@ -150,11 +150,11 @@ def get_index_line_to_write(amber_test_name: str, short_description: str) -> str
     # 1
     test_file_name_start_index = 5
     # 2
-    test_name_start_index = 53
+    test_name_start_index = 97
     # 3
-    test_description_start_index = 93
+    test_description_start_index = 181
     # 4
-    test_close_bracket_index = 181
+    test_close_bracket_index = 265
 
     tab_size = 4
 


### PR DESCRIPTION
In add_amber_tests_to_cts.py, update the indices in a test description line so we can have longer test names.