### PR TITLE
Reducer: remove unused interface blocks

### DIFF
--- a/ast/src/main/java/com/graphicsfuzz/common/ast/decl/InterfaceBlock.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/ast/decl/InterfaceBlock.java
@@ -23,8 +23,10 @@ import com.graphicsfuzz.common.ast.visitors.IAstVisitor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,7 +37,7 @@ public class InterfaceBlock extends Declaration {
   private final List<TypeQualifier> interfaceQualifiers;
   private final String structName;
   private final List<String> memberNames;
-  private final List<Type> memberTypes;
+  private final Map<String, Type> memberTypes;
   private final Optional<String> instanceName;
 
   public InterfaceBlock(
@@ -77,13 +79,15 @@ public class InterfaceBlock extends Declaration {
     this.structName = structName;
     this.memberNames = new ArrayList<>();
     this.memberNames.addAll(memberNames);
-    this.memberTypes = new ArrayList<>();
-    this.memberTypes.addAll(memberTypes);
+    this.memberTypes = new HashMap<>();
+    for (int i = 0; i < memberNames.size(); i++) {
+      this.memberTypes.put(memberNames.get(i), memberTypes.get(i));
+    }
     this.instanceName = instanceName;
   }
 
   public List<Type> getMemberTypes() {
-    return Collections.unmodifiableList(memberTypes);
+    return memberNames.stream().map(memberTypes::get).collect(Collectors.toList());
   }
 
   public List<String> getMemberNames() {
@@ -115,13 +119,8 @@ public class InterfaceBlock extends Declaration {
     return instanceName.get();
   }
 
-  public Optional<Type> getMemberType(String name) {
-    for (int i = 0; i < memberNames.size(); i++) {
-      if (memberNames.get(i).equals(name)) {
-        return Optional.of(memberTypes.get(i));
-      }
-    }
-    return Optional.empty();
+  public Type getMemberType(String name) {
+    return memberTypes.get(name);
   }
 
   public boolean isUniformBlock() {
@@ -151,7 +150,7 @@ public class InterfaceBlock extends Declaration {
         interfaceQualifiers,
         structName,
         memberNames,
-        memberTypes.stream().map(item -> item.clone()).collect(Collectors.toList()),
+        memberNames.stream().map(memberTypes::get).map(Type::clone).collect(Collectors.toList()),
         instanceName);
   }
 

--- a/ast/src/main/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/tool/PrettyPrinterVisitor.java
@@ -774,7 +774,7 @@ public class PrettyPrinterVisitor extends StandardVisitor {
 
     for (String memberName : interfaceBlock.getMemberNames()) {
       indent();
-      final Type memberType = interfaceBlock.getMemberType(memberName).get();
+      final Type memberType = interfaceBlock.getMemberType(memberName);
       visit(memberType);
       out.append(" ").append(memberName);
       emitArrayInfoAfterType(memberType);

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Scope.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Scope.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.common.typing;
 
+import com.graphicsfuzz.common.ast.decl.InterfaceBlock;
 import com.graphicsfuzz.common.ast.decl.ParameterDecl;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
@@ -47,16 +48,26 @@ public class Scope {
     this.parent = parent;
   }
 
-  public void add(String name, Type type, Optional<ParameterDecl> parameterDecl,
-        VariableDeclInfo declInfo,
-        VariablesDeclaration variablesDecl) {
-    checkNameTypeAndParam(name, type, parameterDecl);
-    variableMapping.put(name, new ScopeEntry(type, parameterDecl, declInfo, variablesDecl));
+  public void add(String name, Type type) {
+    checkNameTypeAndParam(name, type, Optional.empty());
+    variableMapping.put(name, new ScopeEntry(type));
   }
 
-  public void add(String name, Type type, Optional<ParameterDecl> parameterDecl) {
-    checkNameTypeAndParam(name, type, parameterDecl);
+  public void add(String name, Type type,
+                  VariableDeclInfo declInfo,
+                  VariablesDeclaration variablesDecl) {
+    checkNameTypeAndParam(name, type, Optional.empty());
+    variableMapping.put(name, new ScopeEntry(type, declInfo, variablesDecl));
+  }
+
+  public void add(String name, Type type, ParameterDecl parameterDecl) {
+    checkNameTypeAndParam(name, type, Optional.of(parameterDecl));
     variableMapping.put(name, new ScopeEntry(type, parameterDecl));
+  }
+
+  public void add(String name, Type type, InterfaceBlock interfaceBlock) {
+    checkNameTypeAndParam(name, type, Optional.empty());
+    variableMapping.put(name, new ScopeEntry(type, interfaceBlock));
   }
 
   public void addStructDefinition(StructDefinitionType sdt) {

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeEntry.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeEntry.java
@@ -16,6 +16,7 @@
 
 package com.graphicsfuzz.common.typing;
 
+import com.graphicsfuzz.common.ast.decl.InterfaceBlock;
 import com.graphicsfuzz.common.ast.decl.ParameterDecl;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
@@ -24,9 +25,11 @@ import java.util.Optional;
 
 public class ScopeEntry {
 
-  private final Optional<ParameterDecl> parameterDecl;
-
   private final Type type;
+
+  // Represents the ParameterDecl that this variable came from, if one exists. If there is no such
+  // object, the optional is empty.
+  private final Optional<ParameterDecl> parameterDecl;
 
   // Represents the VariableDeclInfo that this variable came from, if one exists.  If there is no
   // such object (e.g. because the variable came from a parameter, or was made up for purposes of
@@ -37,26 +40,38 @@ public class ScopeEntry {
   // If there is no such object, the optional is empty.
   private final Optional<VariablesDeclaration> variablesDeclaration;
 
+  // Represents the interface block that this variable is part of, if one exists. If there is no
+  // such object, the optional is empty.
+  private final Optional<InterfaceBlock> interfaceBlock;
+
   private ScopeEntry(Type type, Optional<ParameterDecl> parameterDecl,
-        Optional<VariableDeclInfo> variableDeclInfo,
-        Optional<VariablesDeclaration> variablesDecl) {
+                     Optional<VariableDeclInfo> variableDeclInfo,
+                     Optional<VariablesDeclaration> variablesDecl,
+                     Optional<InterfaceBlock> interfaceBlock) {
     this.type = type;
     this.parameterDecl = parameterDecl;
     this.variableDeclInfo = variableDeclInfo;
     this.variablesDeclaration = variablesDecl;
+    this.interfaceBlock = interfaceBlock;
   }
 
   public ScopeEntry(Type type,
-      Optional<ParameterDecl> parameterDecl,
       VariableDeclInfo variableDeclInfo,
       VariablesDeclaration variablesDecl) {
-    this(type, parameterDecl, Optional.of(variableDeclInfo), Optional.of(variablesDecl));
-    assert variableDeclInfo != null;
-    assert variablesDecl != null;
+    this(type, Optional.empty(), Optional.of(variableDeclInfo), Optional.of(variablesDecl),
+        Optional.empty());
   }
 
-  public ScopeEntry(Type type, Optional<ParameterDecl> parameterDecl) {
-    this(type, parameterDecl, Optional.empty(), Optional.empty());
+  public ScopeEntry(Type type) {
+    this(type, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  public ScopeEntry(Type type, ParameterDecl parameterDecl) {
+    this(type, Optional.of(parameterDecl), Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  public ScopeEntry(Type type, InterfaceBlock interfaceBlock) {
+    this(type, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(interfaceBlock));
   }
 
   public Type getType() {
@@ -85,6 +100,14 @@ public class ScopeEntry {
 
   public boolean hasParameterDecl() {
     return parameterDecl.isPresent();
+  }
+
+  public InterfaceBlock getInterfaceBlock() {
+    return interfaceBlock.get();
+  }
+
+  public boolean hasInterfaceBlock() {
+    return interfaceBlock.isPresent();
   }
 
 }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/ScopeTrackingVisitor.java
@@ -18,6 +18,7 @@ package com.graphicsfuzz.common.typing;
 
 import com.graphicsfuzz.common.ast.decl.FunctionDefinition;
 import com.graphicsfuzz.common.ast.decl.FunctionPrototype;
+import com.graphicsfuzz.common.ast.decl.InterfaceBlock;
 import com.graphicsfuzz.common.ast.decl.ParameterDecl;
 import com.graphicsfuzz.common.ast.decl.VariableDeclInfo;
 import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
@@ -31,7 +32,6 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * This class extends StandardVisitor to track details of what is in scope at each point of
@@ -130,7 +130,16 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
       }
       currentScope.add(p.getName(),
           Typer.combineBaseTypeAndArrayInfo(p.getType(), p.getArrayInfo()),
-          Optional.of(p));
+          p);
+    }
+  }
+
+  @Override
+  public void visitInterfaceBlock(InterfaceBlock interfaceBlock) {
+    assert atGlobalScope();
+    super.visitInterfaceBlock(interfaceBlock);
+    for (String member : interfaceBlock.getMemberNames()) {
+      currentScope.add(member, interfaceBlock.getMemberType(member), interfaceBlock);
     }
   }
 
@@ -155,7 +164,6 @@ public abstract class ScopeTrackingVisitor extends StandardVisitor {
       currentScope.add(declInfo.getName(),
           Typer.combineBaseTypeAndArrayInfo(variablesDeclaration.getBaseType(),
               declInfo.getArrayInfo()),
-          Optional.empty(),
           declInfo, variablesDeclaration);
       visitVariableDeclInfoAfterAddedToScope(declInfo);
     }

--- a/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
+++ b/ast/src/main/java/com/graphicsfuzz/common/typing/Typer.java
@@ -235,15 +235,6 @@ public class Typer extends ScopeTrackingVisitor {
       types.put(variableIdentifierExpr, type);
       return;
     }
-    for (InterfaceBlock interfaceBlock : interfaceBlocks) {
-      final Optional<Type> memberType =
-          interfaceBlock.getMemberType(variableIdentifierExpr.getName());
-      if (memberType.isPresent()) {
-        types.put(variableIdentifierExpr, memberType.get());
-        return;
-      }
-    }
-
     maybeGetTypeOfBuiltinVariable(variableIdentifierExpr.getName())
         .ifPresent(item -> types.put(variableIdentifierExpr, item));
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/FuzzingContext.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/fuzzer/FuzzingContext.java
@@ -24,7 +24,6 @@ import com.graphicsfuzz.common.typing.Scope;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 public class FuzzingContext {
 
@@ -50,7 +49,7 @@ public class FuzzingContext {
   }
 
   public void addGlobal(String name, Type type) {
-    findRootScope().add(name, type, Optional.empty());
+    findRootScope().add(name, type);
   }
 
   private Scope findRootScope() {
@@ -63,12 +62,12 @@ public class FuzzingContext {
 
   public void addLocal(String name, Type type) {
     assert currentScope.hasParent();
-    currentScope.add(name, type, Optional.empty());
+    currentScope.add(name, type);
   }
 
   public void addParameter(ParameterDecl parameterDecl) {
     assert currentScope.hasParent();
-    currentScope.add(parameterDecl.getName(), parameterDecl.getType(), Optional.of(parameterDecl));
+    currentScope.add(parameterDecl.getName(), parameterDecl.getType(), parameterDecl);
   }
 
   public void addFunction(FunctionPrototype prototype) {

--- a/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddSwitchMutation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/semanticspreserving/AddSwitchMutation.java
@@ -49,7 +49,6 @@ import com.graphicsfuzz.util.Constants;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class AddSwitchMutation implements Mutation {
@@ -217,7 +216,6 @@ public class AddSwitchMutation implements Mutation {
       scope.add(declInfo.getName(),
           Typer.combineBaseTypeAndArrayInfo(variablesDeclaration.getBaseType(),
               declInfo.getArrayInfo()),
-          Optional.empty(),
           declInfo, variablesDeclaration);
     }
   }

--- a/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/transformation/DonateCodeTransformation.java
@@ -212,7 +212,7 @@ public abstract class DonateCodeTransformation implements ITransformation {
         // We will declare a global variable of the member's type with a prefixed version of the
         // member's name.  However, we need to take care regarding array members, in particular
         // because interface blocks can have unsized arrays.
-        final Type memberType = interfaceBlock.getMemberType(memberName).get();
+        final Type memberType = interfaceBlock.getMemberType(memberName);
 
         // This will be the array-free base type of the new global variable.
         Type plainVariableBaseType;

--- a/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/OutlineStatementMutationTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/semanticspreserving/OutlineStatementMutationTest.java
@@ -38,7 +38,6 @@ import com.graphicsfuzz.util.Constants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -65,9 +64,9 @@ public class OutlineStatementMutationTest {
             BinOp.ADD), BinOp.ASSIGN));
 
     final Scope fakeScope = new Scope();
-    fakeScope.add("x", BasicType.VEC2, Optional.empty());
-    fakeScope.add("y", BasicType.FLOAT, Optional.empty());
-    fakeScope.add("z", BasicType.VEC2, Optional.empty());
+    fakeScope.add("x", BasicType.VEC2);
+    fakeScope.add("y", BasicType.FLOAT);
+    fakeScope.add("z", BasicType.VEC2);
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
     final String expectedDecl = "vec2 " + Constants.OUTLINED_FUNCTION_PREFIX
@@ -91,9 +90,9 @@ public class OutlineStatementMutationTest {
         BinOp.ASSIGN));
 
     Scope fakeScope = new Scope();
-    fakeScope.add("x", BasicType.VEC2, Optional.empty());
+    fakeScope.add("x", BasicType.VEC2);
     fakeScope.add("y", new QualifiedType(BasicType.VEC2,
-        Collections.singletonList(TypeQualifier.UNIFORM)), Optional.empty());
+        Collections.singletonList(TypeQualifier.UNIFORM)));
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
 
@@ -119,7 +118,7 @@ public class OutlineStatementMutationTest {
         BinOp.ASSIGN));
 
     Scope fakeScope = new Scope();
-    fakeScope.add("x", BasicType.VEC2, Optional.empty());
+    fakeScope.add("x", BasicType.VEC2);
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
 
@@ -146,7 +145,7 @@ public class OutlineStatementMutationTest {
 
     Scope fakeScope = new Scope();
     fakeScope.add("x", new QualifiedType(BasicType.VEC2,
-        Collections.singletonList(TypeQualifier.OUT_PARAM)), Optional.empty());
+        Collections.singletonList(TypeQualifier.OUT_PARAM)));
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
 
@@ -172,7 +171,7 @@ public class OutlineStatementMutationTest {
         BinOp.ASSIGN));
 
     Scope fakeScope = new Scope();
-    fakeScope.add("x", BasicType.FLOAT, Optional.empty());
+    fakeScope.add("x", BasicType.FLOAT);
 
     new OutlineStatementMutation(toOutline, fakeScope, tu, fakeFunction, new IdGenerator()).apply();
 

--- a/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/InjectionPointTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/transformation/injection/InjectionPointTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 import com.graphicsfuzz.common.ast.stmt.Stmt;
 import com.graphicsfuzz.common.ast.type.BasicType;
 import com.graphicsfuzz.common.typing.Scope;
-import java.util.Optional;
 import org.junit.Test;
 
 public class InjectionPointTest {
@@ -63,7 +62,7 @@ public class InjectionPointTest {
   @Test
   public void testThatScopeIsCloned() {
     Scope s = new Scope();
-    s.add("v", BasicType.INT, Optional.empty());
+    s.add("v", BasicType.INT);
     IInjectionPoint injectionPoint = new InjectionPoint(null, false, false, s) {
       @Override
       public void inject(Stmt stmt) {
@@ -86,7 +85,7 @@ public class InjectionPointTest {
       }
     };
 
-    s.add("w", BasicType.INT, Optional.empty());
+    s.add("w", BasicType.INT);
 
     assertNull(injectionPoint.scopeAtInjectionPoint().lookupType("w"));
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
@@ -154,7 +154,8 @@ public class ReductionDriver {
         IReductionOpportunityFinder.liveFragColorWriteFinder(),
         IReductionOpportunityFinder.functionFinder(),
         IReductionOpportunityFinder.variableDeclFinder(),
-        IReductionOpportunityFinder.globalVariablesDeclarationFinder())) {
+        IReductionOpportunityFinder.globalVariablesDeclarationFinder(),
+        IReductionOpportunityFinder.interfaceBlockFinder())) {
       final SystematicReductionPass pass = new SystematicReductionPass(context,
           verbose,
           finder);

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/IReductionOpportunityFinder.java
@@ -92,6 +92,24 @@ public interface IReductionOpportunityFinder<T extends IReductionOpportunity> {
     };
   }
 
+  static IReductionOpportunityFinder<InterfaceBlockReductionOpportunity>
+      interfaceBlockFinder() {
+    return new IReductionOpportunityFinder<InterfaceBlockReductionOpportunity>() {
+      @Override
+      public List<InterfaceBlockReductionOpportunity> findOpportunities(
+          ShaderJob shaderJob,
+          ReducerContext context) {
+        return InterfaceBlockReductionOpportunities
+            .findOpportunities(shaderJob, context);
+      }
+
+      @Override
+      public String getName() {
+        return "interfaceBlock";
+      }
+    };
+  }
+
   static IReductionOpportunityFinder<GlobalPrecisionDeclarationReductionOpportunity>
       globalPrecisionDeclarationFinder() {
     return new IReductionOpportunityFinder<GlobalPrecisionDeclarationReductionOpportunity>() {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunities.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.ast.decl.Declaration;
+import com.graphicsfuzz.common.ast.decl.InterfaceBlock;
+import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
+import com.graphicsfuzz.common.transformreduce.ShaderJob;
+import com.graphicsfuzz.common.typing.ScopeEntry;
+import com.graphicsfuzz.common.util.ListConcat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class InterfaceBlockReductionOpportunities
+    extends ReductionOpportunitiesBase<InterfaceBlockReductionOpportunity> {
+
+  private Set<InterfaceBlock> referencedInterfaceBlocks;
+
+  private InterfaceBlockReductionOpportunities(TranslationUnit tu,
+                                               ReducerContext context) {
+    super(tu, context);
+    this.referencedInterfaceBlocks = new HashSet<>();
+  }
+
+  @Override
+  public void visitTranslationUnit(TranslationUnit translationUnit) {
+    super.visitTranslationUnit(translationUnit);
+    for (Declaration declaration : translationUnit.getTopLevelDeclarations()) {
+      if (!(declaration instanceof InterfaceBlock)) {
+        continue;
+      }
+      if (!referencedInterfaceBlocks.contains(declaration)) {
+        addOpportunity(new InterfaceBlockReductionOpportunity(translationUnit,
+            (InterfaceBlock) declaration,
+            getVistitationDepth()));
+      }
+    }
+  }
+
+  @Override
+  public void visitVariableIdentifierExpr(VariableIdentifierExpr variableIdentifierExpr) {
+    super.visitVariableIdentifierExpr(variableIdentifierExpr);
+    final ScopeEntry scopeEntry =
+        getCurrentScope().lookupScopeEntry(variableIdentifierExpr.getName());
+    if (scopeEntry != null && scopeEntry.hasInterfaceBlock()) {
+      referencedInterfaceBlocks.add(scopeEntry.getInterfaceBlock());
+    }
+  }
+
+  private static List<InterfaceBlockReductionOpportunity> findOpportunitiesForShader(
+      TranslationUnit tu,
+      ReducerContext context) {
+    InterfaceBlockReductionOpportunities finder =
+        new InterfaceBlockReductionOpportunities(tu, context);
+    finder.visit(tu);
+    return finder.getOpportunities();
+  }
+
+  static List<InterfaceBlockReductionOpportunity> findOpportunities(
+      ShaderJob shaderJob,
+      ReducerContext context) {
+    return shaderJob.getShaders()
+        .stream()
+        .map(item -> findOpportunitiesForShader(item, context))
+        .reduce(Arrays.asList(), ListConcat::concatenate);
+  }
+
+}

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunities.java
@@ -23,7 +23,6 @@ import com.graphicsfuzz.common.ast.expr.VariableIdentifierExpr;
 import com.graphicsfuzz.common.transformreduce.ShaderJob;
 import com.graphicsfuzz.common.typing.ScopeEntry;
 import com.graphicsfuzz.common.util.ListConcat;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -31,19 +30,19 @@ import java.util.Set;
 
 /**
  * Finds opportunities to remove unused interface blocks from a shader. That is, interface blocks
- * that are not referenced from anywhere inside the shader.
+ * that are not referenced from anywhere inside the shader. In the following example, the buffer
+ * interface block could be removed:
  *
- * In the following example, the buffer interface block could be removed:
+ * {@code
+ *   layout(binding = 1) buffer SomeName {
+ *     int x;
+ *     int y;
+ *   }
  *
- * layout(binding = 1) buffer SomeName {
- *   int x;
- *   int y;
+ *   void main() {
+ *     // Code that neither references 'x' nor 'y'
+ *   }
  * }
- *
- * void main() {
- *   // Code that neither references 'x' nor 'y'
- * }
- *
  */
 public class InterfaceBlockReductionOpportunities
     extends ReductionOpportunitiesBase<InterfaceBlockReductionOpportunity> {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunity.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The GraphicsFuzz Project Authors
+ * Copyright 2021 The GraphicsFuzz Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,29 @@
 package com.graphicsfuzz.reducer.reductionopportunities;
 
 import com.graphicsfuzz.common.ast.TranslationUnit;
-import com.graphicsfuzz.common.ast.decl.VariablesDeclaration;
+import com.graphicsfuzz.common.ast.decl.InterfaceBlock;
 import com.graphicsfuzz.common.ast.visitors.VisitationDepth;
 
-public class GlobalVariablesDeclarationReductionOpportunity extends AbstractReductionOpportunity {
+public class InterfaceBlockReductionOpportunity extends AbstractReductionOpportunity {
 
   private final TranslationUnit translationUnit;
-  private final VariablesDeclaration variablesDeclaration;
+  private final InterfaceBlock interfaceBlock;
 
-  public GlobalVariablesDeclarationReductionOpportunity(TranslationUnit translationUnit,
-                                                        VariablesDeclaration variablesDeclaration,
-                                                        VisitationDepth depth) {
+  public InterfaceBlockReductionOpportunity(TranslationUnit translationUnit,
+                                            InterfaceBlock interfaceBlock,
+                                            VisitationDepth depth) {
     super(depth);
     this.translationUnit = translationUnit;
-    this.variablesDeclaration = variablesDeclaration;
+    this.interfaceBlock = interfaceBlock;
   }
 
   @Override
   void applyReductionImpl() {
-    translationUnit.removeTopLevelDeclaration(variablesDeclaration);
+    translationUnit.removeTopLevelDeclaration(interfaceBlock);
   }
 
   @Override
   public boolean preconditionHolds() {
-    return translationUnit.getTopLevelDeclarations().contains(variablesDeclaration);
+    return translationUnit.getTopLevelDeclarations().contains(interfaceBlock);
   }
-
 }

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunities.java
@@ -51,6 +51,7 @@ public final class ReductionOpportunities {
         IReductionOpportunityFinder.outlinedStatementFinder(),
         IReductionOpportunityFinder.variableDeclFinder(),
         IReductionOpportunityFinder.globalVariablesDeclarationFinder(),
+        IReductionOpportunityFinder.interfaceBlockFinder(),
         IReductionOpportunityFinder.globalPrecisionDeclarationFinder(),
         IReductionOpportunityFinder.unwrapFinder(),
         IReductionOpportunityFinder.unswitchifyFinder(),

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunitiesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 The GraphicsFuzz Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.graphicsfuzz.reducer.reductionopportunities;
+
+import static org.junit.Assert.assertEquals;
+
+import com.graphicsfuzz.common.ast.TranslationUnit;
+import com.graphicsfuzz.common.glslversion.ShadingLanguageVersion;
+import com.graphicsfuzz.common.util.CompareAsts;
+import com.graphicsfuzz.common.util.IdGenerator;
+import com.graphicsfuzz.common.util.ParseHelper;
+import com.graphicsfuzz.common.util.RandomWrapper;
+import com.graphicsfuzz.common.util.ShaderJobFileOperations;
+import java.util.List;
+import org.junit.Test;
+
+public class InterfaceBlockReductionOpportunitiesTest {
+
+  private final ShaderJobFileOperations fileOps = new ShaderJobFileOperations();
+
+  @Test
+  public void testUsedInterfaceBlockIsNotRemoved() throws Exception {
+    final String original = "layout(binding = 0) buffer SomeName {"
+        + "  int x;"
+        + "};"
+        + "void main() { x; }";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<InterfaceBlockReductionOpportunity> ops = InterfaceBlockReductionOpportunities
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), new IdGenerator()));
+    assertEquals(0, ops.size());
+  }
+
+  @Test
+  public void testUnusedInterfaceBlockIsRemoved() throws Exception {
+    final String original = "layout(binding = 0) buffer SomeName {"
+        + "  int x;"
+        + "};"
+        + "void main() { }";
+    final String expected = "void main() { }";
+    final TranslationUnit tu = ParseHelper.parse(original);
+    final List<InterfaceBlockReductionOpportunity> ops = InterfaceBlockReductionOpportunities
+        .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), new IdGenerator()));
+    assertEquals(1, ops.size());
+    ops.get(0).applyReduction();
+    CompareAsts.assertEqualAsts(expected, tu);
+    final List<InterfaceBlockReductionOpportunity> moreOps =
+        InterfaceBlockReductionOpportunities
+            .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
+                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                    new RandomWrapper(0), new IdGenerator()));
+    assertEquals(0, moreOps.size());
+  }
+
+}


### PR DESCRIPTION
Adds functionality to the reducer to eliminate interface blocks that
are not used. This involved adding support for tracking interface
blocks in the ScopeTrackingVisitor, and some minor changes to the
internals of InterfaceBlock were made in the process.

Fixes #1162.