### PR TITLE
Add linear algebra chessboard sample shader

### DIFF
--- a/shaders/src/main/glsl/samples/320es/linear_algebra_chessboard.frag
+++ b/shaders/src/main/glsl/samples/320es/linear_algebra_chessboard.frag
@@ -1,5 +1,21 @@
 #version 320 es
 
+/*
+ * Copyright 2020 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // 32-bit floating-point numbers.
 precision highp float;
 

--- a/shaders/src/main/glsl/samples/320es/linear_algebra_chessboard.frag
+++ b/shaders/src/main/glsl/samples/320es/linear_algebra_chessboard.frag
@@ -1,0 +1,48 @@
+#version 320 es
+
+// 32-bit floating-point numbers.
+precision highp float;
+
+// Fragment color output.
+layout(location = 0) out vec4 color;
+
+void main() {
+  // Chessboard row and column corresponding to the current fragment.
+  float row = float(int(gl_FragCoord.x) / 16 + 1);
+  float column = float(int(gl_FragCoord.y) / 16 + 1);
+
+  // Scalar, vectors and matrices used in the linear algebra instructions.
+  float scalar = 1.0;
+  vec3 vector_1 = vec3(scalar++ * row, scalar++ * column, scalar++ * row * column);
+  vec3 vector_2 = vec3(scalar++ * row, scalar++ * column, scalar++ * row * column);
+  mat3x3 matrix_1 = mat3x3(scalar++ * row, scalar++ * column, scalar++ * row * column,
+                           scalar++ * row, scalar++ * column, scalar++ * row * column,
+                           scalar++ * row, scalar++ * column, scalar++ * row * column);
+  mat3x3 matrix_2 = mat3x3(scalar++ * row, scalar++ * column, scalar++ * row * column,
+                           scalar++ * row, scalar++ * column, scalar++ * row * column,
+                           scalar++ * row, scalar++ * column, scalar++ * row * column);
+
+  // OpVectorTimesScalar
+  color.rgb = scalar++ * vector_1;
+
+  // OpMatrixTimesScalar
+  color.rgb *= scalar++ * matrix_1;
+
+  // OpVectorTimesMatrix
+  color.rgb += vector_1 * matrix_1;
+
+  // OpMatrixTimesVector
+  color.rgb += matrix_1 * vector_1;
+
+  // OpMatrixTimesMatrix
+  color.rgb *= matrix_1 * matrix_2;
+
+  // OpOuterProduct
+  color.rgb *= outerProduct(vector_1, vector_2);
+
+  // OpDot
+  color.rgb *= dot(vector_1, vector_2);
+
+  // Final color
+  color = vec4(sin(color.rgb), 1.0);
+}


### PR DESCRIPTION
This PR implements a sample shader that uses linear algebra instructions.

![linear_algebra_chessboard](https://user-images.githubusercontent.com/20969363/98133056-e2df9600-1e9b-11eb-95da-b3196bb9f2d2.png)
