### PR TITLE
gfauto: add fuzz --update_ignored_crash_signatures

### DIFF
--- a/gfauto/gfauto/download_cts_gf_tests.py
+++ b/gfauto/gfauto/download_cts_gf_tests.py
@@ -35,7 +35,7 @@ from gfauto import (
 
 
 def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
-    git_tool: Path, cookie: str, output_shaders_dir: Path,
+    git_tool: Path, cookie: str, output_tests_dir: Path,
 ) -> Path:
     work_dir = Path() / "temp" / ("cts_" + fuzz.get_random_name())
 
@@ -107,27 +107,26 @@ def download_cts_graphicsfuzz_tests(  # pylint: disable=too-many-locals;
         / "vulkan"
         / "amber"
         / "graphicsfuzz",
-        output_shaders_dir,
+        output_tests_dir,
     )
 
 
-GERRIT_COOKIE_ARGUMENT_DESCRIPTION = (
-    "The Gerrit cookie used for authentication. Requires Khronos membership. "
-    "To get this, log in to the Khronos Gerrit page in your "
+GERRIT_COOKIE_INSTRUCTIONS = (
+    "Log in to the Khronos Gerrit page in your "
     "browser and paste the following into the JavaScript console (F12) to copy the cookie to your clipboard: "
-    "copy(document.cookie.match(/GerritAccount=([^;]*)/)[1])"
+    "copy( document.cookie.match( /GerritAccount=([^;]*)/ )[1])"
 )
 
 
-def extract_shaders(shader_dir: Path, binaries: binaries_util.BinaryManager) -> None:
-    for amber_file in shader_dir.glob("*.amber"):
+def extract_shaders(tests_dir: Path, binaries: binaries_util.BinaryManager) -> None:
+    for amber_file in tests_dir.glob("*.amber"):
         amber_converter.extract_shaders(
             amber_file, output_dir=amber_file.parent, binaries=binaries
         )
 
         zip_files = [
             util.ZipEntry(f, Path(f.name))
-            for f in sorted(shader_dir.glob(f"{amber_file.stem}.*"))
+            for f in sorted(tests_dir.glob(f"{amber_file.stem}.*"))
         ]
 
         util.create_zip(amber_file.with_suffix(".zip"), zip_files)
@@ -140,7 +139,11 @@ def main() -> None:
         "Requires Git. Requires Khronos membership."
     )
 
