### PR TITLE
Avoid use of 'blacklist' in the code base

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunities.java
@@ -43,16 +43,16 @@ public class InlineInitializerReductionOpportunities
   // All variable identifier expressions that can be potentially replaced with initializers.
   private final List<Pair<VariableDeclInfo, VariableIdentifierExpr>> inlineableUsages;
 
-  // A blacklist of variable declarations that we realise we must not inline references to after
-  // all (used to filter the list of potentially inlineable uses).
-  private final Set<VariableDeclInfo> blackList;
+  // An exclusion list of variable declarations that we realise we must not inline references to
+  // after all (used to filter the list of potentially inlineable uses).
+  private final Set<VariableDeclInfo> exclusionList;
 
   private InlineInitializerReductionOpportunities(
         TranslationUnit tu,
         ReducerContext context) {
     super(tu, context);
     this.inlineableUsages = new LinkedList<>();
-    this.blackList = new HashSet<>();
+    this.exclusionList = new HashSet<>();
   }
 
   static List<SimplifyExprReductionOpportunity> findOpportunities(
@@ -76,7 +76,7 @@ public class InlineInitializerReductionOpportunities
 
   private void addOpportunities() {
     for (Pair<VariableDeclInfo, VariableIdentifierExpr> pair : inlineableUsages) {
-      if (!blackList.contains(pair.getLeft())) {
+      if (!exclusionList.contains(pair.getLeft())) {
         addOpportunity(new SimplifyExprReductionOpportunity(
             parentMap.getParent(pair.getRight()),
             new ParenExpr((pair.getLeft().getInitializer()).getExpr().clone()),
@@ -121,7 +121,7 @@ public class InlineInitializerReductionOpportunities
         //   x += x;
         // we end up with x == 8, but if we would inline the initializer to the r-value usage of
         // x we would get x == 6.
-        blackList.add(variableDeclInfo);
+        exclusionList.add(variableDeclInfo);
       }
       return;
     }

--- a/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
@@ -65,10 +65,10 @@ public class GeneratorUnitTest {
 
   // Toggle this to 'true' to focus on cases that used to fail but may
   // now work due to swiftshader fixes.
-  private static final boolean reverseBlacklist = false;
+  private static final boolean reverseExclusionList = false;
 
   // Toggle this to 'true' to run tests on all shaders.
-  private static final boolean ignoreBlacklist = false;
+  private static final boolean ignoreExclusionList = false;
 
   // TODO: Use ShaderJobFileOperations everywhere.
   private final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
@@ -145,7 +145,7 @@ public class GeneratorUnitTest {
         "donatedead",
         Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_zoom.json"),
         Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_zoom.json"));
-    // Reason for blacklisting^: slow.
+    // Reason for excluding^: slow.
   }
 
   @Test
@@ -158,7 +158,7 @@ public class GeneratorUnitTest {
         "donatelive",
         Arrays.asList("squares.json"),
         Arrays.asList("squares.json"));
-    // Reason for blacklisting^: slow.
+    // Reason for excluding^: slow.
   }
 
   @Test
@@ -202,7 +202,7 @@ public class GeneratorUnitTest {
         "wrap",
         Arrays.asList("bubblesort_flag.json", "colorgrid_modulo.json"),
         Arrays.asList("bubblesort_flag.json", "colorgrid_modulo.json"));
-    // Reason for blacklisting^: slow.
+    // Reason for excluding^: slow.
   }
 
   @Test
@@ -227,7 +227,7 @@ public class GeneratorUnitTest {
   }
 
   private void testTransformation(List<ITransformationSupplier> transformations,
-        TransformationProbabilities probabilities, String suffix, List<String> blacklist,
+        TransformationProbabilities probabilities, String suffix, List<String> exclusionList,
         File[] referenceFiles)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     for (File originalShaderJobFile : referenceFiles) {
@@ -236,11 +236,11 @@ public class GeneratorUnitTest {
         transformationsList.add(supplier.get());
       }
       boolean skipRender;
-      if (ignoreBlacklist) {
+      if (ignoreExclusionList) {
         skipRender = false;
       } else {
         skipRender =
-            (reverseBlacklist != blacklist.contains(originalShaderJobFile.getName()));
+            (reverseExclusionList != exclusionList.contains(originalShaderJobFile.getName()));
       }
       File referenceImage = null;
       if (!skipRender) {
@@ -259,36 +259,36 @@ public class GeneratorUnitTest {
   }
 
   private void testTransformation100(List<ITransformationSupplier> transformations,
-        TransformationProbabilities probabilities, String suffix, List<String> blacklist)
+        TransformationProbabilities probabilities, String suffix, List<String> exclusionList)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
-    testTransformation(transformations, probabilities, suffix, blacklist,
+    testTransformation(transformations, probabilities, suffix, exclusionList,
           Util.getReferenceShaderJobFiles100es(fileOps));
   }
 
   private void testTransformation300es(List<ITransformationSupplier> transformations,
-        TransformationProbabilities probabilities, String suffix, List<String> blacklist)
+        TransformationProbabilities probabilities, String suffix, List<String> exclusionList)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
-    testTransformation(transformations, probabilities, suffix, blacklist,
+    testTransformation(transformations, probabilities, suffix, exclusionList,
         Util.getReferenceShaderJobFiles300es(fileOps));
   }
 
   private void testTransformationMultiVersions(List<ITransformationSupplier> transformations,
                                                TransformationProbabilities probabilities,
                                                String suffix,
-                                               List<String> blacklist100,
-                                               List<String> blacklist300es)
+                                               List<String> exclusionList100,
+                                               List<String> exclusionList300es)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
-    testTransformation100(transformations, probabilities, suffix, blacklist100);
-    testTransformation300es(transformations, probabilities, suffix, blacklist300es);
+    testTransformation100(transformations, probabilities, suffix, exclusionList100);
+    testTransformation300es(transformations, probabilities, suffix, exclusionList300es);
   }
 
   private void testTransformationMultiVersions(ITransformationSupplier transformation,
       TransformationProbabilities probabilities, String suffix,
-                                               List<String> blacklist100,
-                                               List<String> blacklist300es)
+                                               List<String> exclusionList100,
+                                               List<String> exclusionList300es)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
     testTransformationMultiVersions(Arrays.asList(transformation), probabilities,
-        suffix, blacklist100, blacklist300es);
+        suffix, exclusionList100, exclusionList300es);
   }
 
   private void testTransformationMultiVersions(List<ITransformationSupplier> transformations,


### PR DESCRIPTION
In line with:

  https://source.android.com/setup/contribute/respectful-code

this change uses the terms 'exclude' or 'exlusion list' where
'blacklist' was previously used.