### PR TITLE
gfauto: change default llpc config

### DIFF
--- a/gfauto/gfauto/devices_util.py
+++ b/gfauto/gfauto/devices_util.py
@@ -202,7 +202,8 @@ def get_device_list(
     device = Device(
         name="amdllpc",
         shader_compiler=DeviceShaderCompiler(
-            binary="amdllpc", args=["-gfxip=9.0.0", "-verify-ir", "-auto-layout-desc"]
+            binary="amdllpc",
+            args=["-val=false", "-gfxip=9.0.0", "-verify-ir", "-auto-layout-desc"],
         ),
         binaries=[binary_manager.get_binary_by_name("amdllpc")],
     )


### PR DESCRIPTION
Disable SPIR-V validation in the default LLPC configuration, as we validate shaders using a more recent version of spirv-val and we may also have extra spirv-val arguments. Thus, LLPC SPIR-V validation errors are not interesting.