### PR TITLE
Update Java 11 dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.iml
 /.idea/
 
+# VSCode
+.vscode/
+
 # Maven.
 target/
 dependency-reduced-pom.xml

--- a/server-thrift-gen/pom.xml
+++ b/server-thrift-gen/pom.xml
@@ -64,6 +64,13 @@ limitations under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+
 
   </dependencies>
 


### PR DESCRIPTION
`javax.annotation` was removed in Java 11.