### PR TITLE
Smarter removal of loops with limiters

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/util/TruncateLoops.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/util/TruncateLoops.java
@@ -39,6 +39,7 @@ import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.stmt.WhileStmt;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.ast.visitors.StandardVisitor;
+import com.graphicsfuzz.util.Constants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -78,7 +79,7 @@ public class TruncateLoops extends StandardVisitor {
 
   private void handleLoop(LoopStmt loopStmt) {
     final IParentMap parentMap = IParentMap.createParentMap(tu);
-    final String limiterName = prefix + "_looplimiter" + counter;
+    final String limiterName = prefix + "_" + Constants.LOOP_LIMITER + counter;
     counter++;
 
     final DeclarationStmt limiterDeclaration = new DeclarationStmt(

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunities.java
@@ -127,9 +127,9 @@ public class FlattenControlFlowReductionOpportunities
         shaderKind);
   }
 
-  private static boolean isLoopLimiterCheck(Stmt compoundStmt) {
+  private boolean isLoopLimiterCheck(Stmt compoundStmt) {
     return compoundStmt instanceof IfStmt
-          && StmtReductionOpportunities.referencesLoopLimiter(compoundStmt);
+          && StmtReductionOpportunities.referencesLoopLimiter(compoundStmt, getCurrentScope());
   }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -439,7 +439,7 @@ public class StmtReductionOpportunities
       // outside any loop).
       for (int i = loopStack.size() - 1; i >= 0; i--) {
         if (loopStack.get(i).getRight().contains(variablesDeclaration)) {
-          // This is where the loop limiter is declared; shallow loops are not affected by this
+          // This is where the loop limiter is declared; shallower loops are not affected by this
           // loop limiter.
           break;
         }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -17,8 +17,8 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
-import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
+import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -17,18 +17,18 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
 import com.graphicsfuzz.common.ast.expr.FunctionCallExpr;
-import com.graphicsfuzz.common.ast.expr.IntConstantExpr;
 import com.graphicsfuzz.common.ast.expr.MemberLookupExpr;
 import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
-import com.graphicsfuzz.common.ast.stmt.ExprCaseLabel;
+import com.graphicsfuzz.common.ast.stmt.DoStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
 import com.graphicsfuzz.common.ast.stmt.IfStmt;
@@ -36,25 +36,81 @@ import com.graphicsfuzz.common.ast.stmt.LoopStmt;
 import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
+import com.graphicsfuzz.common.ast.stmt.WhileStmt;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.MacroNames;
 import com.graphicsfuzz.common.util.SideEffectChecker;
 import com.graphicsfuzz.common.util.StructUtils;
 import com.graphicsfuzz.util.Constants;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class StmtReductionOpportunities
       extends ReductionOpportunitiesBase<StmtReductionOpportunity> {
 
+  // The translation unit in which statement reduction opportunities are being sought.
   private final TranslationUnit tu;
+
+  // Loops arising from live-injected code maybe equipped with *limiters*, which bound the number
+  // of times they can iterate.  This field records those loops whose removal from the shader will
+  // not impact the limiting of remaining loops.
+  //
+  // For example, consider the following:
+  //
+  //     GLF_live_loop_limiter1 = 0;
+  // (1) while(true) {
+  //       if (GLF_live_loop_limiter1 >= 4) {
+  // (2)     for (int i = 0; i < 10; i++) {
+  //           // nop
+  //         }
+  //         break;
+  //       }
+  // (3)   for(i = 0; i < 1; i++) {
+  //         live_loop_limiter1++;
+  //       }
+  //       GLF_live_loop_limiter2 = 0;
+  // (4)   while(true) {
+  //         if (GLF_live_loop_limiter2 >= 3) {
+  //           break;
+  //         }
+  //         GLF_live_loop_limiter2++;
+  //       }
+  //     }
+  //
+  // Loop (1) can be removed without impacting the limiting of remaining loops: the only loop
+  // limiter to which it refers that is declared outside (1) is 'live_loop_limiter1', and (1) is
+  // outer-most loop in which 'live_loop_limiter1' is visible.
+  //
+  // Loop (2) can be removed without impacting the limiting of remaining loops because it does
+  // not reference any loop limiter variables.
+  //
+  // Loop (3) *cannot* be removed without impacting the limiting of remaining loops because it
+  // references 'live_loop_limiter1', yet is not one of the outer-most loops in which
+  // 'live_loop_limiter1' is visible (loop (1) is).
+  //
+  // Loop (4) can be removed without impacting the limiting of remaining loops: the only loop
+  // limiter to which it refers that is declared outside (4) is 'live_loop_limiter2', and (4) is
+  // the outer-most loop in which 'live_loop_limiter1' is visible.
+  //
+  // The presence of a loop in this set does not necessarily mean that the loop can be removed;
+  // other conditions may need to be met for that to be the case.  It just means that if the loop
+  // were to be removed, the limiting of remaining loops would not be affected.
+  private final Set<LoopStmt> loopsThatCanBeRemovedWithoutImpactingLoopLimiting;
 
   private StmtReductionOpportunities(TranslationUnit tu,
         ReducerContext context) {
     super(tu, context);
     this.tu = tu;
+    this.loopsThatCanBeRemovedWithoutImpactingLoopLimiting = new HashSet<>();
+    new LoopLimiterImpactChecker(tu).visit(tu);
+
   }
 
   static List<StmtReductionOpportunity> findOpportunities(ShaderJob shaderJob,
@@ -119,10 +175,6 @@ public class StmtReductionOpportunities
       return true;
     }
 
-    if (isLoopLimiterBlock(stmt)) {
-      return true;
-    }
-
     // Unless we are in an injected dead code block, we need to be careful about removing
     // non-void return statements, so as to avoid making the shader invalid.
     if (StmtReductionOpportunity
@@ -131,40 +183,37 @@ public class StmtReductionOpportunities
       return false;
     }
 
-    return context.reduceEverywhere()
-          || (isLiveCodeInjection(stmt) && !referencesLoopLimiter(stmt));
+    // If we're not preserving semantics, it's fine to remove this statement.
+    if (context.reduceEverywhere()) {
+      return true;
+    }
+
+    // Otherwise, we can't remove the statement unless we are sure it is live code.
+    if (!isLiveCodeInjection(stmt)) {
+      return false;
+    }
+
+    // Then, for live code, we need to take care about removing statements that manipulate loop
+    // limiters.  If this statement does not reference any loop limiters, that's fine.
+    if (!referencesLoopLimiter(stmt, getCurrentScope())) {
+      return true;
+    }
+
+    // We have a live code statement that does reference a loop limiter.  We can remove it if it
+    // is a loop such that we know removing this loop will not impact on the limiting of other
+    // loops.
+    return stmt instanceof LoopStmt
+        && loopsThatCanBeRemovedWithoutImpactingLoopLimiting.contains(stmt);
 
   }
 
-  private boolean isLoopLimiterBlock(Stmt stmt) {
-    // Identifies when a block starts with a loop-limiter declaration, in which case the whole
-    // block can go.  We are really careful about otherwise removing loop-limiters, so this is
-    // the chance to do it!
-    if (!(stmt instanceof BlockStmt)) {
-      return false;
-    }
-    final BlockStmt blockStmt = (BlockStmt) stmt;
-    if (blockStmt.getNumStmts() == 0) {
-      return false;
-    }
-    final Stmt firstStmt = blockStmt.getStmt(0);
-    if (!(firstStmt instanceof DeclarationStmt)) {
-      return false;
-    }
-    final DeclarationStmt declarationStmt = (DeclarationStmt) firstStmt;
-    if (declarationStmt.getVariablesDeclaration().getNumDecls() == 0) {
-      return false;
-    }
-    return isLooplimiter(declarationStmt.getVariablesDeclaration().getDeclInfo(0).getName());
-  }
-
-  static boolean referencesLoopLimiter(Stmt stmt) {
+  static boolean referencesLoopLimiter(Stmt stmt, Scope scope) {
     return new CheckPredicateVisitor() {
       @Override
       public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
         super.visitVariableIdentifierExpr(variableIdentifierExpr);
         final String name = variableIdentifierExpr.getName();
-        if (isLooplimiter(name)) {
+        if (isLooplimiter(name) && scope.lookupScopeEntry(name) != null) {
           predicateHolds();
         }
       }
@@ -319,7 +368,7 @@ public class StmtReductionOpportunities
 
   static boolean isLooplimiter(String name) {
     return isLiveInjectedVariableName(name)
-          && name.contains("looplimiter");
+          && name.contains(Constants.LOOP_LIMITER);
   }
 
   private boolean isEmptyAndUnreferencedDeclaration(DeclarationStmt stmt) {
@@ -329,6 +378,111 @@ public class StmtReductionOpportunities
 
     return !StructUtils.declaresReferencedStruct(tu,
         stmt.getVariablesDeclaration());
+  }
+
+  private class LoopLimiterImpactChecker extends InjectionTrackingVisitor {
+
+    // A stack that keeps track of the nest of loops currently being visited and, for each loop,
+    // the loop limiters declared in the body of that loop but not in a deeper loop.
+    private final List<ImmutablePair<LoopStmt, Set<VariablesDeclaration>>> loopStack =
+        new ArrayList<>();
+
+    private LoopLimiterImpactChecker(TranslationUnit tu) {
+      super(tu);
+    }
+
+    @Override
+    public void visitVariablesDeclaration(VariablesDeclaration variablesDeclaration) {
+      super.visitVariablesDeclaration(variablesDeclaration);
+      // We only keep track of loop limiters declared in some loop.
+      if (loopStack.isEmpty()) {
+        return;
+      }
+      // Is this a loop limiter?  By construction a loop limiter is declared on its own and has a
+      // special name.
+      if (variablesDeclaration.getNumDecls() == 1
+          && isLooplimiter(variablesDeclaration.getDeclInfo(0).getName())) {
+        // It is a loop limiter, so add the declaration to the set of declarations at the top of
+        // the stack.
+        loopStack.get(loopStack.size() - 1).getRight().add(variablesDeclaration);
+      }
+    }
+
+    @Override
+    public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
+      super.visitVariableIdentifierExpr(variableIdentifierExpr);
+
+      // We are only interested in references to loop limiters.
+      if (!isLooplimiter(variableIdentifierExpr.getName())) {
+        return;
+      }
+
+      // We are only interested in loop limiter references that occur in non-trivial loop nests.
+      if (loopStack.size() < 2) {
+        return;
+      }
+
+      // We are not interested in loop limiter references that occur under a fuzzed macro,
+      // because such uses are guaranteed not to affect loop limiting.
+      if (injectionTracker.underFuzzedMacro()) {
+        return;
+      }
+
+      // Get the variables declaration associated with the loop limiter reference, which by
+      // construction must be in scope.
+      final VariablesDeclaration variablesDeclaration =
+          getCurrentScope().lookupScopeEntry(variableIdentifierExpr.getName())
+              .getVariablesDeclaration();
+
+      // Walk the loop stack backwards until we find the loop in which this limiter was declared
+      // (or until we reach the bottom of the stack, in the case that the limiter is declared
+      // outside any loop).
+      for (int i = loopStack.size() - 1; i >= 0; i--) {
+        if (loopStack.get(i).getRight().contains(variablesDeclaration)) {
+          // This is where the loop limiter is declared; shallow loops are not affected by this
+          // loop limiter.
+          break;
+        }
+        if (i < loopStack.size() - 1) {
+          // We have not yet found the loop limiter declaration, so removal of a deeper loop
+          // might affect the limiting of remaining loops.
+          loopsThatCanBeRemovedWithoutImpactingLoopLimiting.remove(
+              loopStack.get(i + 1).getLeft());
+        }
+      }
+    }
+
+    @Override
+    public void visitDoStmt(DoStmt doStmt) {
+      beforeLoop(doStmt);
+      super.visitDoStmt(doStmt);
+      afterLoop();
+    }
+
+    @Override
+    public void visitForStmt(ForStmt forStmt) {
+      beforeLoop(forStmt);
+      super.visitForStmt(forStmt);
+      afterLoop();
+    }
+
+    @Override
+    public void visitWhileStmt(WhileStmt whileStmt) {
+      beforeLoop(whileStmt);
+      super.visitWhileStmt(whileStmt);
+      afterLoop();
+    }
+
+    private void beforeLoop(LoopStmt loopStmt) {
+      loopsThatCanBeRemovedWithoutImpactingLoopLimiting.add(loopStmt);
+      loopStack.add(new ImmutablePair<>(loopStmt,
+          new HashSet<>()));
+    }
+
+    private void afterLoop() {
+      loopStack.remove(loopStack.size() - 1);
+    }
+
   }
 
 }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
@@ -559,53 +559,6 @@ public class ReductionOpportunitiesTest {
   }
 
   @Test
-  public void testLeaveLoopLimiter() throws Exception {
-    TranslationUnit tu = ParseHelper.parse(""
-          + "void main() {"
-          + "    int GLF_live3_looplimiter0 = 0;\n"
-          + "    for(\n"
-          + "      float GLF_live3sphereNo = 0.0;\n"
-          + "      GLF_live3sphereNo < 10.0;\n"
-          + "      GLF_live3sphereNo ++\n"
-          + "  )\n"
-          + "   {\n"
-          + "    if(GLF_live3_looplimiter0 >= 5)\n"
-          + "     {\n"
-          + "      break;\n"
-          + "     }\n"
-          + "    GLF_live3_looplimiter0 ++;\n"
-          + "  }"
-          + "}\n");
-    while (true) {
-      List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440, new RandomWrapper(0), new IdGenerator()), fileOps);
-      if (ops.isEmpty()) {
-        break;
-      }
-      ops.get(0).applyReduction();
-    }
-
-    final String expected = "void main() {"
-          + "    int GLF_live3_looplimiter0 = 0;\n"
-          + "    for(\n"
-          + "      float GLF_live3sphereNo = 1.0;\n"
-          + "      1.0 < 10.0;\n"
-          + "      GLF_live3sphereNo ++\n"
-          + "  )\n"
-          + "   {\n"
-          + "    if(GLF_live3_looplimiter0 >= 5)\n"
-          + "     {\n"
-          + "      break;\n"
-          + "     }\n"
-          + "    GLF_live3_looplimiter0 ++;\n"
-          + "  }"
-          + "}\n";
-    CompareAsts.assertEqualAsts(expected, tu);
-
-  }
-
-  @Test
   public void testTernary() throws Exception {
     final String program = "void main() {"
           + "  int a = 2, b = 3, c = 4;"
@@ -629,7 +582,7 @@ public class ReductionOpportunitiesTest {
 
   @Test
   public void testRemoveLoopLimiter() throws Exception {
-    final String program = "void main() {"
+    final String program = "void main() {\n"
           + " {\n"
           + "  int GLF_live10_looplimiter0 = 0;\n"
           + "  for(\n"
@@ -644,10 +597,13 @@ public class ReductionOpportunitiesTest {
           + "     }\n"
           + "    GLF_live10_looplimiter0 ++;\n"
           + "   }\n"
-          + " }"
-          + "}";
-    final String expected = "void main() {"
-          + "}";
+          + " }\n"
+          + "}\n";
+    final String expected = "void main() {\n"
+          + " {\n"
+          + "  int GLF_live10_looplimiter0 = 0;\n"
+          + " }\n"
+          + "}\n";
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
           MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
@@ -656,6 +612,41 @@ public class ReductionOpportunitiesTest {
     ops.get(0).applyReduction();
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)),
           PrettyPrinterVisitor.prettyPrintAsString(tu));
+  }
+
+  @Test
+  public void testRemoveLoopLimiter2() throws Exception {
+    TranslationUnit tu = ParseHelper.parse(""
+        + "void main() {\n"
+        + "  int GLF_live3_looplimiter0 = 0;\n"
+        + "  for(\n"
+        + "      float GLF_live3sphereNo = 0.0;\n"
+        + "      GLF_live3sphereNo < 10.0;\n"
+        + "      GLF_live3sphereNo ++\n"
+        + "  )\n"
+        + "   {\n"
+        + "    if(GLF_live3_looplimiter0 >= 5)\n"
+        + "     {\n"
+        + "      break;\n"
+        + "     }\n"
+        + "    GLF_live3_looplimiter0 ++;\n"
+        + "  }\n"
+        + "}\n");
+    while (true) {
+      List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+          new ReducerContext(false,
+              ShadingLanguageVersion.GLSL_440, new RandomWrapper(0), new IdGenerator()), fileOps);
+      if (ops.isEmpty()) {
+        break;
+      }
+      ops.get(0).applyReduction();
+    }
+
+    final String expected = ""
+        + "void main() {\n"
+        + "}\n";
+    CompareAsts.assertEqualAsts(expected, tu);
+
   }
 
   @Test

--- a/util/src/main/java/com/graphicsfuzz/util/Constants.java
+++ b/util/src/main/java/com/graphicsfuzz/util/Constants.java
@@ -106,5 +106,7 @@ public final class Constants {
   // constant provides a size for said array.
   public static final int DUMMY_SIZE_FOR_UNSIZED_ARRAY_DONATION = 10;
 
+  // String used inside live-injected variable to indicate that it is a loop limiter.
+  public static final String LOOP_LIMITER = "looplimiter";
 
 }


### PR DESCRIPTION
The statement removal reduction pass is enhanced with an analysis that
figures out those loops whose removal will not affect the limiting
(via loop limiters) of other loops.  This is used when looking for
statements to remove: a live-injected loop whose removal is known not
to impact the limiting of other loops can be removed.