### PR TITLE
Replace the bash shebang with `#!/usr/bin/env bash`

### DIFF
--- a/experiments/build-Imagination_Vulkan.sh
+++ b/experiments/build-Imagination_Vulkan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The GraphicsFuzz Project Authors
 #

--- a/experiments/build-Khronos_Samples_Vulkan.sh
+++ b/experiments/build-Khronos_Samples_Vulkan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The GraphicsFuzz Project Authors
 #

--- a/experiments/build-SaschaWillems_Vulkan.sh
+++ b/experiments/build-SaschaWillems_Vulkan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The GraphicsFuzz Project Authors
 #

--- a/experiments/build-google_vulkan_test_applications.sh
+++ b/experiments/build-google_vulkan_test_applications.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The GraphicsFuzz Project Authors
 #

--- a/experiments/build-project.sh
+++ b/experiments/build-project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The GraphicsFuzz Project Authors
 #

--- a/experiments/build-swiftshader-coverage.sh
+++ b/experiments/build-swiftshader-coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2020 The GraphicsFuzz Project Authors
 #


### PR DESCRIPTION
This PR replaces the shebang in the build scripts with `#!/usr/bin/env bash`. This change removes any assumptions about the location of the bash executable.