### PR TITLE
Allow removal of live-injected array assignments

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -19,6 +19,7 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 import com.graphicsfuzz.common.ast.TranslationUnit;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
@@ -333,8 +334,12 @@ public class StmtReductionOpportunities
   }
 
   private static boolean isLiveInjectionVariableReference(Expr lhs) {
-    while (lhs instanceof MemberLookupExpr) {
-      lhs = ((MemberLookupExpr) lhs).getStructure();
+    while (lhs instanceof MemberLookupExpr || lhs instanceof ArrayIndexExpr) {
+      if (lhs instanceof MemberLookupExpr) {
+        lhs = ((MemberLookupExpr) lhs).getStructure();
+      } else {
+        lhs = ((ArrayIndexExpr) lhs).getArray();
+      }
     }
     if (!(lhs instanceof VariableIdentifierExpr)) {
       return false;

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
@@ -1108,4 +1108,21 @@ public class ReductionOpportunitiesTest {
     ops.forEach(IReductionOpportunity::applyReduction);
   }
 
+  @Test
+  public void testCanRemoveLiveInjectedVariables() throws Exception {
+    final String shader = "#version 310 es\n"
+        + "void main() {\n"
+        + " vec4 GLF_live6c = vec4(1.0);\n"
+        + " GLF_live6c[0] = 1.0;\n"
+        + "}\n";
+
+    final TranslationUnit tu = ParseHelper.parse(shader);
+
+    List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
+        MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
+            ShadingLanguageVersion.ESSL_310,
+            new RandomWrapper(0), new IdGenerator()), fileOps);
+    assertFalse(ops.isEmpty());
+  }
+
 }


### PR DESCRIPTION
This change teaches the reducer how to remove a statement of the form:

  live_injected_variable[...] = ...