### PR TITLE
Fix bug to do with reducing global variables

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunities.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunities.java
@@ -48,7 +48,9 @@ public class VariableDeclReductionOpportunities
   private void getReductionOpportunitiesForUnusedGlobals() {
     for (String name : getCurrentScope().keys()) {
       ScopeEntry entry = getCurrentScope().lookupScopeEntry(name);
-      assert entry.hasVariableDeclInfo();
+      if (!entry.hasVariableDeclInfo()) {
+        continue;
+      }
       assert referencedScopeEntries.peek() != null;
       if (!referencedScopeEntries.peek().contains(entry)) {
         addOpportunity(new VariableDeclReductionOpportunity(entry.getVariableDeclInfo(),


### PR DESCRIPTION
Since adding support for interface blocks, we need to check that a
global-scope declaration really does refer to a variable group.