### PR TITLE
cov: add function coverage option

### DIFF
--- a/gfauto/gfauto/cov_from_gcov.py
+++ b/gfauto/gfauto/cov_from_gcov.py
@@ -84,6 +84,9 @@ def main() -> None:
     if not parsed_args.gcov_path:
         parser.error("Please provide gcov_path")
 
+    if parsed_args.gcov_functions and not parsed_args.gcov_uses_json:
+        parser.error("Function coverage requires using --gcov_uses_json with gcc 9+.")
+
     gcov_path: str = parsed_args.gcov_path
 
     build_dir = parsed_args.build_dir
@@ -102,9 +105,7 @@ def main() -> None:
 
     data = cov_util.GetLineCountsData(
         gcov_path=gcov_path,
-        gcov_uses_json_output=True
-        if parsed_args.gcov_functions
-        else parsed_args.gcov_uses_json,
+        gcov_uses_json_output=parsed_args.gcov_uses_json,
         build_dir=build_dir,
         gcov_prefix_dir=gcov_prefix_dir,
         num_threads=parsed_args.num_threads,

--- a/gfauto/gfauto/cov_from_gcov.py
+++ b/gfauto/gfauto/cov_from_gcov.py
@@ -71,6 +71,13 @@ def main() -> None:
         'and the coverage results will be merged. E.g. Given "--gcov_prefix_dir /cov/PROC_ID", the results from '
         "/cov/001 /cov/002 /cov/blah etc. will be computed and the results will be merged.",
     )
+    
+    parser.add_argument(
+        "--gcov_functions",
+        help="Pass to indicate that the output measures coverage of functions (instead of lines)."
+        "This requires using --gcov_uses_json and you must have gcc 9+.",
+        action="store_true",
+    )    
 
     parsed_args = parser.parse_args(sys.argv[1:])
 
@@ -87,12 +94,15 @@ def main() -> None:
     gcov_prefix_dir = os.path.abspath(gcov_prefix_dir)
     gcov_prefix_dir = os.path.normpath(gcov_prefix_dir)
 
+    gcov_tags = ["functions", "start_line", "execution_count"] if parsed_args.gcov_functions else ["lines", "line_number", "count"]
+
     data = cov_util.GetLineCountsData(
         gcov_path=gcov_path,
-        gcov_uses_json_output=parsed_args.gcov_uses_json,
+        gcov_uses_json_output=True if parsed_args.gcov_functions else parsed_args.gcov_uses_json,
         build_dir=build_dir,
         gcov_prefix_dir=gcov_prefix_dir,
         num_threads=parsed_args.num_threads,
+        gcov_json_tags=gcov_tags,
     )
 
     output_coverage_path: str = parsed_args.out

--- a/gfauto/gfauto/cov_from_gcov.py
+++ b/gfauto/gfauto/cov_from_gcov.py
@@ -71,13 +71,13 @@ def main() -> None:
         'and the coverage results will be merged. E.g. Given "--gcov_prefix_dir /cov/PROC_ID", the results from '
         "/cov/001 /cov/002 /cov/blah etc. will be computed and the results will be merged.",
     )
-    
+
     parser.add_argument(
         "--gcov_functions",
         help="Pass to indicate that the output measures coverage of functions (instead of lines)."
         "This requires using --gcov_uses_json and you must have gcc 9+.",
         action="store_true",
-    )    
+    )
 
     parsed_args = parser.parse_args(sys.argv[1:])
 

--- a/gfauto/gfauto/cov_from_gcov.py
+++ b/gfauto/gfauto/cov_from_gcov.py
@@ -94,11 +94,17 @@ def main() -> None:
     gcov_prefix_dir = os.path.abspath(gcov_prefix_dir)
     gcov_prefix_dir = os.path.normpath(gcov_prefix_dir)
 
-    gcov_tags = ["functions", "start_line", "execution_count"] if parsed_args.gcov_functions else ["lines", "line_number", "count"]
+    gcov_tags = (
+        ["functions", "start_line", "execution_count"]
+        if parsed_args.gcov_functions
+        else ["lines", "line_number", "count"]
+    )
 
     data = cov_util.GetLineCountsData(
         gcov_path=gcov_path,
-        gcov_uses_json_output=True if parsed_args.gcov_functions else parsed_args.gcov_uses_json,
+        gcov_uses_json_output=True
+        if parsed_args.gcov_functions
+        else parsed_args.gcov_uses_json,
         build_dir=build_dir,
         gcov_prefix_dir=gcov_prefix_dir,
         num_threads=parsed_args.num_threads,

--- a/gfauto/gfauto/cov_util.py
+++ b/gfauto/gfauto/cov_util.py
@@ -24,10 +24,9 @@ import subprocess
 import threading
 import typing
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from queue import Queue
 from typing import Any, Dict, List, Optional, Tuple
-from dataclasses import field
 
 from gfauto import util
 
@@ -50,7 +49,9 @@ class GetLineCountsData:  # pylint: disable=too-many-instance-attributes;
     gcno_files_queue: "Queue[DirAndItsFiles]" = dataclasses.field(default_factory=Queue)
     stdout_queue: "Queue[DirAndItsOutput]" = dataclasses.field(default_factory=Queue)
     line_counts: LineCounts = dataclasses.field(default_factory=dict)
-    gcov_json_tags: List[str] = field(default_factory=lambda: ["lines", "line_number", "count"])
+    gcov_json_tags: List[str] = field(
+        default_factory=lambda: ["lines", "line_number", "count"]
+    )
 
 
 def _thread_gcov(data: GetLineCountsData) -> None:

--- a/gfauto/gfauto/cov_util.py
+++ b/gfauto/gfauto/cov_util.py
@@ -27,6 +27,7 @@ from collections import Counter
 from dataclasses import dataclass
 from queue import Queue
 from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import field
 
 from gfauto import util
 
@@ -49,6 +50,7 @@ class GetLineCountsData:  # pylint: disable=too-many-instance-attributes;
     gcno_files_queue: "Queue[DirAndItsFiles]" = dataclasses.field(default_factory=Queue)
     stdout_queue: "Queue[DirAndItsOutput]" = dataclasses.field(default_factory=Queue)
     line_counts: LineCounts = dataclasses.field(default_factory=dict)
+    gcov_json_tags: List[str] = field(default_factory=lambda: ["lines", "line_number", "count"])
 
 
 def _thread_gcov(data: GetLineCountsData) -> None:
@@ -145,9 +147,9 @@ def _process_json_lines(data: GetLineCountsData, lines: typing.TextIO) -> None:
                 file_path = os.path.join(current_working_directory, file_path)
                 file_path = os.path.normpath(file_path)
             file_line_counts = data.line_counts.setdefault(file_path, Counter())
-            for line in file_coverage_info["lines"]:
-                line_number = line["line_number"]
-                line_count = int(line["count"])
+            for line in file_coverage_info[data.gcov_json_tags[0]]:
+                line_number = line[data.gcov_json_tags[1]]
+                line_count = int(line[data.gcov_json_tags[2]])
                 file_line_counts.update({line_number: line_count})
 
 


### PR DESCRIPTION
I added a new option: --gcov_functions to generate instead of line coverage, the function coverage when using JSON format. I did testing to check that without the new flag, the tool still generates line coverage, and with the new flag, the tool generates function coverage.