### PR TITLE
Provide uniform arguments as strings

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/PipelineInfo.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/PipelineInfo.java
@@ -75,7 +75,8 @@ public final class PipelineInfo {
       Optional<Integer> arrayCount, List<? extends Number> values) {
     assert isLegalUniformName(name);
     JsonObject info = new JsonObject();
-    info.addProperty("func", PipelineInfo.get(basicType, arrayCount.isPresent()));
+    info.addProperty("func", PipelineInfo.getGlUniformFunctionName(basicType,
+        arrayCount.isPresent()));
     JsonArray jsonValues = new JsonArray();
     for (Number n : values) {
       jsonValues.add(n);
@@ -173,14 +174,14 @@ public final class PipelineInfo {
 
   public void zeroUnsetUniforms(TranslationUnit tu) {
     // Find all uniforms not yet set, and make them zero
-    final Supplier<Float> floatSupplier = () -> new Float(0.0);
-    final Supplier<Integer> intSupplier = () -> new Integer(0);
-    final Supplier<Integer> uintSupplier = () -> new Integer(0);
-    final Supplier<Integer> boolSupplier = () -> new Integer(0);
+    final Supplier<Float> floatSupplier = () -> 0.0f;
+    final Supplier<Integer> intSupplier = () -> 0;
+    final Supplier<Integer> uintSupplier = () -> 0;
+    final Supplier<Integer> boolSupplier = () -> 0;
     setUniforms(tu, floatSupplier, intSupplier, uintSupplier, boolSupplier);
   }
 
-  private static String get(BasicType type, boolean isArray) {
+  private static String getGlUniformFunctionName(BasicType type, boolean isArray) {
     String result = "glUniform";
 
     if (type.isMatrix()) {
@@ -314,12 +315,19 @@ public final class PipelineInfo {
     return new PipelineInfo(newUniformsInfo);
   }
 
-  public List<Number> getArgs(String uniformName) {
-    final List<Number> result = new ArrayList<>();
+  /**
+   * Returns the contents of the numeric arguments associated with "uniformName" as strings.
+   * Strings are used in order to insulate against internal details of the way numbers are
+   * represented by the underlying JSON library.
+   * @param uniformName The name of the uniform whose numeric arguments are to be retrieved.
+   * @return The numeric arguments associated with the uniforms, as strings.
+   */
+  public List<String> getArgs(String uniformName) {
+    final List<String> result = new ArrayList<>();
     final JsonArray args = lookupUniform(uniformName).get("args")
           .getAsJsonArray();
     for (int i = 0; i < args.size(); i++) {
-      result.add(args.get(i).getAsNumber());
+      result.add(args.get(i).toString());
     }
     return result;
   }

--- a/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/PruneUniforms.java
@@ -138,7 +138,7 @@ public final class PruneUniforms {
 
   private static Initializer makeInitializer(BasicType baseType,
                                              ArrayInfo arrayInfo,
-                                             List<Number> args) {
+                                             List<String> args) {
     if (arrayInfo != null) {
       assert arrayInfo.getConstantSize() * baseType.getNumElements() == args.size();
       List<Expr> argExprs = new ArrayList<>();
@@ -154,10 +154,12 @@ public final class PruneUniforms {
     return new Initializer(getBasicTypeLiteralExpr(baseType, args));
   }
 
-  public static Expr getBasicTypeLiteralExpr(BasicType baseType, List<Number> args) {
+  public static Expr getBasicTypeLiteralExpr(BasicType baseType, List<String> args) {
     List<Expr> argExprs;
     if (baseType.getElementType() == BasicType.BOOL) {
-      argExprs = args.stream().map(item -> new BoolConstantExpr(item.intValue() == 1))
+      // If the type is bool then each element of "args" is required to have an integer value, thus
+      // "parseInt" should not fail.
+      argExprs = args.stream().map(item -> new BoolConstantExpr(Integer.parseInt(item) == 1))
           .collect(Collectors.toList());
     } else if (baseType.getElementType() == BasicType.FLOAT) {
       argExprs = args.stream().map(item -> new FloatConstantExpr(item.toString()))

--- a/common/src/test/java/com/graphicsfuzz/common/util/PipelineInfoTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/util/PipelineInfoTest.java
@@ -23,11 +23,11 @@ import static org.junit.Assert.assertTrue;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class PipelineInfoTest {
@@ -73,11 +73,11 @@ public class PipelineInfoTest {
   @Test
   public void testAppendValueToUniform() {
     final PipelineInfo pipelineInfo = new PipelineInfo();
-    pipelineInfo.addUniform("a", BasicType.FLOAT, Optional.empty(), Arrays.asList(1.0));
+    pipelineInfo.addUniform("a", BasicType.FLOAT, Optional.empty(), Collections.singletonList(1.0));
     assertTrue(pipelineInfo.hasUniform("a"));
 
-    final List<Number> args = pipelineInfo.getArgs("a");
-    assertEquals(args, Arrays.asList(1.0));
+    final List<String> args = pipelineInfo.getArgs("a");
+    assertEquals(args, Collections.singletonList("1.0"));
 
     final String pipelineBefore = "{\n"
         + "  \"a\": {\n"
@@ -92,8 +92,8 @@ public class PipelineInfoTest {
     final int index = pipelineInfo.appendValueToUniform("a", 2.0);
     assertEquals(index, 1);
 
-    final List<Number> args2 = pipelineInfo.getArgs("a");
-    assertEquals(args2, Arrays.asList(1.0, 2.0));
+    final List<String> args2 = pipelineInfo.getArgs("a");
+    assertEquals(args2, Arrays.asList("1.0", "2.0"));
 
     final String pipelineAfter = "{\n"
         + "  \"a\": {\n"
@@ -351,18 +351,17 @@ public class PipelineInfoTest {
   }
 
   @Test
-  @Ignore
   public void testClone() throws Exception {
     final Integer one = 1;
-    
+
     final PipelineInfo pipelineInfo = new PipelineInfo();
     pipelineInfo.addUniform("GLF_uniform_int_values", BasicType.INT,
         Optional.of(0), new ArrayList<>());
     pipelineInfo.appendValueToUniform("GLF_uniform_int_values", one);
 
-    assertTrue(pipelineInfo.getArgs("GLF_uniform_int_values").contains(one));
+    assertTrue(pipelineInfo.getArgs("GLF_uniform_int_values").contains(one.toString()));
 
-    assertTrue(pipelineInfo.clone().getArgs("GLF_uniform_int_values").contains(one));
+    assertTrue(pipelineInfo.clone().getArgs("GLF_uniform_int_values").contains(one.toString()));
   }
 
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LiteralToUniformReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/LiteralToUniformReductionOpportunity.java
@@ -85,10 +85,10 @@ public class LiteralToUniformReductionOpportunity
     }
 
     final int index;
-    final List<Number> values = shaderJob.getPipelineInfo().getArgs(arrayName);
+    final List<String> values = shaderJob.getPipelineInfo().getArgs(arrayName);
 
-    if (values.contains(numericValue)) {
-      index = values.indexOf(numericValue);
+    if (values.contains(numericValue.toString())) {
+      index = values.indexOf(numericValue.toString());
     } else {
       index = shaderJob.getPipelineInfo().appendValueToUniform(arrayName, numericValue);
     }


### PR DESCRIPTION
PipelineInfo provides a method for getting the numeric arguments for a
uniform.  This previously returned a list of type Number.  It turned
out that the JSON library backing PipelineInfo might sometimes
represent numeric values using non-standard subclasses of Number - in
particular LazilyParsedNumber.

To guard against this, numeric arguments are now provided as strings.
We always know the types of uniform variables, so can interpret these
strings as integers or floats accordingly.

Fixes #1054.