### PR TITLE
Remove unused variable from sample shaders

### DIFF
--- a/shaders/src/main/glsl/samples/320es/stable_sampler_polar_simple.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_polar_simple.frag
@@ -84,7 +84,6 @@ float ReallyApproxNormalizedAtan2(vec2 v)
 
 vec2 polarize(vec2 coord)
 {
-    float pi = (355.0 / 113.0);
     vec2 center = coord - vec2(0.5);
     float dist = length(center);
     float angle = ReallyApproxNormalizedAtan2(center);

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_polar_warp.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_polar_warp.frag
@@ -85,7 +85,6 @@ float ReallyApproxNormalizedAtan2(vec2 v)
 
 vec2 polarize(vec2 coord)
 {
-    float pi = (355.0 / 113.0);
     vec2 center = coord - vec2(0.5);
     float dist = length(center);
     float angle = ReallyApproxNormalizedAtan2(center);


### PR DESCRIPTION
This commit removes a redundant line from stable_sampler_polar_warp.frag
that contained an unused variable.