### PR TITLE
Allow restricting to WGSL-supported builtins

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ShadingLanguageVersionAndKind.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ShadingLanguageVersionAndKind.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.common.typing;
+
+import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.ShaderKind;
+import java.util.Objects;
+
+public class ShadingLanguageVersionAndKind {
+  private final ShadingLanguageVersion shadingLanguageVersion;
+  private final boolean isWgslCompatible;
+  private final ShaderKind shaderKind;
+
+  public ShadingLanguageVersionAndKind(ShadingLanguageVersion shadingLanguageVersion,
+                                  boolean isWgslCompatible, ShaderKind shaderKind) {
+    this.shadingLanguageVersion = shadingLanguageVersion;
+    this.isWgslCompatible = isWgslCompatible;
+    this.shaderKind = shaderKind;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (this == that) {
+      return true;
+    }
+    if (that == null || getClass() != that.getClass()) {
+      return false;
+    }
+    ShadingLanguageVersionAndKind thatShadingLanguageVersionAndKind =
+        (ShadingLanguageVersionAndKind) that;
+    return isWgslCompatible == thatShadingLanguageVersionAndKind.isWgslCompatible
+        && Objects.equals(shadingLanguageVersion,
+        thatShadingLanguageVersionAndKind.shadingLanguageVersion)
+        && shaderKind == thatShadingLanguageVersionAndKind.shaderKind;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(shadingLanguageVersion, isWgslCompatible, shaderKind);
+  }
+}

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
@@ -172,7 +172,7 @@ public class Typer extends ScopeTrackingVisitor {
     // Next, see if there is a builtin with a matching prototype.
     final Optional<Type> maybeMatchingBuiltinFunctionReturn =
         lookForMatchingFunction(functionCallExpr,
-        TyperHelper.getBuiltins(tu.getShadingLanguageVersion(), tu.getShaderKind())
+        TyperHelper.getBuiltins(tu.getShadingLanguageVersion(), false, tu.getShaderKind())
             .get(functionCallExpr.getCallee()));
     if (maybeMatchingBuiltinFunctionReturn.isPresent()) {
       types.put(functionCallExpr, maybeMatchingBuiltinFunctionReturn.get());
@@ -510,7 +510,7 @@ public class Typer extends ScopeTrackingVisitor {
       result.addAll(userDefinedFunctions.get(name));
     }
     final Map<String, List<FunctionPrototype>> builtins =
-        TyperHelper.getBuiltins(tu.getShadingLanguageVersion(), tu.getShaderKind());
+        TyperHelper.getBuiltins(tu.getShadingLanguageVersion(), false, tu.getShaderKind());
     if (builtins.containsKey(name)) {
       result.addAll(builtins.get(name));
     }

--- a/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
+++ b/ast/src/test/java/com/graphicsfuzz/common/typing/TyperTest.java
@@ -1237,8 +1237,9 @@ public class TyperTest {
     }
     result.append("#endif\n");
     int counter = 0;
-    for (String name : TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind).keySet()) {
-      for (FunctionPrototype fp : TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind)
+    for (String name :
+        TyperHelper.getBuiltins(shadingLanguageVersion, false, shaderKind).keySet()) {
+      for (FunctionPrototype fp : TyperHelper.getBuiltins(shadingLanguageVersion, false, shaderKind)
           .get(name)) {
         counter++;
         result.append(fp.getReturnType() + " test" + counter + "_" + fp.getName() + "(");

--- a/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/SideEffectChecker.java
@@ -43,10 +43,10 @@ public class SideEffectChecker {
 
       @Override
       public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
-        if (TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind)
+        if (TyperHelper.getBuiltins(shadingLanguageVersion, false, shaderKind)
             .containsKey(functionCallExpr.getCallee())) {
           for (FunctionPrototype p :
-              TyperHelper.getBuiltins(shadingLanguageVersion, shaderKind)
+              TyperHelper.getBuiltins(shadingLanguageVersion, false, shaderKind)
                   .get(functionCallExpr.getCallee())) {
             // We check each argument of the built-in's prototypes to see if they require lvalues -
             // if so, they can cause side effects.

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/Fuzzer.java
@@ -287,6 +287,7 @@ public class Fuzzer {
 
   private Stream<IExprTemplate> availableTemplatesFromContext() {
     return Stream.concat(availableTemplatesFromScope(shadingLanguageVersion,
+        generationParams.isWgslCompatible(),
         generationParams.getShaderKind(),
         fuzzingContext.getCurrentScope()),
       fuzzingContext.getFunctionPrototypes().stream().map(FunctionCallExprTemplate::new));
@@ -294,10 +295,13 @@ public class Fuzzer {
 
   public static Stream<IExprTemplate> availableTemplatesFromScope(
       ShadingLanguageVersion shadingLanguageVersion,
+      boolean isWgslCompatible,
       ShaderKind shaderKind,
       Scope scope) {
-    return Stream.concat(Templates.get(shadingLanguageVersion, shaderKind).stream(),
-        scope.namesOfAllVariablesInScope()
+    return Stream.concat(Templates.get(shadingLanguageVersion,
+            isWgslCompatible,
+            shaderKind)
+            .stream(), scope.namesOfAllVariablesInScope()
             .stream()
             .map(item -> new VariableIdentifierExprTemplate(item, scope.lookupType(item),
                 scope.lookupScopeEntry(item).hasParameterDecl())));
@@ -606,6 +610,7 @@ public class Fuzzer {
     // Call this from main to produce a list of templates
     List<IExprTemplate> templates = new ArrayList<>();
     templates.addAll(Templates.get(ShadingLanguageVersion.fromVersionString(args[0]),
+        false,
         ShaderKind.fromExtension(args[1])));
     Collections.sort(templates, new Comparator<IExprTemplate>() {
       @Override

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGenerator.java
@@ -235,7 +235,7 @@ public final class OpaqueExpressionGenerator {
     if (type != BasicType.FLOAT) {
       return Optional.empty();
     }
-    if (!shadingLanguageVersion.supportedDeterminant()) {
+    if (!shadingLanguageVersion.supportedDeterminant() || generationParams.isWgslCompatible()) {
       return Optional.empty();
     }
     // If true, we will make an upper triangular matrix - otherwise it will be lower triangular.

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/InterchangeExprMutationFinder.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticschanging/InterchangeExprMutationFinder.java
@@ -63,7 +63,8 @@ public class InterchangeExprMutationFinder extends Expr2ExprMutationFinder {
   private Expr applyInterchange(Expr expr, List<Type> argumentTypes) {
     final Type resultType = typer.lookupType(expr).getWithoutQualifiers();
     List<IExprTemplate> templates = Fuzzer.availableTemplatesFromScope(
-        getTranslationUnit().getShadingLanguageVersion(), getTranslationUnit().getShaderKind(),
+        getTranslationUnit().getShadingLanguageVersion(), false,
+            getTranslationUnit().getShaderKind(),
         getCurrentScope())
         // Ignore templates that require l-values, so that invalidity is not too likely
         .filter(InterchangeExprMutationFinder::doesNotRequireLvalue)

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Generate.java
@@ -138,6 +138,11 @@ public class Generate {
             + "shader validation as Vulkan target.")
         .action(Arguments.storeTrue());
 
+    parser.addArgument("--wgsl-compatible")
+        .help("Try to avoid generating code that will not be supported by pathways to WGSL (e.g. "
+            + "via naga, or glslang + tint).")
+        .action(Arguments.storeTrue());
+
     parser.addArgument("--max-uniforms")
         .help("Ensure that generated shaders have no more than the given number of uniforms; "
             + "required for Vulkan compatibility.")
@@ -309,8 +314,12 @@ public class Generate {
 
     final GenerationParams generationParams =
         args.getSmall()
-            ? GenerationParams.small(shaderKind, args.getAddInjectionSwitch())
-            : GenerationParams.normal(shaderKind, args.getAddInjectionSwitch());
+            ? GenerationParams.small(shaderKind,
+                args.getIsWgslCompatible(),
+                args.getAddInjectionSwitch())
+            : GenerationParams.normal(shaderKind,
+                args.getIsWgslCompatible(),
+                args.getAddInjectionSwitch());
 
     final TransformationProbabilities probabilities =
         createProbabilities(args, random);
@@ -400,7 +409,8 @@ public class Generate {
         enabledTransformations,
         !ns.getBoolean("no_injection_switch"),
         Optional.ofNullable(shaderStage),
-        ns.getFloat("push_constant_probability")
+        ns.getFloat("push_constant_probability"),
+        ns.getBoolean("wgsl_compatible")
     );
   }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/GeneratorArguments.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/GeneratorArguments.java
@@ -33,6 +33,7 @@ public class GeneratorArguments {
   private final boolean addInjectionSwitch;
   private final Optional<ShaderKind> onlyFuzzShaderStage;
   private final float pushConstantProbability;
+  private final boolean isWgslCompatible;
 
   public GeneratorArguments(
         boolean small,
@@ -45,7 +46,8 @@ public class GeneratorArguments {
         EnabledTransformations enabledTransformations,
         boolean addInjectionSwitch,
         Optional<ShaderKind> onlyFuzzShaderStage,
-        float pushConstantProbability) {
+        float pushConstantProbability,
+        boolean isWgslCompatible) {
     this.small = small;
     this.allowLongLoops = allowLongLoops;
     this.singlePass = singlePass;
@@ -57,6 +59,7 @@ public class GeneratorArguments {
     this.addInjectionSwitch = addInjectionSwitch;
     this.onlyFuzzShaderStage = onlyFuzzShaderStage;
     this.pushConstantProbability = pushConstantProbability;
+    this.isWgslCompatible = isWgslCompatible;
   }
 
   public Optional<ShaderKind> getOnlyFuzzShaderStage() {
@@ -107,6 +110,10 @@ public class GeneratorArguments {
     return pushConstantProbability;
   }
 
+  public boolean getIsWgslCompatible() {
+    return isWgslCompatible;
+  }
+
   @Override
   public final String toString() {
     final StringBuilder sb = new StringBuilder();
@@ -120,6 +127,7 @@ public class GeneratorArguments {
     sb.append("enabledTransformations: " + enabledTransformations + "\n");
     sb.append("addInjectionSwitch: " + addInjectionSwitch + "\n");
     sb.append("pushConstantProbability: " + pushConstantProbability + "\n");
+    sb.append("isWgslCompatible: " + isWgslCompatible + "\n");
     return sb.toString();
   }
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/tool/Mutate.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/tool/Mutate.java
@@ -147,6 +147,7 @@ public class Mutate {
     List<? extends Mutation> mutations;
     int tries = 0;
     final GenerationParams generationParams = GenerationParams.normal(tu.getShaderKind(),
+        false,
         true);
     final List<Supplier<MutationFinder<?>>> mutationFinders = Arrays.asList(
 

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -327,7 +327,7 @@ public abstract class DonateCodeTransformation implements ITransformation {
       @Override
       public void visitFunctionCallExpr(FunctionCallExpr functionCallExpr) {
         super.visitFunctionCallExpr(functionCallExpr);
-        if (!TyperHelper.getBuiltins(tu.getShadingLanguageVersion(), tu.getShaderKind())
+        if (!TyperHelper.getBuiltins(tu.getShadingLanguageVersion(), false, tu.getShaderKind())
             .containsKey(functionCallExpr.getCallee())) {
           functionCallExpr.setCallee(addPrefix(functionCallExpr.getCallee()));
         }

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/GenerationParams.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/GenerationParams.java
@@ -23,6 +23,8 @@ public class GenerationParams {
   // What sort of shader are we generating?
   private final ShaderKind shaderKind;
 
+  private final boolean isWgslCompatible;
+
   // Can we rely in 'injectionSwitch' being defined?
   private final boolean injectionSwitchIsAvailable;
 
@@ -41,14 +43,19 @@ public class GenerationParams {
   private int maxInjectedSwitchCasesInOriginalCode = 10;
   private int maxInjectedSwitchCasesAfterOriginalCode = 3;
 
-  private GenerationParams(ShaderKind shaderKind, boolean injectionSwitchIsAvailable) {
+  private GenerationParams(ShaderKind shaderKind, boolean isWgslCompatible,
+                           boolean injectionSwitchIsAvailable) {
     // Prevent external construction
     this.shaderKind = shaderKind;
+    this.isWgslCompatible = isWgslCompatible;
     this.injectionSwitchIsAvailable = injectionSwitchIsAvailable;
   }
 
-  public static GenerationParams normal(ShaderKind shaderKind, boolean injectionSwitchAvailable) {
-    final GenerationParams result = new GenerationParams(shaderKind, injectionSwitchAvailable);
+  public static GenerationParams normal(ShaderKind shaderKind,
+                                        boolean isWgslCompatible,
+                                        boolean injectionSwitchAvailable) {
+    final GenerationParams result = new GenerationParams(shaderKind, isWgslCompatible,
+        injectionSwitchAvailable);
     result.maxDepthForGeneratedExpr = 3;
     result.maxStructNestingDepth = 2;
     result.maxStructFields = 8;
@@ -59,8 +66,11 @@ public class GenerationParams {
     return result;
   }
 
-  public static GenerationParams small(ShaderKind shaderKind, boolean injectionSwitchAvailable) {
-    GenerationParams result = new GenerationParams(shaderKind, injectionSwitchAvailable);
+  public static GenerationParams small(ShaderKind shaderKind,
+                                       boolean isWgslCompatible,
+                                       boolean injectionSwitchAvailable) {
+    GenerationParams result = new GenerationParams(shaderKind, isWgslCompatible,
+        injectionSwitchAvailable);
     result.maxDepthForGeneratedExpr = 2;
     result.maxStructNestingDepth = 1;
     result.maxStructFields = 3;
@@ -71,8 +81,11 @@ public class GenerationParams {
     return result;
   }
 
-  public static GenerationParams large(ShaderKind shaderKind, boolean injectionSwitchAvailable) {
-    GenerationParams result = new GenerationParams(shaderKind, injectionSwitchAvailable);
+  public static GenerationParams large(ShaderKind shaderKind,
+                                       boolean isWgslCompatible,
+                                       boolean injectionSwitchAvailable) {
+    GenerationParams result = new GenerationParams(shaderKind, isWgslCompatible,
+        injectionSwitchAvailable);
     result.maxDepthForGeneratedExpr = 5;
     result.maxStructNestingDepth = 4;
     result.maxStructFields = 7;
@@ -85,6 +98,10 @@ public class GenerationParams {
 
   public ShaderKind getShaderKind() {
     return shaderKind;
+  }
+
+  public boolean isWgslCompatible() {
+    return isWgslCompatible;
   }
 
   public boolean getInjectionSwitchIsAvailable() {

--- a/generator/src/main/java/com/graphicsfuzz/generator/util/RestrictFragmentShaderColors.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/RestrictFragmentShaderColors.java
@@ -165,6 +165,7 @@ public class RestrictFragmentShaderColors {
         super.visitFunctionCallExpr(functionCallExpr);
         Set<String> acceptableFunctionNames = new HashSet<>();
         acceptableFunctionNames.addAll(TyperHelper.getBuiltins(shadingLanguageVersion,
+            false,
             ShaderKind.FRAGMENT).keySet());
         acceptableFunctionNames.add(Constants.GLF_FUZZED);
         acceptableFunctionNames.add(Constants.GLF_IDENTITY);

--- a/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/FuzzerTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/FuzzerTest.java
@@ -60,7 +60,10 @@ public class FuzzerTest {
         if (variableIdentifierExpr.getName().equals("doitWhenYouReachMyUse")) {
           Expr expr = new Fuzzer(new FuzzingContext(getCurrentScope()),
               ShadingLanguageVersion.ESSL_100,
-              new ZeroCannedRandom(), GenerationParams.normal(ShaderKind.FRAGMENT, true), "prefix")
+              new ZeroCannedRandom(), GenerationParams.normal(ShaderKind.FRAGMENT,
+              false,
+              true),
+              "prefix")
               .fuzzExpr(new StructNameType("B"), false, false, 0);
           assertTrue(expr instanceof TypeConstructorExpr);
           // Sanity check a few things about the result

--- a/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGeneratorTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/fuzzer/OpaqueExpressionGeneratorTest.java
@@ -109,7 +109,8 @@ public class OpaqueExpressionGeneratorTest {
     // We declare only one variable and generate a number of assignments to this variable,
     // instead of making multiple declarations and assignments.
     // numberOfAssignments should be large enough to get high coverage, e.g. 1000.
-    final GenerationParams generationParams = GenerationParams.large(ShaderKind.FRAGMENT, true);
+    final GenerationParams generationParams = GenerationParams.large(ShaderKind.FRAGMENT, false,
+        true);
     final List<Stmt> newStmts = new ArrayList<>();
     newStmts.add(new DeclarationStmt(new VariablesDeclaration(basicType,
         new VariableDeclInfo("x", null,
@@ -134,7 +135,8 @@ public class OpaqueExpressionGeneratorTest {
   public void testWaysToMakeZeroAndOne() throws Exception {
 
     final IRandom generator = new RandomWrapper(0);
-    final GenerationParams generationParams = GenerationParams.large(ShaderKind.FRAGMENT, true);
+    final GenerationParams generationParams = GenerationParams.large(ShaderKind.FRAGMENT, false,
+        true);
 
     // These are the shading language versions we support best, so test them thoroughly.
     for (ShadingLanguageVersion shadingLanguageVersion : Arrays.asList(

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/AddSwitchMutationFinderTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/AddSwitchMutationFinderTest.java
@@ -59,7 +59,7 @@ public class AddSwitchMutationFinderTest {
       final List<AddSwitchMutation> mutations =
           new AddSwitchMutationFinder(tu,
               new RandomWrapper(i),
-              GenerationParams.normal(tu.getShaderKind(), false))
+              GenerationParams.normal(tu.getShaderKind(), false, false))
               .findMutations();
       mutations.get(0).apply();
       if (mutations.size() > 1) {
@@ -92,7 +92,7 @@ public class AddSwitchMutationFinderTest {
       final List<AddSwitchMutation> mutations =
           new AddSwitchMutationFinder(tu,
               new RandomWrapper(i),
-              GenerationParams.normal(tu.getShaderKind(), false))
+              GenerationParams.normal(tu.getShaderKind(), false, false))
               .findMutations();
       for (AddSwitchMutation mutation : mutations) {
         mutation.apply();
@@ -129,7 +129,8 @@ public class AddSwitchMutationFinderTest {
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(program);
 
-    final GenerationParams generationParams = GenerationParams.normal(tu.getShaderKind(), false);
+    final GenerationParams generationParams = GenerationParams.normal(tu.getShaderKind(), false,
+        false);
     generationParams.setMaxInjectedSwitchCasesAfterOriginalCode(10);
     for (int i = 0; i < limit; i++) {
       final List<AddSwitchMutation> mutations =

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/AddWrappingConditionalMutationFinderTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/AddWrappingConditionalMutationFinderTest.java
@@ -58,7 +58,7 @@ public class AddWrappingConditionalMutationFinderTest {
       final List<AddWrappingConditionalMutation> mutations =
           new AddWrappingConditionalMutationFinder(tu,
               new RandomWrapper(i),
-              GenerationParams.normal(tu.getShaderKind(), false))
+              GenerationParams.normal(tu.getShaderKind(), false, false))
           .findMutations();
       mutations.get(0).apply();
       if (mutations.size() > 1) {

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/IdentityMutationFinderTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/IdentityMutationFinderTest.java
@@ -69,7 +69,7 @@ public class IdentityMutationFinderTest {
     final IdentityMutationFinder identityMutationFinder = new IdentityMutationFinder(
         tu,
         new CannedRandom(),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     final List<Expr2ExprMutation> mutations = identityMutationFinder.findMutations();
     assertEquals(9, mutations.size());
   }
@@ -92,7 +92,7 @@ public class IdentityMutationFinderTest {
     final IdentityMutationFinder identityMutationFinder = new IdentityMutationFinder(
         tu,
         new CannedRandom(),
-        GenerationParams.normal(ShaderKind.FRAGMENT, false));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, false));
     final List<Expr2ExprMutation> mutations = identityMutationFinder.findMutations();
     // The loop guard is untouchable as this is GLSL 100.
     assertEquals(4, mutations.size());
@@ -111,7 +111,7 @@ public class IdentityMutationFinderTest {
     final IdentityMutationFinder identityMutationFinder = new IdentityMutationFinder(
         tu,
         new CannedRandom(),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     final List<Expr2ExprMutation> mutations = identityMutationFinder.findMutations();
     // Loop guard is untouchable as this is GLSL 100.
     // LHS of "j = j + 1" is also untouchable.
@@ -135,7 +135,7 @@ public class IdentityMutationFinderTest {
     final IdentityMutationFinder identityMutationFinder = new IdentityMutationFinder(
         tu,
         new CannedRandom(),
-        GenerationParams.normal(ShaderKind.FRAGMENT, false));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, false));
     final List<Expr2ExprMutation> mutations = identityMutationFinder.findMutations();
     assertEquals(2, mutations.size());
   }
@@ -205,7 +205,7 @@ public class IdentityMutationFinderTest {
     final IdentityMutationFinder identityMutationFinder = new IdentityMutationFinder(
         tu,
         new RandomWrapper(0),
-        GenerationParams.normal(ShaderKind.FRAGMENT, false));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, false));
     final List<Expr2ExprMutation> mutations = identityMutationFinder.findMutations();
     mutations.forEach(Mutation::apply);
     assertTrue(shaderIsValid(tu));
@@ -232,7 +232,7 @@ public class IdentityMutationFinderTest {
         + "}");
     final List<Expr2ExprMutation> mutations =
         new IdentityMutationFinder(tu, new RandomWrapper(0),
-            GenerationParams.normal(ShaderKind.FRAGMENT, false))
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, false))
             .findMutations();
     assertEquals(2, mutations.size());
     mutations.get(0).apply();
@@ -254,7 +254,7 @@ public class IdentityMutationFinderTest {
     for (int i = 0; i < 20; i++) {
       final TranslationUnit tu = ParseHelper.parse(program);
       IdentityMutationFinder identityMutationFinder = new IdentityMutationFinder(tu,
-          new RandomWrapper(i), GenerationParams.small(ShaderKind.FRAGMENT, false));
+          new RandomWrapper(i), GenerationParams.small(ShaderKind.FRAGMENT, false, false));
       identityMutationFinder.findMutations().forEach(Expr2ExprMutation::apply);
       new StandardVisitor() {
         @Override
@@ -327,7 +327,7 @@ public class IdentityMutationFinderTest {
     for (int i = 0; i < 20; i++) {
       final TranslationUnit tu = ParseHelper.parse(program);
       new IdentityMutationFinder(tu,
-          new RandomWrapper(i), GenerationParams.normal(ShaderKind.FRAGMENT, true))
+          new RandomWrapper(i), GenerationParams.normal(ShaderKind.FRAGMENT, false, true))
           .findMutations()
           .forEach(Expr2ExprMutation::apply);
       final File shaderJobFile = temporaryFolder.newFile("shader" + i + ".json");
@@ -354,7 +354,7 @@ public class IdentityMutationFinderTest {
     for (int i = 0; i < 20; i++) {
       final TranslationUnit tu = ParseHelper.parse(program);
       new IdentityMutationFinder(tu,
-          new RandomWrapper(i), GenerationParams.normal(ShaderKind.FRAGMENT, false))
+          new RandomWrapper(i), GenerationParams.normal(ShaderKind.FRAGMENT, false, false))
           .findMutations()
           .forEach(Expr2ExprMutation::apply);
       final File shaderJobFile = temporaryFolder.newFile("shader" + i + ".json");

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/StructificationMutationFinderTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/StructificationMutationFinderTest.java
@@ -57,7 +57,7 @@ public class StructificationMutationFinderTest {
     // leads to valid shaders.
     for (int i = 0; i < limit; i++) {
       new StructificationMutationFinder(tu, new RandomWrapper(i),
-          GenerationParams.normal(tu.getShaderKind(), true))
+          GenerationParams.normal(tu.getShaderKind(), false, true))
           .findMutations()
           .get(0).apply();
 

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/StructificationMutationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/StructificationMutationTest.java
@@ -130,7 +130,7 @@ public class StructificationMutationTest {
         tu,
         new IdGenerator(),
         generator,
-        GenerationParams.normal(ShaderKind.FRAGMENT, true))
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true))
         .apply();
     // The generator should have used up all its values by now.
     assertTrue(generator.isExhausted());
@@ -195,7 +195,7 @@ public class StructificationMutationTest {
         0 /* instead it is FLOAT */);
     List<StructDefinitionType> structs = StructificationMutation.randomStruct(0, generator,
         new IdGenerator(), ShadingLanguageVersion.GLSL_440,
-        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     assertEquals(3, structs.size());
     StructDefinitionType enclosingStruct = structs.get(0);
     assertEquals(enclosingStruct.getFieldName(0), "_f0");
@@ -223,7 +223,7 @@ public class StructificationMutationTest {
       List<StructDefinitionType> structs =
           StructificationMutation.randomStruct(0, new RandomWrapper(0),
               new IdGenerator(), ShadingLanguageVersion.ESSL_100,
-              GenerationParams.normal(ShaderKind.FRAGMENT, true));
+              GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
       checkDisjointSubStructs(structs.get(0), structs);
     }
 

--- a/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/tool/GenerateTest.java
@@ -171,11 +171,11 @@ public class GenerateTest {
     final TranslationUnit tu = ParseHelper.parse(reference);
     new DonateLiveCodeTransformation(TransformationProbabilities
         .likelyDonateLiveCode()::donateLiveCodeAtStmt,
-        donorsFolder, GenerationParams.normal(ShaderKind.FRAGMENT, true), false)
+        donorsFolder, GenerationParams.normal(ShaderKind.FRAGMENT, false, true), false)
         .apply(tu,
             TransformationProbabilities.likelyDonateLiveCode(),
             new RandomWrapper(0),
-            GenerationParams.normal(ShaderKind.FRAGMENT, true));
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
   }
 
   @Test

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/AddLiveOutputWriteTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/AddLiveOutputWriteTransformationTest.java
@@ -92,7 +92,7 @@ public class AddLiveOutputWriteTransformationTest {
     new AddLiveOutputWriteTransformation().apply(tu,
         TransformationProbabilities.onlyAddLiveFragColorWrites(),
         new RandomWrapper(seed),
-        GenerationParams.normal(shaderKind, true));
+        GenerationParams.normal(shaderKind, false, true));
   }
 
   private String getBackedUpVariableName(TranslationUnit tu) {

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/AddWrappingConditionalTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/AddWrappingConditionalTransformationTest.java
@@ -42,7 +42,7 @@ public class AddWrappingConditionalTransformationTest {
     new AddWrappingConditionalTransformation().apply(tu, TransformationProbabilities.onlyWrap(),
         new CannedRandom(0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     checkStructuralProperties(tu);
     TranslationUnit tu2 = ParseHelper.parse(PrettyPrinterVisitor.prettyPrintAsString(tu));
     checkStructuralProperties(tu2);

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateDeadCodeTransformationTest.java
@@ -62,7 +62,7 @@ public class DonateDeadCodeTransformationTest {
 
   private DonateDeadCodeTransformation getDummyTransformationObject() {
     return new DonateDeadCodeTransformation(IRandom::nextBoolean, testFolder.getRoot(),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
   }
 
   @Test
@@ -438,7 +438,7 @@ public class DonateDeadCodeTransformationTest {
       // Do live code donation.
       final DonateDeadCodeTransformation transformation =
           new DonateDeadCodeTransformation(IRandom::nextBoolean, donors,
-              GenerationParams.normal(ShaderKind.FRAGMENT, false));
+              GenerationParams.normal(ShaderKind.FRAGMENT, false, false));
 
       assert referenceShaderJob.getFragmentShader().isPresent();
 
@@ -446,7 +446,7 @@ public class DonateDeadCodeTransformationTest {
           referenceShaderJob.getFragmentShader().get(),
           TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
           new RandomWrapper(seed),
-          GenerationParams.normal(ShaderKind.FRAGMENT, false)
+          GenerationParams.normal(ShaderKind.FRAGMENT, false, false)
       );
 
       if (result) {

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/DonateLiveCodeTransformationTest.java
@@ -81,7 +81,7 @@ public class DonateLiveCodeTransformationTest {
 
   private DonateLiveCodeTransformation getDummyTransformationObject() {
     return new DonateLiveCodeTransformation(IRandom::nextBoolean, testFolder.getRoot(),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true),
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true),
         false);
   }
 
@@ -386,7 +386,7 @@ public class DonateLiveCodeTransformationTest {
 
       final DonateLiveCodeTransformation donateLiveCode =
           new DonateLiveCodeTransformation(item -> true, testFolder.getRoot(),
-              GenerationParams.normal(ShaderKind.FRAGMENT, true),
+              GenerationParams.normal(ShaderKind.FRAGMENT, false, true),
               false);
 
       final TranslationUnit referenceTu = ParseHelper.parse(reference);
@@ -460,7 +460,7 @@ public class DonateLiveCodeTransformationTest {
 
       identityTransformation.apply(referenceTu, TransformationProbabilities.onlyMutateExpressions(),
           generator,
-          GenerationParams.large(ShaderKind.FRAGMENT, true)
+          GenerationParams.large(ShaderKind.FRAGMENT, false, true)
       );
     }
   }
@@ -523,7 +523,7 @@ public class DonateLiveCodeTransformationTest {
 
     DonateLiveCodeTransformation transformation =
         new DonateLiveCodeTransformation(IRandom::nextBoolean, donors,
-            GenerationParams.normal(ShaderKind.FRAGMENT, true), false);
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true), false);
 
     assert referenceShaderJob.getFragmentShader().isPresent();
 
@@ -531,7 +531,7 @@ public class DonateLiveCodeTransformationTest {
         referenceShaderJob.getFragmentShader().get(),
         TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
         new RandomWrapper(0),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true)
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true)
     );
 
     Assert.assertTrue(result);
@@ -589,7 +589,7 @@ public class DonateLiveCodeTransformationTest {
 
     DonateLiveCodeTransformation transformation =
         new DonateLiveCodeTransformation(IRandom::nextBoolean, donors,
-            GenerationParams.normal(ShaderKind.FRAGMENT, true), false);
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true), false);
 
     assert referenceShaderJob.getFragmentShader().isPresent();
 
@@ -597,7 +597,7 @@ public class DonateLiveCodeTransformationTest {
         referenceShaderJob.getFragmentShader().get(),
         TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
         new RandomWrapper(0),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true)
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true)
     );
 
     Assert.assertTrue(result);
@@ -673,7 +673,7 @@ public class DonateLiveCodeTransformationTest {
       // Do live code donation.
       DonateLiveCodeTransformation transformation =
           new DonateLiveCodeTransformation(IRandom::nextBoolean, donors,
-              GenerationParams.normal(ShaderKind.FRAGMENT, true), false);
+              GenerationParams.normal(ShaderKind.FRAGMENT, false, true), false);
 
       assert referenceShaderJob.getFragmentShader().isPresent();
 
@@ -681,7 +681,7 @@ public class DonateLiveCodeTransformationTest {
           referenceShaderJob.getFragmentShader().get(),
           TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
           new RandomWrapper(seed),
-          GenerationParams.normal(ShaderKind.FRAGMENT, true)
+          GenerationParams.normal(ShaderKind.FRAGMENT, false, true)
       );
 
       if (!result) {
@@ -760,7 +760,7 @@ public class DonateLiveCodeTransformationTest {
       // Do live code donation.
       final DonateLiveCodeTransformation transformation =
           new DonateLiveCodeTransformation(IRandom::nextBoolean, donors,
-              GenerationParams.normal(ShaderKind.FRAGMENT, true), false);
+              GenerationParams.normal(ShaderKind.FRAGMENT, false, true), false);
 
       assert referenceShaderJob.getFragmentShader().isPresent();
 
@@ -768,7 +768,7 @@ public class DonateLiveCodeTransformationTest {
           referenceShaderJob.getFragmentShader().get(),
           TransformationProbabilities.onlyLiveCodeAlwaysSubstitute(),
           new RandomWrapper(seed),
-          GenerationParams.normal(ShaderKind.FRAGMENT, true)
+          GenerationParams.normal(ShaderKind.FRAGMENT, false, true)
       );
 
       // Check that the resulting shader typechecks.

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/SplitForLoopTransformationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/SplitForLoopTransformationTest.java
@@ -156,7 +156,7 @@ public class SplitForLoopTransformationTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     assertEquals(1, countForLoops(tu));
     new SplitForLoopTransformation().apply(tu, TransformationProbabilities.onlySplitLoops(),
-        new RandomWrapper(0), GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        new RandomWrapper(0), GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     assertEquals(2, countForLoops(tu));
   }
 
@@ -167,7 +167,7 @@ public class SplitForLoopTransformationTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     assertEquals(1, countForLoops(tu));
     new SplitForLoopTransformation().apply(tu, TransformationProbabilities.onlySplitLoops(),
-        new RandomWrapper(0), GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        new RandomWrapper(0), GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     assertEquals(1, countForLoops(tu));
   }
 

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/donation/CheckDonorVersionMatchesTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/donation/CheckDonorVersionMatchesTest.java
@@ -60,6 +60,7 @@ public class CheckDonorVersionMatchesTest {
     fileOperations.writeShaderJobFile(es310ShaderJob, reference);
 
     final GenerationParams normalGenerationParams = GenerationParams.normal(ShaderKind.FRAGMENT,
+        false,
         false);
     final DonateLiveCodeTransformation transformation = new DonateLiveCodeTransformation(
         TransformationProbabilities.ALWAYS::donateLiveCodeAtStmt,

--- a/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
@@ -143,7 +143,7 @@ public class GeneratorUnitTest {
     testTransformationMultiVersions(() -> new DonateDeadCodeTransformation(
         TransformationProbabilities.likelyDonateDeadCode()::donateDeadCodeAtStmt,
             Util.getDonorsFolder(),
-            GenerationParams.normal(ShaderKind.FRAGMENT, true)),
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true)),
         TransformationProbabilities.likelyDonateDeadCode(),
         "donatedead",
         Arrays.asList("bubblesort_flag.json", "squares.json", "mandelbrot_zoom.json"),
@@ -156,7 +156,7 @@ public class GeneratorUnitTest {
     testTransformationMultiVersions(() -> new DonateLiveCodeTransformation(
         TransformationProbabilities.likelyDonateLiveCode()::donateLiveCodeAtStmt,
             Util.getDonorsFolder(),
-            GenerationParams.normal(ShaderKind.FRAGMENT, true),
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true),
         false), TransformationProbabilities.likelyDonateLiveCode(),
         "donatelive",
         Collections.singletonList("squares.json"),
@@ -330,7 +330,7 @@ public class GeneratorUnitTest {
     for (ITransformation transformation : transformations) {
       transformation.apply(tu, probabilities,
           generator,
-          GenerationParams.normal(ShaderKind.FRAGMENT, true));
+          GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
     }
     Generate.addInjectionSwitchIfNotPresent(tu);
     Generate.setInjectionSwitch(shaderJob.getPipelineInfo());
@@ -395,7 +395,7 @@ public class GeneratorUnitTest {
     testTransformation(Collections.singletonList(() -> new DonateDeadCodeTransformation(
             TransformationProbabilities.likelyDonateDeadCode()::donateDeadCodeAtStmt,
             donors,
-            GenerationParams.normal(ShaderKind.FRAGMENT, true))),
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true))),
         TransformationProbabilities.likelyDonateDeadCode(),
         "donatedead", Collections.emptyList(),
         new File[] { reference });

--- a/tester/src/test/java/com/graphicsfuzz/tester/MiscellaneousGenerateThenReduceTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/MiscellaneousGenerateThenReduceTest.java
@@ -69,7 +69,7 @@ public class MiscellaneousGenerateThenReduceTest {
     new AddWrappingConditionalTransformation().apply(tu,
         TransformationProbabilities.onlyWrap(),
         new SameValueRandom(false, 0, 0L),
-        GenerationParams.normal(ShaderKind.FRAGMENT, true));
+        GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
 
     System.out.println(PrettyPrinterVisitor.prettyPrintAsString(tu));
 

--- a/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
@@ -161,7 +161,7 @@ public class ReducerUnitTest {
       for (int i = 0; i < 4; i++) {
         getTransformation(transformationsCopy, generator).apply(
             fragmentShader, TransformationProbabilities.DEFAULT_PROBABILITIES,
-            generator, GenerationParams.normal(ShaderKind.FRAGMENT, true));
+            generator, GenerationParams.normal(ShaderKind.FRAGMENT, false, true));
       }
       if (new StatsVisitor(fragmentShader).getNumNodes() <= maxAstNodes) {
         return shaderJob;
@@ -186,11 +186,11 @@ public class ReducerUnitTest {
     result.add(() -> new DonateDeadCodeTransformation(
             TransformationProbabilities.DEFAULT_PROBABILITIES::donateDeadCodeAtStmt,
             Util.getDonorsFolder(),
-            GenerationParams.normal(ShaderKind.FRAGMENT, true)));
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true)));
     result.add(() -> new DonateLiveCodeTransformation(
             TransformationProbabilities.likelyDonateLiveCode()::donateLiveCodeAtStmt,
             Util.getDonorsFolder(),
-            GenerationParams.normal(ShaderKind.FRAGMENT, true),
+            GenerationParams.normal(ShaderKind.FRAGMENT, false, true),
             false));
     result.add(() -> new AddDeadOutputWriteTransformation());
     result.add(() -> new AddLiveOutputWriteTransformation());


### PR DESCRIPTION
GraphicsFuzz can be used to test WGSL implementations, via translators
from GLSL to WGSL (possibly via SPIR-V). But this only works for shaders
that are WGSL compatible. This change adds an option to control this,
and avoids generating a number of builtins that are not currently
supported in the WGSL spec.