### PR TITLE
Add new basic type groups returning functions

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/type/BasicType.java
@@ -308,6 +308,14 @@ public class BasicType extends BuiltinType {
     return result;
   }
 
+  public static List<BasicType> allSignedTypes() {
+    return new ArrayList<BasicType>(Arrays.asList(
+       INT,
+       IVEC2,
+       IVEC3,
+       IVEC4));
+  }
+
   public static List<BasicType> allUnsignedTypes() {
     return new ArrayList<BasicType>(Arrays.asList(
         UINT,
@@ -356,7 +364,7 @@ public class BasicType extends BuiltinType {
     return result;
   }
 
-  private static List<BasicType> allBoolTypes() {
+  public static List<BasicType> allBoolTypes() {
     return new ArrayList<BasicType>(Arrays.asList(
           BOOL,
           BVEC2,


### PR DESCRIPTION
Adds new utility functions to return lists of all signed integer based
types (int, ivec2, ivec3, ivec4) and changes the availability of the
boolean utility function.