### PR TITLE
Always initialize variables during donation

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
@@ -194,6 +194,17 @@ public class Fuzzer {
           .stream().map(item -> makeExpr(item, false, constContext, depth + 1))
           .collect(Collectors.toList()));
     }
+    if (targetType instanceof StructDefinitionType) {
+      final StructDefinitionType structDefinitionType = (StructDefinitionType) targetType;
+      if (structDefinitionType.hasStructNameType()) {
+        return makeExpr(structDefinitionType.getStructNameType(),
+            isLValue,
+            constContext,
+            depth);
+      }
+      // We cannot fuzz a constructor for an un-named struct type.
+      throw new FuzzedIntoACornerException();
+    }
     throw new FuzzedIntoACornerException();
 
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -74,7 +74,7 @@ public class DonateLiveCodeTransformation extends DonateCodeTransformation {
       final Type typeWithRestrictedQualifiers =
           dropQualifiersThatCannotBeUsedForLocalVariable(type);
 
-      Initializer initializer;
+      final Initializer initializer;
       // We fuzz a const expression because we need to ensure we don't generate side-effects to
       // non-injected code
       if (isLoopLimiter(vars.getKey(), typeWithRestrictedQualifiers.getWithoutQualifiers())) {

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
@@ -438,7 +438,7 @@ public class DonateDeadCodeTransformationTest {
       // Do live code donation.
       final DonateDeadCodeTransformation transformation =
           new DonateDeadCodeTransformation(IRandom::nextBoolean, donors,
-              GenerationParams.normal(ShaderKind.FRAGMENT, true));
+              GenerationParams.normal(ShaderKind.FRAGMENT, false));
 
       assert referenceShaderJob.getFragmentShader().isPresent();
 
@@ -446,7 +446,7 @@ public class DonateDeadCodeTransformationTest {
           referenceShaderJob.getFragmentShader().get(),
           TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
           new RandomWrapper(seed),
-          GenerationParams.normal(ShaderKind.FRAGMENT, true)
+          GenerationParams.normal(ShaderKind.FRAGMENT, false)
       );
 
       if (result) {


### PR DESCRIPTION
To reduce the chances of undefined behaviour, this change forces all
variables to be initialized before a module is donated.

An existing test is fixed in the process; its brokenness was exposed
by this change.

Fixes #1063.