### PR TITLE
gfauto: support SPIR-V donors and references

### DIFF
--- a/gfauto/gfauto/fuzz.py
+++ b/gfauto/gfauto/fuzz.py
@@ -106,6 +106,9 @@ from gfauto.util import check_dir_exists
 DONORS_DIR = "donors"
 REFERENCES_DIR = "references"
 
+SPIRV_DONORS_DIR = "spirv_fuzz_donors"
+SPIRV_REFERENCES_DIR = "spirv_fuzz_references"
+
 REFERENCE_IMAGE_FILE_NAME = "reference.png"
 VARIANT_IMAGE_FILE_NAME = "variant.png"
 BUFFER_FILE_NAME = "buffer.bin"
@@ -356,19 +359,23 @@ def main_helper(  # pylint: disable=too-many-locals, too-many-branches, too-many
     fuzz_failures_dir = reports_dir / FUZZ_FAILURES_DIR_NAME
     references_dir = Path() / REFERENCES_DIR
     donors_dir = Path() / DONORS_DIR
-    spirv_fuzz_shaders_dir = Path() / "spirv_fuzz_shaders"
+    spirv_fuzz_references_dir = Path() / SPIRV_REFERENCES_DIR
+    spirv_fuzz_donors_dir = Path() / SPIRV_DONORS_DIR
 
     # Log a warning if there is no tool on the PATH for printing stack traces.
     prepended = util.prepend_catchsegv_if_available([], log_warning=True)
     if not allow_no_stack_traces and not prepended:
         raise AssertionError("Stopping because we cannot get stack traces.")
 
-    spirv_fuzz_shaders: List[Path] = []
+    spirv_fuzz_reference_shaders: List[Path] = []
+    spirv_fuzz_donor_shaders: List[Path] = []
     references: List[Path] = []
 
     if FuzzingTool.SPIRV_FUZZ in fuzzing_tool_pattern:
-        check_dir_exists(spirv_fuzz_shaders_dir)
-        spirv_fuzz_shaders = sorted(spirv_fuzz_shaders_dir.rglob("*.json"))
+        check_dir_exists(spirv_fuzz_references_dir)
+        check_dir_exists(spirv_fuzz_donors_dir)
+        spirv_fuzz_reference_shaders = sorted(spirv_fuzz_references_dir.rglob("*.json"))
+        spirv_fuzz_donor_shaders = sorted(spirv_fuzz_donors_dir.rglob("*.json"))
 
     if FuzzingTool.GLSL_FUZZ in fuzzing_tool_pattern:
         check_dir_exists(references_dir)
@@ -435,7 +442,8 @@ def main_helper(  # pylint: disable=too-many-locals, too-many-branches, too-many
                 reports_dir,
                 fuzz_failures_dir,
                 active_devices,
-                spirv_fuzz_shaders,
+                spirv_fuzz_reference_shaders,
+                spirv_fuzz_donor_shaders,
                 settings,
                 binary_manager,
             )

--- a/gfauto/gfauto/fuzz_spirv_test.py
+++ b/gfauto/gfauto/fuzz_spirv_test.py
@@ -466,7 +466,8 @@ def fuzz_spirv(  # pylint: disable=too-many-locals;
     reports_dir: Path,
     fuzz_failures_dir: Path,
     active_devices: List[Device],
-    spirv_fuzz_shaders: List[Path],
+    spirv_fuzz_reference_shaders: List[Path],
+    spirv_fuzz_donor_shaders: List[Path],
     settings: Settings,
     binary_manager: binaries_util.BinaryManager,
 ) -> None:
@@ -474,7 +475,9 @@ def fuzz_spirv(  # pylint: disable=too-many-locals;
     staging_name = staging_dir.name
     template_source_dir = staging_dir / "source_template"
 
-    reference_spirv_shader_job_orig_path: Path = random.choice(spirv_fuzz_shaders)
+    reference_spirv_shader_job_orig_path: Path = random.choice(
+        spirv_fuzz_reference_shaders
+    )
 
     # Copy in a randomly chosen reference.
     reference_spirv_shader_job = shader_job_util.copy(
@@ -493,7 +496,7 @@ def fuzz_spirv(  # pylint: disable=too-many-locals;
                     ).path,
                     reference_spirv_shader_job,
                     template_source_dir / test_util.VARIANT_DIR / test_util.SHADER_JOB,
-                    donor_shader_job_paths=spirv_fuzz_shaders,
+                    donor_shader_job_paths=spirv_fuzz_donor_shaders,
                     seed=str(random.getrandbits(spirv_fuzz_util.GENERATE_SEED_BITS)),
                     other_args=list(settings.extra_spirv_fuzz_generate_args)
                     + list(settings.common_spirv_args),


### PR DESCRIPTION
Adds support for different donors and references when using SPIR-V fuzz. These should be placed in spirv_fuzz_donors/ and spirv_fuzz_references/, respectively.