### PR TITLE
gfauto: generate variant_2

### DIFF
--- a/gfauto/gfauto/binaries_util.py
+++ b/gfauto/gfauto/binaries_util.py
@@ -40,6 +40,7 @@ BINARY_RECIPES_PREFIX = "//binaries"
 LATEST_GRAPHICSFUZZ_ARTIFACT = f"{BINARY_RECIPES_PREFIX}/graphicsfuzz_v1.2.1"
 
 GLSLANG_VALIDATOR_NAME = "glslangValidator"
+SPIRV_FUZZ_NAME = "spirv-fuzz"
 SPIRV_OPT_NAME = "spirv-opt"
 SPIRV_VAL_NAME = "spirv-val"
 SPIRV_DIS_NAME = "spirv-dis"

--- a/gfauto/gfauto/fuzz.py
+++ b/gfauto/gfauto/fuzz.py
@@ -46,6 +46,7 @@ from gfauto import (
 )
 from gfauto.device_pb2 import Device, DevicePreprocess
 from gfauto.gflogging import log
+from gfauto.settings_pb2 import Settings
 from gfauto.util import check_dir_exists
 
 # Root:
@@ -460,14 +461,14 @@ def main_helper(  # pylint: disable=too-many-locals, too-many-branches, too-many
 
 
 def create_summary_and_reproduce(
-    test_dir: Path, binary_manager: binaries_util.BinaryManager
+    test_dir: Path, binary_manager: binaries_util.BinaryManager, settings: Settings,
 ) -> None:
     util.mkdirs_p(test_dir / "summary")
     test_metadata = test_util.metadata_read(test_dir)
 
     # noinspection PyTypeChecker
     if test_metadata.HasField("glsl") or test_metadata.HasField("spirv_fuzz"):
-        fuzz_glsl_test.create_summary_and_reproduce(test_dir, binary_manager)
+        fuzz_glsl_test.create_summary_and_reproduce(test_dir, binary_manager, settings)
     else:
         raise AssertionError("Unrecognized test type")
 


### PR DESCRIPTION
When creating the summary of a crash bug derived from a `stable_` shader, `reduction_1/` will contain a "wrong image" test that exposes the bug. In this case, we now add a `variant_2` shader that is the same as the variant shader, but with the last transformation removed. This is likely to give a shader that is very similar to the variant but does not trigger the bug. The `variant_2` shader is created using the `--replay-range` option of spirv-fuzz.