### PR TITLE
cov: make gcov_prefix_dir optional

### DIFF
--- a/gfauto/docs/coverage.md
+++ b/gfauto/docs/coverage.md
@@ -28,10 +28,10 @@ unset GCOV_PREFIX
 # The --gcov_uses_json flag below is needed for GCC 9+.
 
 # Process the .gcda files from run1.
-gfauto_cov_from_gcov --gcov_uses_json --out run1.cov $BUILD_DIR /data/gcda_files/run1 --num_threads 32
+gfauto_cov_from_gcov --gcov_uses_json --out run1.cov $BUILD_DIR --gcov_prefix_dir /data/gcda_files/run1 --num_threads 32
 
 # Process the .gcda files from run2.
-gfauto_cov_from_gcov --gcov_uses_json --out run2.cov $BUILD_DIR /data/gcda_files/run2 --num_threads 32
+gfauto_cov_from_gcov --gcov_uses_json --out run2.cov $BUILD_DIR --gcov_prefix_dir /data/gcda_files/run2 --num_threads 32
 
 # Output just the *newly-covered* lines from run2 into "new.cov".
 gfauto_cov_new run1.cov run2.cov new.cov
@@ -151,12 +151,12 @@ cd $COV_ROOT
 # Process the .gcda files from the dEQP run into "deqp.cov".
 # Do not replace "PROC_ID" with a number; gfauto understands this special
 # directory name.
-gfauto_cov_from_gcov --gcov_uses_json --out deqp.cov $BUILD_DIR $COV_ROOT/prefix_deqp/PROC_ID --num_threads 32
+gfauto_cov_from_gcov --gcov_uses_json --out deqp.cov $BUILD_DIR --gcov_prefix_dir $COV_ROOT/prefix_deqp/PROC_ID --num_threads 32
 
 # Process the .gcda files from the gfauto run into "gfauto.cov".
 # Do not replace "PROC_ID" with a number; gfauto understands this special
 # directory name.
-gfauto_cov_from_gcov --gcov_uses_json --out gfauto.cov $BUILD_DIR $COV_ROOT/prefix_gfauto/PROC_ID --num_threads 32
+gfauto_cov_from_gcov --gcov_uses_json --out gfauto.cov $BUILD_DIR --gcov_prefix_dir $COV_ROOT/prefix_gfauto/PROC_ID --num_threads 32
 
 # Output just the *newly-covered* lines from the gfauto run into "new.cov".
 gfauto_cov_new deqp.cov gfauto.cov new.cov

--- a/gfauto/gfauto/cov_from_gcov.py
+++ b/gfauto/gfauto/cov_from_gcov.py
@@ -24,6 +24,7 @@ import os
 import pickle
 import shutil
 import sys
+from typing import Optional
 
 from gfauto import cov_util
 
@@ -64,8 +65,9 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "gcov_prefix_dir",
+        "--gcov_prefix_dir",
         type=str,
+        default=None,
         help="The GCOV_PREFIX directory that was used when running the target application. "
         'If the directory ends with "PROC_ID" then "PROC_ID" will be replaced with each directory that exists '
         'and the coverage results will be merged. E.g. Given "--gcov_prefix_dir /cov/PROC_ID", the results from '
@@ -93,9 +95,10 @@ def main() -> None:
     build_dir = os.path.abspath(build_dir)
     build_dir = os.path.normpath(build_dir)
 
-    gcov_prefix_dir = parsed_args.gcov_prefix_dir
-    gcov_prefix_dir = os.path.abspath(gcov_prefix_dir)
-    gcov_prefix_dir = os.path.normpath(gcov_prefix_dir)
+    gcov_prefix_dir: Optional[str] = parsed_args.gcov_prefix_dir
+    if gcov_prefix_dir:
+        gcov_prefix_dir = os.path.abspath(gcov_prefix_dir)
+        gcov_prefix_dir = os.path.normpath(gcov_prefix_dir)
 
     gcov_tags = (
         ["functions", "start_line", "execution_count"]
@@ -115,7 +118,7 @@ def main() -> None:
     output_coverage_path: str = parsed_args.out
 
     # Special case for "PROC_ID".
-    if "PROC_ID" in gcov_prefix_dir:
+    if gcov_prefix_dir and "PROC_ID" in gcov_prefix_dir:
         print("Detected PROC_ID in gcov_prefix_dir")
         if os.path.exists(gcov_prefix_dir):
             raise AssertionError(f"Unexpected file/directory: {gcov_prefix_dir}.")


### PR DESCRIPTION
In cov_from_gcov.py, change command line arg "gcov_prefix_dir" to an optional arg "--gcov_prefix_dir". If provided then we proceed as before:
 - in gcov_prefix_dir, create symlinks to all .gcno files from the build directory
 - iterate over all .gcno files in gcov_prefix_dir

If not provided then we just iterate over all .gcno files in the build directory.