### PR TITLE
Clean up redundant loop limiter uses in the reducer

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunities.java
@@ -34,10 +34,14 @@ import java.util.List;
 public class FlattenControlFlowReductionOpportunities
       extends ReductionOpportunitiesBase<AbstractReductionOpportunity> {
 
+  // Used to assess whether code that references loop limiters can be flattened.
+  private final LoopLimiterImpactChecker loopLimiterImpactChecker;
+
   private FlattenControlFlowReductionOpportunities(
         TranslationUnit tu,
         ReducerContext context) {
     super(tu, context);
+    this.loopLimiterImpactChecker = new LoopLimiterImpactChecker(tu);
   }
 
   static List<AbstractReductionOpportunity> findOpportunities(
@@ -129,7 +133,8 @@ public class FlattenControlFlowReductionOpportunities
 
   private boolean isLoopLimiterCheck(Stmt compoundStmt) {
     return compoundStmt instanceof IfStmt
-          && StmtReductionOpportunities.referencesLoopLimiter(compoundStmt, getCurrentScope());
+          && loopLimiterImpactChecker.referencesNonRedundantLoopLimiter(compoundStmt,
+                                                                        getCurrentScope());
   }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunities.java
@@ -26,6 +26,7 @@ import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.typing.ScopeEntry;
 import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.StatsVisitor;
+import com.graphicsfuzz.util.Constants;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -140,11 +141,11 @@ public class InlineInitializerReductionOpportunities
     if (currentProgramPointIsDeadCode()) {
       return true;
     }
-    if (StmtReductionOpportunities.isLooplimiter(variableDeclInfo.getName())) {
+    if (Constants.isLooplimiterVariableName(variableDeclInfo.getName())) {
       // Do not mess with loop limiters.
       return false;
     }
-    if (isLiveInjectedVariableName(variableDeclInfo.getName())) {
+    if (Constants.isLiveInjectedVariableName(variableDeclInfo.getName())) {
       return true;
     }
     return false;

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineUniformReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineUniformReductionOpportunities.java
@@ -25,6 +25,7 @@ import com.graphicsfuzz.common.typing.ScopeEntry;
 import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.PipelineInfo;
 import com.graphicsfuzz.common.util.PruneUniforms;
+import com.graphicsfuzz.util.Constants;
 import java.util.Arrays;
 import java.util.List;
 
@@ -63,7 +64,7 @@ public class InlineUniformReductionOpportunities extends SimplifyExprReductionOp
     // We only inline uniforms if we are not preserving semantics, if the current program point is
     // is dead code, or if the uniform is a live-injected variable.
     if (!(context.reduceEverywhere() || currentProgramPointIsDeadCode()
-        || isLiveInjectedVariableName(variableIdentifierExpr.getName()))) {
+        || Constants.isLiveInjectedVariableName(variableIdentifierExpr.getName()))) {
       return;
     }
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LoopLimiterImpactChecker.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LoopLimiterImpactChecker.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2020 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.IAstNode;
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
+import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
+import com.graphicsfuzz.common.ast.stmt.DoStmt;
+import com.graphicsfuzz.common.ast.stmt.ForStmt;
+import com.graphicsfuzz.common.ast.stmt.LoopStmt;
+import com.graphicsfuzz.common.ast.stmt.Stmt;
+import com.graphicsfuzz.common.ast.stmt.WhileStmt;
+import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
+import com.graphicsfuzz.common.typing.Scope;
+import com.graphicsfuzz.common.typing.ScopeEntry;
+import com.graphicsfuzz.util.Constants;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+public class LoopLimiterImpactChecker {
+
+  // Loops arising from live-injected code maybe equipped with *limiters*, which bound the number
+  // of times they can iterate.  This field records those loops whose removal from the shader will
+  // not impact the limiting of remaining loops.
+  //
+  // For example, consider the following:
+  //
+  //     GLF_live_loop_limiter1 = 0;
+  // (1) while(true) {
+  //       if (GLF_live_loop_limiter1 >= 4) {
+  // (2)     for (int i = 0; i < 10; i++) {
+  //           // nop
+  //         }
+  //         break;
+  //       }
+  // (3)   for(i = 0; i < 1; i++) {
+  //         live_loop_limiter1++;
+  //       }
+  //       GLF_live_loop_limiter2 = 0;
+  // (4)   while(true) {
+  //         if (GLF_live_loop_limiter2 >= 3) {
+  //           break;
+  //         }
+  //         GLF_live_loop_limiter2++;
+  //       }
+  //     }
+  //
+  // Loop (1) can be removed without impacting the limiting of remaining loops: the only loop
+  // limiter to which it refers that is declared outside (1) is 'live_loop_limiter1', and (1) is
+  // outer-most loop in which 'live_loop_limiter1' is visible.
+  //
+  // Loop (2) can be removed without impacting the limiting of remaining loops because it does
+  // not reference any loop limiter variables.
+  //
+  // Loop (3) *cannot* be removed without impacting the limiting of remaining loops because it
+  // references 'live_loop_limiter1', yet is not one of the outer-most loops in which
+  // 'live_loop_limiter1' is visible (loop (1) is).
+  //
+  // Loop (4) can be removed without impacting the limiting of remaining loops: the only loop
+  // limiter to which it refers that is declared outside (4) is 'live_loop_limiter2', and (4) is
+  // the outer-most loop in which 'live_loop_limiter1' is visible.
+  //
+  // The presence of a loop in this set does not necessarily mean that the loop can be removed;
+  // other conditions may need to be met for that to be the case.  It just means that if the loop
+  // were to be removed, the limiting of remaining loops would not be affected.
+  private final Set<LoopStmt> loopsThatCanBeRemovedWithoutImpactingLoopLimiting;
+
+  // This captures loop limiters whose associated loops have been removed, and allows removal of
+  // left-over statements that reference such loop limiters.
+  private final Set<VariablesDeclaration> nonRedundantLoopLimiters;
+
+  public LoopLimiterImpactChecker(TranslationUnit tu) {
+
+    this.loopsThatCanBeRemovedWithoutImpactingLoopLimiting = new HashSet<>();
+    this.nonRedundantLoopLimiters = new HashSet<>();
+
+    new InjectionTrackingVisitor(tu) {
+
+      // A stack that keeps track of the nest of loops currently being visited and, for each loop,
+      // the loop limiters declared in the body of that loop but not in a deeper loop.  The first
+      // element in each pair must be a loop statement, with the exception of the very first pair
+      // whose first element is a function's block statement (to capture those loop limiters not
+      // declared in any loop).
+      private final List<ImmutablePair<Stmt, Set<VariablesDeclaration>>> loopStack =
+          new ArrayList<>();
+
+      @Override
+      public void visitFunctionDefinition(FunctionDefinition functionDefinition) {
+        assert loopStack.isEmpty();
+        loopStack.add(new ImmutablePair<>(functionDefinition.getBody(), new HashSet<>()));
+        super.visitFunctionDefinition(functionDefinition);
+        assert loopStack.size() == 1;
+        loopStack.remove(0);
+      }
+
+      @Override
+      public void visitVariablesDeclaration(VariablesDeclaration variablesDeclaration) {
+        super.visitVariablesDeclaration(variablesDeclaration);
+
+        if (getEnclosingFunction() == null) {
+          // Loop limiters are not relevant at global scope.
+          return;
+        }
+
+        // We are in a function, so should have a non-empty loop stack.
+        assert !loopStack.isEmpty();
+
+        // Is this a loop limiter?  By construction a loop limiter is declared on its own and has a
+        // special name.
+        if (variablesDeclaration.getNumDecls() == 1
+            && Constants.isLooplimiterVariableName(variablesDeclaration.getDeclInfo(0).getName())) {
+          // It is a loop limiter, so add the declaration to the set of declarations at the top of
+          // the stack.
+          loopStack.get(loopStack.size() - 1).getRight().add(variablesDeclaration);
+        }
+      }
+
+      @Override
+      public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
+        super.visitVariableIdentifierExpr(variableIdentifierExpr);
+
+        // We are only interested in references to loop limiters.
+        if (!Constants.isLooplimiterVariableName(variableIdentifierExpr.getName())) {
+          return;
+        }
+
+        // We are not interested in loop limiter references that occur under a fuzzed macro,
+        // because such uses are guaranteed not to affect loop limiting.
+        if (injectionTracker.underFuzzedMacro()) {
+          return;
+        }
+
+        // Get the variables declaration associated with the loop limiter reference, which by
+        // construction must be in scope.
+        final VariablesDeclaration variablesDeclaration =
+            getCurrentScope().lookupScopeEntry(variableIdentifierExpr.getName())
+                .getVariablesDeclaration();
+
+        // Walk the loop stack backwards until we find the loop in which this limiter was declared
+        // (or until we reach the bottom of the stack, in the case that the limiter is declared
+        // outside any loop).
+        for (int i = loopStack.size() - 1; i >= 0; i--) {
+          if (i < loopStack.size() - 1) {
+            // The loop limiter variable is declared in some loop body that is shallower than the
+            // loop body in which it is used.  It thus may not be redundant: it might be being used
+            // to limit that loop.
+            nonRedundantLoopLimiters.add(variablesDeclaration);
+          }
+          if (loopStack.get(i).getRight().contains(variablesDeclaration)) {
+            // This is where the loop limiter is declared; shallower loops are not affected by this
+            // loop limiter.
+            break;
+          }
+          if (i < loopStack.size() - 1) {
+            // We have not yet found the loop limiter declaration, so removal of a deeper loop
+            // might affect the limiting of remaining loops.
+            final LoopStmt loopStmt = (LoopStmt) loopStack.get(i + 1).getLeft();
+            loopsThatCanBeRemovedWithoutImpactingLoopLimiting.remove(loopStmt);
+          }
+        }
+      }
+
+      @Override
+      public void visitDoStmt(DoStmt doStmt) {
+        beforeLoop(doStmt);
+        super.visitDoStmt(doStmt);
+        afterLoop();
+      }
+
+      @Override
+      public void visitForStmt(ForStmt forStmt) {
+        beforeLoop(forStmt);
+        super.visitForStmt(forStmt);
+        afterLoop();
+      }
+
+      @Override
+      public void visitWhileStmt(WhileStmt whileStmt) {
+        beforeLoop(whileStmt);
+        super.visitWhileStmt(whileStmt);
+        afterLoop();
+      }
+
+      private void beforeLoop(LoopStmt loopStmt) {
+        loopsThatCanBeRemovedWithoutImpactingLoopLimiting.add(loopStmt);
+        loopStack.add(new ImmutablePair<>(loopStmt,
+            new HashSet<>()));
+      }
+
+      private void afterLoop() {
+        loopStack.remove(loopStack.size() - 1);
+      }
+
+    }.visit(tu);
+  }
+
+  /**
+   * Determines whether the given loop may impact the limiting of other loops.
+   * @param loopStmt A loop statement to be checked.
+   * @return true if and only if the given loop does not impact the limiting of other loops.
+   */
+  public boolean doesNotImpactLoopLimiting(LoopStmt loopStmt) {
+    return loopsThatCanBeRemovedWithoutImpactingLoopLimiting.contains(loopStmt);
+  }
+
+  /**
+   * Determines whether a given node references a non-redundant loop limiter declared in its
+   * enclosing scope.
+   * @param node An AST node to be checked.
+   * @param scope Variables in the scope of the node.
+   * @return True if and only if the node references some non-redundant loop limiter that is
+   *         declared in the given scope.
+   */
+  public boolean referencesNonRedundantLoopLimiter(IAstNode node, Scope scope) {
+    return new CheckPredicateVisitor() {
+      @Override
+      public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
+        super.visitVariableIdentifierExpr(variableIdentifierExpr);
+        final String name = variableIdentifierExpr.getName();
+        if (!Constants.isLooplimiterVariableName(name)) {
+          // We are only interested in loop limiters.
+          return;
+        }
+        // This loop limiter might be declared inside 'stmt', which is OK; we're only interested
+        // in it if it is part of 'scope'.
+        final ScopeEntry scopeEntry = scope.lookupScopeEntry(name);
+        if (scopeEntry == null) {
+          // The loop limiter was not part of 'scope'.
+          return;
+        }
+        // Finally, check whether the loop limiter is redundant; we only care about non-redundant
+        // loop limiters.
+        if (nonRedundantLoopLimiters.contains(scopeEntry.getVariablesDeclaration())) {
+          predicateHolds();
+        }
+      }
+    }.test(node);
+  }
+
+}

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesBase.java
@@ -18,7 +18,6 @@ package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.IAstNode;
 import com.graphicsfuzz.common.ast.TranslationUnit;
-import com.graphicsfuzz.common.ast.decl.ArrayInfo;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
 import com.graphicsfuzz.common.ast.expr.Expr;
@@ -26,7 +25,6 @@ import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.stmt.ExprCaseLabel;
 import com.graphicsfuzz.common.util.ShaderKind;
 import com.graphicsfuzz.common.util.SideEffectChecker;
-import com.graphicsfuzz.util.Constants;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -134,10 +132,6 @@ public abstract class ReductionOpportunitiesBase
       // does not hold -- this would lead to a reduction loop.
       opportunities.add(opportunity);
     }
