### PR TITLE
gfauto: use --fuzzer-pass-validation

### DIFF
--- a/gfauto/gfauto/spirv_fuzz_util.py
+++ b/gfauto/gfauto/spirv_fuzz_util.py
@@ -123,6 +123,7 @@ def run_generate(
         "-o",
         str(output_shader_spv),
         f"--donors={str(donors_list_path)}",
+        "--fuzzer-pass-validation",
     ]
 
     if seed:


### PR DESCRIPTION
When running spirv-fuzz, use `--fuzzer-pass-validation` to detect validation errors after each fuzzer pass (i.e. spirv-fuzz bugs).