### PR TITLE
Enable comma operator fuzzing, cleanup

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Templates.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Templates.java
@@ -20,7 +20,6 @@ import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
 import com.graphicsfuzz.common.ast.expr.BinOp;
 import com.graphicsfuzz.common.ast.expr.UnOp;
 import com.graphicsfuzz.common.ast.type.BasicType;
-import com.graphicsfuzz.common.ast.type.Type;
 import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
 import com.graphicsfuzz.common.typing.SupportedTypes;
 import com.graphicsfuzz.common.typing.TyperHelper;
@@ -35,7 +34,6 @@ import com.graphicsfuzz.generator.fuzzer.templates.TernaryExprTemplate;
 import com.graphicsfuzz.generator.fuzzer.templates.TypeConstructorExprTemplate;
 import com.graphicsfuzz.generator.fuzzer.templates.UnaryExprTemplate;
 import com.graphicsfuzz.generator.fuzzer.templates.VectorMatrixIndexExprTemplate;
-import com.graphicsfuzz.generator.util.GenerationParams;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -679,12 +677,10 @@ public class Templates {
       the right-most expression in a comma separated list of expressions. All expressions are
       evaluated, in order, from left to right.
       */
-    if (GenerationParams.COMMA_OPERATOR_ENABLED) {
-      for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
-        addTemplate(templates,
-              new BinaryExprTemplate(supportedBasicTypes(shadingLanguageVersion),
-                  type, type, BinOp.COMMA));
-      }
+    for (BasicType type : supportedBasicTypes(shadingLanguageVersion)) {
+      addTemplate(templates,
+            new BinaryExprTemplate(supportedBasicTypes(shadingLanguageVersion),
+                type, type, BinOp.COMMA));
     }
 
     /*
@@ -1095,18 +1091,7 @@ public class Templates {
   }
 
   private static void addTemplate(List<IExprTemplate> templates, IExprTemplate template) {
-    if (isBannedType(template.getResultType())) {
-      return;
-    }
     templates.add(template);
-  }
-
-  private static boolean isBannedType(Type type) {
-    if (!GenerationParams.NON_SQUARE_MATRICES_ENABLED) {
-      return Arrays.asList(BasicType.MAT2X3, BasicType.MAT2X4, BasicType.MAT3X2, BasicType.MAT3X4,
-            BasicType.MAT4X2, BasicType.MAT4X3).contains(type);
-    }
-    return false;
   }
 
 }

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/GenerationParams.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/GenerationParams.java
@@ -20,10 +20,6 @@ import com.graphicsfuzz.common.util.ShaderKind;
 
 public class GenerationParams {
 
-  // Expression fuzzing
-  public static final boolean COMMA_OPERATOR_ENABLED = false;
-  public static final boolean NON_SQUARE_MATRICES_ENABLED = true;
-
   // What sort of shader are we generating?
   private final ShaderKind shaderKind;
 

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_boxfilter.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_boxfilter.frag
@@ -45,7 +45,7 @@ const float weights[9] = float[9](
 void main()
 {
     vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
-    float step = 1.0 / 256.0;
+    float uvstep = 1.0 / 256.0;
 
     vec4 res = vec4(0);
 
@@ -53,7 +53,7 @@ void main()
     {
         for (int j = 0; j < 3; j++)
         {
-            res += texture(tex, coord + vec2(float(i - 1) * step, float(j - 1) * step)) * weights[i * 3 + j];
+            res += texture(tex, coord + vec2(float(i - 1) * uvstep, float(j - 1) * uvstep)) * weights[i * 3 + j];
         }
     }
 

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_trace.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_trace.frag
@@ -40,16 +40,16 @@ uniform sampler2D tex;
 void main()
 {
     int i = 0;
-    vec2 step = vec2(1.0) * (1.0 / 256.0);
+    vec2 uvstep = vec2(1.0) * (1.0 / 256.0);
     float slope = 2.0 / 256.0;
     vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
     float refh = texture(tex, coord).y;
-    coord -= step;
+    coord -= uvstep;
     refh += slope;
     float h = texture(tex, coord).y;
     while (h < refh && i < 32)
     {
-        coord -= step;
+        coord -= uvstep;
         refh += slope;
         h = texture(tex, coord).y;
         i++;


### PR DESCRIPTION
This change enables the disabled comma operator fuzzing and
also removes the unused code that could be used to disable
the use of non-rectangular matrices.