-  }
-
-  static boolean isLiveInjectedVariableName(String name) {
-    return name.startsWith(Constants.LIVE_PREFIX);
   }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunities.java
@@ -17,8 +17,6 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
-import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
-import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
 import com.graphicsfuzz.common.ast.expr.ArrayIndexExpr;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.BinaryExpr;
@@ -29,7 +27,6 @@ import com.graphicsfuzz.common.ast.expr.UnaryExpr;
 import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.ast.stmt.BlockStmt;
 import com.graphicsfuzz.common.ast.stmt.DeclarationStmt;
-import com.graphicsfuzz.common.ast.stmt.DoStmt;
 import com.graphicsfuzz.common.ast.stmt.ExprStmt;
 import com.graphicsfuzz.common.ast.stmt.ForStmt;
 import com.graphicsfuzz.common.ast.stmt.IfStmt;
@@ -37,21 +34,15 @@ import com.graphicsfuzz.common.ast.stmt.LoopStmt;
 import com.graphicsfuzz.common.ast.stmt.NullStmt;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.stmt.SwitchStmt;
-import com.graphicsfuzz.common.ast.stmt.WhileStmt;
 import com.graphicsfuzz.common.ast.visitors.CheckPredicateVisitor;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
-import com.graphicsfuzz.common.typing.Scope;
 import com.graphicsfuzz.common.util.ListConcat;
 import com.graphicsfuzz.common.util.MacroNames;
 import com.graphicsfuzz.common.util.SideEffectChecker;
 import com.graphicsfuzz.common.util.StructUtils;
 import com.graphicsfuzz.util.Constants;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class StmtReductionOpportunities
       extends ReductionOpportunitiesBase<StmtReductionOpportunity> {
@@ -59,58 +50,14 @@ public class StmtReductionOpportunities
   // The translation unit in which statement reduction opportunities are being sought.
   private final TranslationUnit tu;
 
-  // Loops arising from live-injected code maybe equipped with *limiters*, which bound the number
-  // of times they can iterate.  This field records those loops whose removal from the shader will
-  // not impact the limiting of remaining loops.
-  //
-  // For example, consider the following:
-  //
-  //     GLF_live_loop_limiter1 = 0;
-  // (1) while(true) {
-  //       if (GLF_live_loop_limiter1 >= 4) {
-  // (2)     for (int i = 0; i < 10; i++) {
-  //           // nop
-  //         }
-  //         break;
-  //       }
-  // (3)   for(i = 0; i < 1; i++) {
-  //         live_loop_limiter1++;
-  //       }
-  //       GLF_live_loop_limiter2 = 0;
-  // (4)   while(true) {
-  //         if (GLF_live_loop_limiter2 >= 3) {
-  //           break;
-  //         }
-  //         GLF_live_loop_limiter2++;
-  //       }
-  //     }
-  //
-  // Loop (1) can be removed without impacting the limiting of remaining loops: the only loop
-  // limiter to which it refers that is declared outside (1) is 'live_loop_limiter1', and (1) is
-  // outer-most loop in which 'live_loop_limiter1' is visible.
-  //
-  // Loop (2) can be removed without impacting the limiting of remaining loops because it does
-  // not reference any loop limiter variables.
-  //
-  // Loop (3) *cannot* be removed without impacting the limiting of remaining loops because it
-  // references 'live_loop_limiter1', yet is not one of the outer-most loops in which
-  // 'live_loop_limiter1' is visible (loop (1) is).
-  //
-  // Loop (4) can be removed without impacting the limiting of remaining loops: the only loop
-  // limiter to which it refers that is declared outside (4) is 'live_loop_limiter2', and (4) is
-  // the outer-most loop in which 'live_loop_limiter1' is visible.
-  //
-  // The presence of a loop in this set does not necessarily mean that the loop can be removed;
-  // other conditions may need to be met for that to be the case.  It just means that if the loop
-  // were to be removed, the limiting of remaining loops would not be affected.
-  private final Set<LoopStmt> loopsThatCanBeRemovedWithoutImpactingLoopLimiting;
+  // Used to identify when code that references loop limiters can be safely removed.
+  private final LoopLimiterImpactChecker loopLimiterImpactChecker;
 
   private StmtReductionOpportunities(TranslationUnit tu,
         ReducerContext context) {
     super(tu, context);
     this.tu = tu;
-    this.loopsThatCanBeRemovedWithoutImpactingLoopLimiting = new HashSet<>();
-    new LoopLimiterImpactChecker(tu).visit(tu);
+    this.loopLimiterImpactChecker = new LoopLimiterImpactChecker(tu);
 
   }
 
@@ -196,7 +143,7 @@ public class StmtReductionOpportunities
 
     // Then, for live code, we need to take care about removing statements that manipulate loop
     // limiters.  If this statement does not reference any loop limiters, that's fine.
-    if (!referencesLoopLimiter(stmt, getCurrentScope())) {
+    if (!loopLimiterImpactChecker.referencesNonRedundantLoopLimiter(stmt, getCurrentScope())) {
       return true;
     }
 
@@ -204,21 +151,8 @@ public class StmtReductionOpportunities
     // is a loop such that we know removing this loop will not impact on the limiting of other
     // loops.
     return stmt instanceof LoopStmt
-        && loopsThatCanBeRemovedWithoutImpactingLoopLimiting.contains(stmt);
+        && loopLimiterImpactChecker.doesNotImpactLoopLimiting((LoopStmt) stmt);
 
-  }
-
-  static boolean referencesLoopLimiter(Stmt stmt, Scope scope) {
-    return new CheckPredicateVisitor() {
-      @Override
-      public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
-        super.visitVariableIdentifierExpr(variableIdentifierExpr);
-        final String name = variableIdentifierExpr.getName();
-        if (isLooplimiter(name) && scope.lookupScopeEntry(name) != null) {
-          predicateHolds();
-        }
-      }
-    }.test(stmt);
   }
 
   /**
@@ -292,12 +226,7 @@ public class StmtReductionOpportunities
   static boolean isLiveCodeVariableDeclaration(DeclarationStmt stmt) {
     return stmt.getVariablesDeclaration().getDeclInfos()
           .stream()
-          .anyMatch(StmtReductionOpportunities::isLiveCodeVariableDeclaration);
-  }
-
-  private static boolean isLiveCodeVariableDeclaration(VariableDeclInfo vdi) {
-    final String name = vdi.getName();
-    return isLiveInjectedVariableName(name);
+          .anyMatch(item -> Constants.isLiveInjectedVariableName(item.getName()));
   }
 
   /**
@@ -328,7 +257,7 @@ public class StmtReductionOpportunities
       return isLiveInjectionVariableReference(((UnaryExpr) expr).getExpr());
     }
     if (expr instanceof FunctionCallExpr) {
-      return isLiveInjectedVariableName(((FunctionCallExpr) expr).getCallee());
+      return Constants.isLiveInjectedVariableName(((FunctionCallExpr) expr).getCallee());
     }
     return false;
   }
@@ -344,7 +273,7 @@ public class StmtReductionOpportunities
     if (!(lhs instanceof VariableIdentifierExpr)) {
       return false;
     }
-    return isLiveInjectedVariableName(((VariableIdentifierExpr) lhs).getName());
+    return Constants.isLiveInjectedVariableName(((VariableIdentifierExpr) lhs).getName());
   }
 
   private boolean isRedundantCopy(Stmt stmt) {
@@ -371,11 +300,6 @@ public class StmtReductionOpportunities
           .equals(((VariableIdentifierExpr) rhs).getName());
   }
 
-  static boolean isLooplimiter(String name) {
-    return isLiveInjectedVariableName(name)
-          && name.contains(Constants.LOOP_LIMITER);
-  }
-
   private boolean isEmptyAndUnreferencedDeclaration(DeclarationStmt stmt) {
     if (stmt.getVariablesDeclaration().getNumDecls() != 0) {
       return false;
@@ -385,109 +309,5 @@ public class StmtReductionOpportunities
         stmt.getVariablesDeclaration());
   }
 
-  private class LoopLimiterImpactChecker extends InjectionTrackingVisitor {
-
-    // A stack that keeps track of the nest of loops currently being visited and, for each loop,
-    // the loop limiters declared in the body of that loop but not in a deeper loop.
-    private final List<ImmutablePair<LoopStmt, Set<VariablesDeclaration>>> loopStack =
-        new ArrayList<>();
-
-    private LoopLimiterImpactChecker(TranslationUnit tu) {
-      super(tu);
-    }
-
-    @Override
-    public void visitVariablesDeclaration(VariablesDeclaration variablesDeclaration) {
-      super.visitVariablesDeclaration(variablesDeclaration);
-      // We only keep track of loop limiters declared in some loop.
-      if (loopStack.isEmpty()) {
-        return;
-      }
-      // Is this a loop limiter?  By construction a loop limiter is declared on its own and has a
-      // special name.
-      if (variablesDeclaration.getNumDecls() == 1
-          && isLooplimiter(variablesDeclaration.getDeclInfo(0).getName())) {
-        // It is a loop limiter, so add the declaration to the set of declarations at the top of
-        // the stack.
-        loopStack.get(loopStack.size() - 1).getRight().add(variablesDeclaration);
-      }
-    }
-
-    @Override
-    public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
-      super.visitVariableIdentifierExpr(variableIdentifierExpr);
-
-      // We are only interested in references to loop limiters.
-      if (!isLooplimiter(variableIdentifierExpr.getName())) {
-        return;
-      }
-
-      // We are only interested in loop limiter references that occur in non-trivial loop nests.
-      if (loopStack.size() < 2) {
-        return;
-      }
-
-      // We are not interested in loop limiter references that occur under a fuzzed macro,
-      // because such uses are guaranteed not to affect loop limiting.
-      if (injectionTracker.underFuzzedMacro()) {
-        return;
-      }
-
-      // Get the variables declaration associated with the loop limiter reference, which by
-      // construction must be in scope.
-      final VariablesDeclaration variablesDeclaration =
-          getCurrentScope().lookupScopeEntry(variableIdentifierExpr.getName())
-              .getVariablesDeclaration();
-
-      // Walk the loop stack backwards until we find the loop in which this limiter was declared
-      // (or until we reach the bottom of the stack, in the case that the limiter is declared
-      // outside any loop).
-      for (int i = loopStack.size() - 1; i >= 0; i--) {
-        if (loopStack.get(i).getRight().contains(variablesDeclaration)) {
-          // This is where the loop limiter is declared; shallower loops are not affected by this
-          // loop limiter.
-          break;
-        }
-        if (i < loopStack.size() - 1) {
-          // We have not yet found the loop limiter declaration, so removal of a deeper loop
-          // might affect the limiting of remaining loops.
-          loopsThatCanBeRemovedWithoutImpactingLoopLimiting.remove(
-              loopStack.get(i + 1).getLeft());
-        }
-      }
-    }
-
-    @Override
-    public void visitDoStmt(DoStmt doStmt) {
-      beforeLoop(doStmt);
-      super.visitDoStmt(doStmt);
-      afterLoop();
-    }
-
-    @Override
-    public void visitForStmt(ForStmt forStmt) {
-      beforeLoop(forStmt);
-      super.visitForStmt(forStmt);
-      afterLoop();
-    }
-
-    @Override
-    public void visitWhileStmt(WhileStmt whileStmt) {
-      beforeLoop(whileStmt);
-      super.visitWhileStmt(whileStmt);
-      afterLoop();
-    }
-
-    private void beforeLoop(LoopStmt loopStmt) {
-      loopsThatCanBeRemovedWithoutImpactingLoopLimiting.add(loopStmt);
-      loopStack.add(new ImmutablePair<>(loopStmt,
-          new HashSet<>()));
-    }
-
-    private void afterLoop() {
-      loopStack.remove(loopStack.size() - 1);
-    }
-
-  }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunities.java
@@ -129,7 +129,7 @@ public class VariableDeclReductionOpportunities
     // Fine to remove if in a dead context, a live context, if no initializer, or if
     // initializer does not have side effects.
     return context.reduceEverywhere() || currentProgramPointIsDeadCode()
-        || isLiveInjectedVariableName(variableDeclInfo.getName())
+        || Constants.isLiveInjectedVariableName(variableDeclInfo.getName())
         || !variableDeclInfo.hasInitializer()
         || initializerIsScalarAndSideEffectFree(variableDeclInfo);
   }

--- a/util/src/main/java/com/graphicsfuzz/util/Constants.java
+++ b/util/src/main/java/com/graphicsfuzz/util/Constants.java
@@ -116,4 +116,13 @@ public final class Constants {
   // String used inside live-injected variable to indicate that it is a loop limiter.
   public static final String LOOP_LIMITER = "looplimiter";
 
+  public static boolean isLiveInjectedVariableName(String name) {
+    return name.startsWith(Constants.LIVE_PREFIX);
+  }
+
+  public static boolean isLooplimiterVariableName(String name) {
+    return isLiveInjectedVariableName(name)
+        && name.contains(Constants.LOOP_LIMITER);
+  }
+
 }


### PR DESCRIPTION
This change teaches the reducer when a loop limiter is not actually
used to limit any loop, in which case uses of the loop limiter can be
safely removed or simplified.

This is achieved by extracting existing functionality for analysing
loop limiters into its own class, so that it provides functions that
can be queried from multiple ReductionOpportunities classes.

In the process, static helper functions to test whether variable names
are live variables or loop limiters have been moved into the Constants
helper class, where the prefixes for live variables and loop limiters
are defined.

Fixes #950.