### PR TITLE
Avoid discard in live-donated code

### DIFF
--- a/build/travis/check_headers.py
+++ b/build/travis/check_headers.py
@@ -138,7 +138,7 @@ def exclude_filename(f: str):
 
 def go():
     fail = False
-    copyright_pattern = re.compile(r"Copyright 20(18|19|20) The GraphicsFuzz Project Authors")
+    copyright_pattern = re.compile(r"Copyright 20(18|19|20|21) The GraphicsFuzz Project Authors")
     generated_pattern = re.compile(r"(g|G)enerated")
 
     for (dirpath, dirnames, filenames) in os.walk(os.curdir, topdown=True):

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformation.java
@@ -96,7 +96,6 @@ public class DonateLiveCodeTransformation extends DonateCodeTransformation {
     new RemoveImmediateContinueStatements(donatedStmt);
     new RemoveImmediateCaseLabels(donatedStmt);
     new RemoveReturnStatements(donatedStmt);
-    new RemoveDiscardStatements(donatedStmt);
     return donatedStmt;
   }
 
@@ -110,6 +109,9 @@ public class DonateLiveCodeTransformation extends DonateCodeTransformation {
     if (!allowLongLoops) {
       new TruncateLoops(3 + generator.nextInt(5), addPrefix(""), tu);
     }
+    // We get rid of all discard statements from the donor, since if an injected discard is ever
+    // reached it will change the semantics of the shader.
+    new RemoveDiscardStatements(tu);
   }
 
   private boolean isLoopLimiter(String name, Type type) {

--- a/generator/src/test/java/com/graphicsfuzz/generator/util/RemoveDiscardStatementsTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/util/RemoveDiscardStatementsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.generator.util;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.ParseHelper;
+import org.junit.Test;
+
+public class RemoveDiscardStatementsTest {
+
+  @Test
+  public void testBasicRemoval() throws Exception {
+    final String shader = "#version 320 es\n"
+        + "void main() {\n"
+        + "  discard;\n"
+        + "}\n";
+    final String expected = "#version 320 es\n"
+        + "void main() {\n"
+        + "  1;\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(shader);
+    new RemoveDiscardStatements(tu);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testRemovalInSwitch() throws Exception {
+    final String shader = "#version 320 es\n"
+        + "void main() {\n"
+        + "  switch(0) {"
+        + "    case 0:"
+        + "      discard;\n"
+        + "  }\n"
+        + "}\n";
+    final String expected = "#version 320 es\n"
+        + "void main() {\n"
+        + "  switch(0) {"
+        + "    case 0:"
+        + "      1;\n"
+        + "  }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(shader);
+    new RemoveDiscardStatements(tu);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+  @Test
+  public void testRemovalInShader() throws Exception {
+    final String shader = "float patternize(vec2 uv) {\n"
+        + "    vec2 size = vec2(0.45);\n"
+        + "    vec2 st = smoothstep(size, size, uv);\n"
+        + "     switch (int(mod(gl_FragCoord.y, 5.0))) {\n"
+        + "        case 0:\n"
+        + "            return mix(pow(st.x, injectionSwitch.y), st.x, size.y);\n"
+        + "        break;\n"
+        + "        case 1:\n"
+        + "            return mix(pow(uv.y, injectionSwitch.y), st.y, size.x);\n"
+        + "        break;\n"
+        + "        case 2:\n"
+        + "            discard;\n"
+        + "        break;\n"
+        + "        case 3:\n"
+        + "            return mix(pow(uv.y, injectionSwitch.y), uv.y, size.y);\n"
+        + "        break;\n"
+        + "        case 4:\n"
+        + "            return mix(pow(st.y, injectionSwitch.y), st.x, size.x); \n"
+        + "        break;\n"
+        + "     }\n"
+        + "}\n";
+    final String expected = "float patternize(vec2 uv) {\n"
+        + "    vec2 size = vec2(0.45);\n"
+        + "    vec2 st = smoothstep(size, size, uv);\n"
+        + "     switch (int(mod(gl_FragCoord.y, 5.0))) {\n"
+        + "        case 0:\n"
+        + "            return mix(pow(st.x, injectionSwitch.y), st.x, size.y);\n"
+        + "        break;\n"
+        + "        case 1:\n"
+        + "            return mix(pow(uv.y, injectionSwitch.y), st.y, size.x);\n"
+        + "        break;\n"
+        + "        case 2:\n"
+        + "            1;\n"
+        + "        break;\n"
+        + "        case 3:\n"
+        + "            return mix(pow(uv.y, injectionSwitch.y), uv.y, size.y);\n"
+        + "        break;\n"
+        + "        case 4:\n"
+        + "            return mix(pow(st.y, injectionSwitch.y), st.x, size.x); \n"
+        + "        break;\n"
+        + "     }\n"
+        + "}\n";
+    final TranslationUnit tu = ParseHelper.parse(shader);
+    new RemoveDiscardStatements(tu);
+    CompareAsts.assertEqualAsts(expected, tu);
+  }
+
+}


### PR DESCRIPTION
Removes discard statements from a donor during live code donation, instead of only removing discards from the statements that get locally donated.  This avoids roblems where a donated statement calls a function that contains a discard.

Some tests are also refactored.

Fixes #1110.