-    parser.add_argument("gerrit_cookie", help=GERRIT_COOKIE_ARGUMENT_DESCRIPTION)
+    parser.add_argument(
+        "gerrit_cookie",
+        help="The Gerrit cookie used for authentication. Requires Khronos membership. Obtain this as follows. "
+        + GERRIT_COOKIE_INSTRUCTIONS,
+    )
 
     parser.add_argument(
         "--settings",
@@ -160,9 +163,9 @@ def main() -> None:
 
     binaries = binaries_util.get_default_binary_manager(settings=settings)
 
-    shaders_dir = Path() / "graphicsfuzz"
-    download_cts_graphicsfuzz_tests(git_tool, cookie, shaders_dir)
-    extract_shaders(shaders_dir, binaries)
+    tests_dir = Path() / "graphicsfuzz"
+    download_cts_graphicsfuzz_tests(git_tool, cookie, tests_dir)
+    extract_shaders(tests_dir, binaries)
 
 
 if __name__ == "__main__":

--- a/gfauto/gfauto/run_cts_gf_tests.py
+++ b/gfauto/gfauto/run_cts_gf_tests.py
@@ -20,7 +20,7 @@ import argparse
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional, Set
+from typing import List, Optional, Set, TextIO
 
 from gfauto import (
     android_device,
@@ -38,6 +38,7 @@ from gfauto import (
 )
 from gfauto.device_pb2 import Device
 from gfauto.gflogging import log
+from gfauto.settings_pb2 import Settings
 
 DEFAULT_TIMEOUT = 30
 SPIRV_OPT_O = "spirv-opt -O"
@@ -65,7 +66,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     )
 
     parser.add_argument(
-        "--update_ignored_signatures",
+        "--update_ignored_crash_signatures",
         help="As the tests are run for each device, add any crash signatures to the device's ignored_crash_signatures "
         "property and write out the updated settings.json file.",
         action="store_true",
@@ -82,7 +83,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     # Args.
     tests_dir: Path = Path(parsed_args.tests)
     settings_path: Path = Path(parsed_args.settings)
-    update_ignored_signatures: bool = parsed_args.update_ignored_signatures
+    update_ignored_crash_signatures: bool = parsed_args.update_ignored_crash_signatures
     results_out_path: Path = Path(parsed_args.results_out)
 
     # Settings and devices.
@@ -92,224 +93,243 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     # Binaries.
     binaries = binaries_util.get_default_binary_manager(settings=settings)
 
-    work_dir = Path() / "temp" / f"cts_run_{fuzz.get_random_name()[:8]}"
+    work_dir = Path() / "temp" / f"graphicsfuzz_cts_run_{fuzz.get_random_name()[:8]}"
+    with util.file_open_text(results_out_path, "w") as results_out_handle:
+        main_helper(
+            tests_dir=tests_dir,
+            work_dir=work_dir,
+            binaries=binaries,
+            settings=settings,
+            active_devices=active_devices,
+            results_out_handle=results_out_handle,
+            updated_settings_output_path=(
+                settings_path if update_ignored_crash_signatures else None
+            ),
+        )
+
+
+def main_helper(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements;
+    tests_dir: Path,
+    work_dir: Path,
+    binaries: binaries_util.BinaryManager,
+    settings: Settings,
+    active_devices: List[Device],
+    results_out_handle: Optional[TextIO],
+    updated_settings_output_path: Optional[Path],
+) -> None:
 
     util.mkdirs_p(work_dir)
 
-    with util.file_open_text(results_out_path, "w") as results_handle:
+    def write_entry(entry: str) -> None:
+        if not results_out_handle:
+            return
+        results_out_handle.write(entry)
+        results_out_handle.write(", ")
+        results_out_handle.flush()
 
-        def write_entry(entry: str) -> None:
-            results_handle.write(entry)
-            results_handle.write(", ")
-            results_handle.flush()
+    def write_newline() -> None:
+        if not results_out_handle:
+            return
+        results_out_handle.write("\n")
+        results_out_handle.flush()
 
-        def write_newline() -> None:
-            results_handle.write("\n")
-            results_handle.flush()
+    spirv_opt_path: Optional[Path] = None
+    swift_shader_path: Optional[Path] = None
+    amber_path: Optional[Path] = None
 
-        spirv_opt_path: Optional[Path] = None
-        swift_shader_path: Optional[Path] = None
-        amber_path: Optional[Path] = None
+    # Small hack to ensure we have three devices for spirv-opt, each with a different name.
+    main_spirv_opt_device: Optional[Device] = None
 
-        # Small hack to ensure we have three devices for spirv-opt, each with a different name.
-        main_spirv_opt_device: Optional[Device] = None
+    if active_devices and active_devices[0].name == "host_preprocessor":
+        main_spirv_opt_device = active_devices[0]
+        main_spirv_opt_device.name = SPIRV_OPT_O
 
-        if active_devices and active_devices[0].name == "host_preprocessor":
-            main_spirv_opt_device = active_devices[0]
-            main_spirv_opt_device.name = SPIRV_OPT_O
+        spirv_opt_custom = Device()
+        spirv_opt_custom.CopyFrom(main_spirv_opt_device)
+        spirv_opt_custom.name = SPIRV_OPT_CUSTOM
+        active_devices.insert(1, spirv_opt_custom)
 
-            spirv_opt_custom = Device()
-            spirv_opt_custom.CopyFrom(main_spirv_opt_device)
-            spirv_opt_custom.name = SPIRV_OPT_CUSTOM
-            active_devices.insert(1, spirv_opt_custom)
+        spirv_opt_os = Device()
+        spirv_opt_os.CopyFrom(main_spirv_opt_device)
+        spirv_opt_os.name = SPIRV_OPT_OS
+        active_devices.insert(1, spirv_opt_os)
 
-            spirv_opt_os = Device()
-            spirv_opt_os.CopyFrom(main_spirv_opt_device)
-            spirv_opt_os.name = SPIRV_OPT_OS
-            active_devices.insert(1, spirv_opt_os)
+    # Enumerate active devices, writing their name and storing binary paths if needed.
+    write_entry("test")
+    for device in active_devices:
+        write_entry(device.name)
 
-        # Enumerate active devices, writing their name and storing binary paths if needed.
-        write_entry("test")
+        if device.HasField("preprocess"):
+            spirv_opt_path = binaries.get_binary_path_by_name(
+                binaries_util.SPIRV_OPT_NAME
+            ).path
+
+        if device.HasField("swift_shader"):
+            swift_shader_path = binaries.get_binary_path_by_name(
+                binaries_util.SWIFT_SHADER_NAME
+            ).path
+
+        if device.HasField("swift_shader") or device.HasField("host"):
+            amber_path = binaries.get_binary_path_by_name(binaries_util.AMBER_NAME).path
+
+    write_newline()
+
+    # Enumerate tests and devices, writing the results.
+
+    for test in sorted(tests_dir.glob("*.amber")):
+        test_name = util.remove_end(test.name, ".amber")
+        write_entry(test_name)
+        spirv_shaders = sorted(
+            tests_dir.glob(util.remove_end(test.name, "amber") + "*.spv")
+        )
         for device in active_devices:
-            write_entry(device.name)
+            test_run_dir = work_dir / f"{test_name}_{device.name}"
+            util.mkdirs_p(test_run_dir)
+            ignored_signatures_set: Set[str] = set(device.ignored_crash_signatures)
 
-            if device.HasField("preprocess"):
-                spirv_opt_path = binaries.get_binary_path_by_name(
-                    binaries_util.SPIRV_OPT_NAME
-                ).path
+            with util.file_open_text(test_run_dir / "log.txt", "w") as log_stream:
+                try:
+                    gflogging.push_stream_for_logging(log_stream)
+                    if device.HasField("preprocess"):
+                        # This just means spirv-opt for now.
 
-            if device.HasField("swift_shader"):
-                swift_shader_path = binaries.get_binary_path_by_name(
-                    binaries_util.SWIFT_SHADER_NAME
-                ).path
+                        assert spirv_opt_path  # noqa
+                        assert main_spirv_opt_device  # noqa
 
-            if device.HasField("swift_shader") or device.HasField("host"):
-                amber_path = binaries.get_binary_path_by_name(
-                    binaries_util.AMBER_NAME
-                ).path
+                        # Pick spirv-opt arguments based on device name.
+                        if device.name == SPIRV_OPT_O:
+                            spirv_opt_args = ["-O"]
+                        elif device.name == SPIRV_OPT_OS:
+                            spirv_opt_args = ["-Os"]
+                        elif device.name == SPIRV_OPT_CUSTOM:
+                            spirv_opt_args = (
+                                spirv_opt_util.OPT_INTERESTING_SUBSET_OF_PASSES
+                            )
+                        else:
+                            raise AssertionError(
+                                f"Can't tell how to run device {device.name}; "
+                                f"must be named host_preprocessor and be the first active device."
+                            )
+
+                        # Reset device and ignored_crash_signatures.
+                        device = main_spirv_opt_device
+                        ignored_signatures_set = set(device.ignored_crash_signatures)
+
+                        try:
+                            for spirv_shader in spirv_shaders:
+                                spirv_opt_util.run_spirv_opt_on_spirv_shader(
+                                    spirv_shader,
+                                    test_run_dir,
+                                    spirv_opt_args,
+                                    spirv_opt_path,
+                                )
+                            result_util.write_status(
+                                test_run_dir, fuzz.STATUS_SUCCESS,
+                            )
+                        except subprocess.CalledProcessError:
+                            result_util.write_status(
+                                test_run_dir, fuzz.STATUS_TOOL_CRASH,
+                            )
+                        except subprocess.TimeoutExpired:
+                            result_util.write_status(
+                                test_run_dir, fuzz.STATUS_TOOL_TIMEOUT,
+                            )
+                    elif device.HasField("shader_compiler"):
+                        try:
+                            for spirv_shader in spirv_shaders:
+                                shader_compiler_util.run_shader(
+                                    shader_compiler_device=device.shader_compiler,
+                                    shader_path=spirv_shader,
+                                    output_dir=test_run_dir,
+                                    compiler_path=binaries.get_binary_path_by_name(
+                                        device.shader_compiler.binary
+                                    ).path,
+                                    timeout=DEFAULT_TIMEOUT,
+                                )
+                            result_util.write_status(
+                                test_run_dir, fuzz.STATUS_SUCCESS,
+                            )
+                        except subprocess.CalledProcessError:
+                            result_util.write_status(
+                                test_run_dir, fuzz.STATUS_CRASH,
+                            )
+                        except subprocess.TimeoutExpired:
+                            result_util.write_status(
+                                test_run_dir, fuzz.STATUS_TIMEOUT,
+                            )
+                    elif device.HasField("swift_shader"):
+                        assert swift_shader_path  # noqa
+                        assert amber_path  # noqa
+                        host_device_util.run_amber(
+                            test,
+                            test_run_dir,
+                            amber_path=amber_path,
+                            dump_image=False,
+                            dump_buffer=False,
+                            icd=swift_shader_path,
+                        )
+                    elif device.HasField("host"):
+                        assert amber_path  # noqa
+                        host_device_util.run_amber(
+                            test,
+                            test_run_dir,
+                            amber_path=amber_path,
+                            dump_image=False,
+                            dump_buffer=False,
+                            custom_launcher=list(device.host.custom_launcher),
+                        )
+                    elif device.HasField("android"):
+                        android_device.run_amber_on_device(
+                            test,
+                            test_run_dir,
+                            dump_image=False,
+                            dump_buffer=False,
+                            serial=device.android.serial,
+                        )
+                    else:
+                        raise AssertionError(f"Unsupported device {device.name}")
+
+                finally:
+                    gflogging.pop_stream_for_logging()
+
+            status = result_util.get_status(test_run_dir)
+
+            if status == fuzz.STATUS_SUCCESS:
+                write_entry("P")
+            elif status in (fuzz.STATUS_TIMEOUT, fuzz.STATUS_TOOL_TIMEOUT):
+                write_entry("T")
+            else:
+                write_entry("F")
+
+            # Update ignored signatures.
+            if (
+                status
+                in (
+                    fuzz.STATUS_TOOL_CRASH,
+                    fuzz.STATUS_CRASH,
+                    fuzz.STATUS_UNRESPONSIVE,
+                )
+                and updated_settings_output_path
+            ):
+                log_contents = util.file_read_text(
+                    result_util.get_log_path(test_run_dir)
+                )
+                signature = signature_util.get_signature_from_log_contents(log_contents)
+                if signature == signature_util.NO_SIGNATURE:
+                    log(f"NOT updating ignored signatures to include {signature}")
+                elif signature in ignored_signatures_set:
+                    log(f"Signature is already ignored: {signature}")
+                else:
+                    log(f"Adding ignored signature: {signature}")
+                    device.ignored_crash_signatures.append(signature)
 
         write_newline()
 
-        # Enumerate tests and devices, writing the results.
-
-        for test in sorted(tests_dir.glob("*.amber")):
-            test_name = util.remove_end(test.name, ".amber")
-            write_entry(test_name)
-            spirv_shaders = sorted(
-                tests_dir.glob(util.remove_end(test.name, "amber") + "*.spv")
-            )
-            for device in active_devices:
-                test_run_dir = work_dir / f"{test_name}_{device.name}"
-                util.mkdirs_p(test_run_dir)
-                ignored_signatures_set: Set[str] = set(device.ignored_crash_signatures)
-
-                with util.file_open_text(test_run_dir / "log.txt", "w") as log_stream:
-                    try:
-                        gflogging.push_stream_for_logging(log_stream)
-                        if device.HasField("preprocess"):
-                            # This just means spirv-opt for now.
-
-                            assert spirv_opt_path  # noqa
-                            assert main_spirv_opt_device  # noqa
-
-                            # Pick spirv-opt arguments based on device name.
-                            if device.name == SPIRV_OPT_O:
-                                spirv_opt_args = ["-O"]
-                            elif device.name == SPIRV_OPT_OS:
-                                spirv_opt_args = ["-Os"]
-                            elif device.name == SPIRV_OPT_CUSTOM:
-                                spirv_opt_args = (
-                                    spirv_opt_util.OPT_INTERESTING_SUBSET_OF_PASSES
-                                )
-                            else:
-                                raise AssertionError(
-                                    f"Can't tell how to run device {device.name}; "
-                                    f"must be named host_preprocessor and be the first active device."
-                                )
-
-                            # Reset device and ignored_crash_signatures.
-                            device = main_spirv_opt_device
-                            ignored_signatures_set = set(
-                                device.ignored_crash_signatures
-                            )
-
-                            try:
-                                for spirv_shader in spirv_shaders:
-                                    spirv_opt_util.run_spirv_opt_on_spirv_shader(
-                                        spirv_shader,
-                                        test_run_dir,
-                                        spirv_opt_args,
-                                        spirv_opt_path,
-                                    )
-                                result_util.write_status(
-                                    test_run_dir, fuzz.STATUS_SUCCESS,
-                                )
-                            except subprocess.CalledProcessError:
-                                result_util.write_status(
-                                    test_run_dir, fuzz.STATUS_TOOL_CRASH,
-                                )
-                            except subprocess.TimeoutExpired:
-                                result_util.write_status(
-                                    test_run_dir, fuzz.STATUS_TOOL_TIMEOUT,
-                                )
-                        elif device.HasField("shader_compiler"):
-                            try:
-                                for spirv_shader in spirv_shaders:
-                                    shader_compiler_util.run_shader(
-                                        shader_compiler_device=device.shader_compiler,
-                                        shader_path=spirv_shader,
-                                        output_dir=test_run_dir,
-                                        compiler_path=binaries.get_binary_path_by_name(
-                                            device.shader_compiler.binary
-                                        ).path,
-                                        timeout=DEFAULT_TIMEOUT,
-                                    )
-                                result_util.write_status(
-                                    test_run_dir, fuzz.STATUS_SUCCESS,
-                                )
-                            except subprocess.CalledProcessError:
-                                result_util.write_status(
-                                    test_run_dir, fuzz.STATUS_CRASH,
-                                )
-                            except subprocess.TimeoutExpired:
-                                result_util.write_status(
-                                    test_run_dir, fuzz.STATUS_TIMEOUT,
-                                )
-                        elif device.HasField("swift_shader"):
-                            assert swift_shader_path  # noqa
-                            assert amber_path  # noqa
-                            host_device_util.run_amber(
-                                test,
-                                test_run_dir,
-                                amber_path=amber_path,
-                                dump_image=False,
-                                dump_buffer=False,
-                                icd=swift_shader_path,
-                            )
-                        elif device.HasField("host"):
-                            assert amber_path  # noqa
-                            host_device_util.run_amber(
-                                test,
-                                test_run_dir,
-                                amber_path=amber_path,
-                                dump_image=False,
-                                dump_buffer=False,
-                                custom_launcher=list(device.host.custom_launcher),
-                            )
-                        elif device.HasField("android"):
-                            android_device.run_amber_on_device(
-                                test,
-                                test_run_dir,
-                                dump_image=False,
-                                dump_buffer=False,
-                                serial=device.android.serial,
-                            )
-                        else:
-                            raise AssertionError(f"Unsupported device {device.name}")
-
-                    finally:
-                        gflogging.pop_stream_for_logging()
-
-                status = result_util.get_status(test_run_dir)
-
-                if status == fuzz.STATUS_SUCCESS:
-                    write_entry("P")
-                elif status in (fuzz.STATUS_TIMEOUT, fuzz.STATUS_TOOL_TIMEOUT):
-                    write_entry("T")
-                else:
-                    write_entry("F")
-
-                # Update ignored signatures.
-                if (
-                    status
-                    in (
-                        fuzz.STATUS_TOOL_CRASH,
-                        fuzz.STATUS_CRASH,
-                        fuzz.STATUS_UNRESPONSIVE,
-                    )
-                    and update_ignored_signatures
-                ):
-                    log_contents = util.file_read_text(
-                        result_util.get_log_path(test_run_dir)
-                    )
-                    signature = signature_util.get_signature_from_log_contents(
-                        log_contents
-                    )
-                    if signature == signature_util.NO_SIGNATURE:
-                        log(f"NOT updating ignored signatures to include {signature}")
-                    elif signature in ignored_signatures_set:
-                        log(f"Signature is already ignored: {signature}")
-                    else:
-                        log(f"Adding ignored signature: {signature}")
-                        device.ignored_crash_signatures.append(signature)
-
-            write_newline()
-
-        if update_ignored_signatures:
-            # Reset main_spirv_opt_device name before writing it back out.
-            if main_spirv_opt_device:
-                main_spirv_opt_device.name = "host_preprocessor"
-            settings_util.write(settings, settings_path)
+    if updated_settings_output_path:
+        # Reset main_spirv_opt_device name before writing it back out.
+        if main_spirv_opt_device:
+            main_spirv_opt_device.name = "host_preprocessor"
+        settings_util.write(settings, updated_settings_output_path)
 
 
 if __name__ == "__main__":

--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -241,3 +241,4 @@ cts
 writelines
 colorgrid
 logd
+gf


### PR DESCRIPTION
Add --update_ignored_crash_signatures to the gfauto_fuzz command. This downloads and runs GraphicsFuzz AmberScript tests to update known crash signatures for every active device. You could already do this by running download_cts_gf_tests.py and run_cts_gf_tests.py (with an option), but this new option is easier.