### PR TITLE
gfauto_cov: fix gcc 9+ support again

### DIFF
--- a/gfauto/.idea/inspectionProfiles/profiles_settings.xml
+++ b/gfauto/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <settings>
     <option name="PROJECT_PROFILE" value="gfauto_inspections" />
-    <option name="USE_PROJECT_PROFILE" value="false" />
+    <option name="USE_PROJECT_PROFILE" value="true" />
     <version value="1.0" />
   </settings>
 </component>


### PR DESCRIPTION
Each stdout line from gcov is a JSON object; do not try to parse entire output as JSON, as this will fail. Make stderr from gcov visible to user.

Rename variables gcda->gcno.

Fix PyCharm profile setting.