### PR TITLE
Remove vk-default-no-waivers.tx from mustpass paths

### DIFF
--- a/gfauto/gfauto/add_amber_tests_to_cts.py
+++ b/gfauto/gfauto/add_amber_tests_to_cts.py
@@ -33,9 +33,6 @@ SHORT_DESCRIPTION_LINE_PREFIX = "# Short description: "
 MUST_PASS_PATHS = [
     os.path.join("android", "cts", "master", "vk-master.txt"),
     os.path.join("android", "cts", "master", "vk-master-2020-03-01.txt"),
-    os.path.join(
-        "external", "vulkancts", "mustpass", "master", "vk-default-no-waivers.txt"
-    ),
     os.path.join("external", "vulkancts", "mustpass", "master", "vk-default.txt"),
 ]
 


### PR DESCRIPTION
Removed `vk-default-no-waivers.txt` from MUST_PASS_PATHS as the file has been removed from cts and can't be modified anymore.