### PR TITLE
gfauto: fix SSBO binding

### DIFF
--- a/gfauto/whitelist.dic
+++ b/gfauto/whitelist.dic
@@ -242,3 +242,5 @@ writelines
 colorgrid
 logd
 gf
+SIGSEGV
+SIGABRT


### PR DESCRIPTION
The AmberScript generated from a compute shader job always had a binding location of 0. Now, it uses the binding location from the JSON.

Also add some missing words from the whitelist.dic file.