### PR TITLE
Reducer: Add --no-ub-guards argument

### DIFF
--- a/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/ReductionDriver.java
@@ -233,7 +233,7 @@ public class ReductionDriver {
       boolean makeArrayAccessesInBounds = false;
       boolean addInitializers = false;
 
-      if (context.reduceEverywhere()) {
+      if (context.addUbGuards() && context.reduceEverywhere()) {
         LOGGER.info("We are not preserving semantics, so see whether adding guards against "
             + "undefined behaviour preserves interestingness.");
 

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReducerContext.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/reductionopportunities/ReducerContext.java
@@ -26,6 +26,7 @@ public class ReducerContext {
   private static final int DEFAULT_AGGRESSION_DECREASE_STEP = 5;
 
   private final boolean reduceEverywhere;
+  private final boolean addUbGuards;
   private final ShadingLanguageVersion shadingLanguageVersion;
   private final IRandom random;
   private final IdGenerator idGenerator;
@@ -33,10 +34,12 @@ public class ReducerContext {
   private final int aggressionDecreaseStep;
 
   public ReducerContext(boolean reduceEverywhere,
+                        boolean addUbGuards,
                         ShadingLanguageVersion shadingLanguageVersion,
                         IRandom random, IdGenerator idGenerator, int maxPercentageToReduce,
                         int aggressionDecreaseStep) {
     this.reduceEverywhere = reduceEverywhere;
+    this.addUbGuards = addUbGuards;
     this.shadingLanguageVersion = shadingLanguageVersion;
     this.random = random;
     this.idGenerator = idGenerator;
@@ -45,14 +48,19 @@ public class ReducerContext {
   }
 
   public ReducerContext(boolean reduceEverywhere,
+                        boolean addUbGuards,
                         ShadingLanguageVersion shadingLanguageVersion,
                         IRandom random, IdGenerator idGenerator) {
-    this(reduceEverywhere, shadingLanguageVersion, random, idGenerator,
+    this(reduceEverywhere, addUbGuards, shadingLanguageVersion, random, idGenerator,
         DEFAULT_MAX_PERCENTAGE_TO_REDUCE, DEFAULT_AGGRESSION_DECREASE_STEP);
   }
 
   public boolean reduceEverywhere() {
     return reduceEverywhere;
+  }
+
+  public boolean addUbGuards() {
+    return addUbGuards;
   }
 
   public ShadingLanguageVersion getShadingLanguageVersion() {

--- a/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
+++ b/reducer/src/main/java/com/graphicsfuzz/reducer/tool/GlslReduce.java
@@ -220,6 +220,11 @@ public class GlslReduce {
               + "numbers with uniforms.")
           .action(Arguments.storeTrue());
 
+    parser.addArgument("--no-ub-guards")
+        .help("Do not emit guards against undefined behaviour (such as loop limiters and array "
+            + "bounds clamping).")
+        .action(Arguments.storeTrue());
+
     return parser;
 
   }
@@ -295,6 +300,7 @@ public class GlslReduce {
       final IRandom random = new RandomWrapper(ArgsUtil.getSeedArgument(ns));
       final String errorString = ns.get("error_string");
       final boolean reduceEverywhere = !ns.getBoolean("preserve_semantics");
+      final boolean addUbGuards = !ns.getBoolean("no_ub_guards");
       final boolean stopOnError = ns.get("stop_on_error");
 
       final String server = ns.get("server");
@@ -465,6 +471,7 @@ public class GlslReduce {
           workDir,
           maxSteps,
           reduceEverywhere,
+          addUbGuards,
           continuePreviousReduction,
           literalsToUniforms,
           verbose,
@@ -492,6 +499,7 @@ public class GlslReduce {
       File workDir,
       int stepLimit,
       boolean reduceEverywhere,
+      boolean addUbGuards,
       boolean continuePreviousReduction,
       boolean literalsToUniforms,
       boolean verbose,
@@ -526,6 +534,7 @@ public class GlslReduce {
     new ReductionDriver(
         new ReducerContext(
             reduceEverywhere,
+            addUbGuards,
             shadingLanguageVersion,
             random,
             idGenerator),

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/ReductionDriverTest.java
@@ -112,13 +112,14 @@ public class ReductionDriverTest {
 
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
                 MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, version, generator, new IdGenerator()),
+                new ReducerContext(false, true, version, generator, new IdGenerator()),
                 fileOps);
     assertEquals(3, ops.size());
 
     new ReductionDriver(
         new ReducerContext(
             false,
+            true,
             version,
             generator,
             new IdGenerator()),
@@ -230,7 +231,7 @@ public class ReductionDriverTest {
         Optional.empty(), new PipelineInfo(tempJsonFile),
         translationUnits);
 
-    return new ReductionDriver(new ReducerContext(reduceEverywhere, version,
+    return new ReductionDriver(new ReducerContext(reduceEverywhere, true, version,
         generator, new IdGenerator()), false, fileOps,
         judge, testFolder.getRoot())
         .doReduction(state, getPrefix(tempFragmentShaderFile), 0, stepLimit);
@@ -283,7 +284,7 @@ public class ReductionDriverTest {
     };
 
     final String reducedFilesPrefix = new ReductionDriver(
-        new ReducerContext(false, version, generator, new IdGenerator()),
+        new ReducerContext(false, true, version, generator, new IdGenerator()),
         false, fileOps,
         referencesSinCosAnd3, testFolder.getRoot())
         .doReduction(state, getPrefix(tempFile), 0, -1);
@@ -548,6 +549,7 @@ public class ReductionDriverTest {
     fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(true,
+        true,
         ShadingLanguageVersion.ESSL_300,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -602,6 +604,7 @@ public class ReductionDriverTest {
     fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(false,
+        true,
         ShadingLanguageVersion.ESSL_300,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -636,6 +639,7 @@ public class ReductionDriverTest {
     fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(true,
+        true,
         ShadingLanguageVersion.ESSL_100,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -693,6 +697,7 @@ public class ReductionDriverTest {
             fileOps);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(true,
+        true,
         ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -767,6 +772,7 @@ public class ReductionDriverTest {
             fileOps);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(true,
+        true,
         ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -840,6 +846,7 @@ public class ReductionDriverTest {
       fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
       final String resultsPrefix = new ReductionDriver(new ReducerContext(true,
+          true,
           ShadingLanguageVersion.ESSL_310,
           new RandomWrapper(0),
           new IdGenerator()),
@@ -894,6 +901,7 @@ public class ReductionDriverTest {
     fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(true,
+        true,
         ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -951,6 +959,7 @@ public class ReductionDriverTest {
     fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
     new ReductionDriver(new ReducerContext(true,
+        true,
         ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0),
         new IdGenerator()),
@@ -1040,6 +1049,7 @@ public class ReductionDriverTest {
     fileOps.writeShaderJobFile(shaderJob, tempShaderJobFile);
 
     final String resultsPrefix = new ReductionDriver(new ReducerContext(false,
+        true,
         ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0),
         new IdGenerator()),

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundExprToSubExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/CompoundExprToSubExprReductionOpportunitiesTest.java
@@ -41,7 +41,7 @@ public class CompoundExprToSubExprReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     final List<SimplifyExprReductionOpportunity> ops = CompoundExprToSubExprReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+              new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
                 new RandomWrapper(0), new IdGenerator()));
     assertTrue(ops.isEmpty());
   }
@@ -170,7 +170,7 @@ public class CompoundExprToSubExprReductionOpportunitiesTest {
         boolean reduceEverywhere) {
     return CompoundExprToSubExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(reduceEverywhere, ShadingLanguageVersion.GLSL_440,
+          new ReducerContext(reduceEverywhere, true, ShadingLanguageVersion.GLSL_440,
           new RandomWrapper(0), new IdGenerator()));
   }
 
@@ -186,7 +186,7 @@ public class CompoundExprToSubExprReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = CompoundExprToSubExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(0, ops.size());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/DestructifyReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/DestructifyReductionOpportunitiesTest.java
@@ -42,7 +42,7 @@ public class DestructifyReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<DestructifyReductionOpportunity> ops = DestructifyReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-          ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+          true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as there is already a variable called 'dist' in scope
     assertEquals(0, ops.size());
   }
@@ -73,7 +73,7 @@ public class DestructifyReductionOpportunitiesTest {
     final List<DestructifyReductionOpportunity> ops = DestructifyReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
           new ReducerContext(false,
-          ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+          true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     // There should be one opportunity as variable dist is in a different scope and not used in this
     // scope.
     assertEquals(1, ops.size());
@@ -99,7 +99,7 @@ public class DestructifyReductionOpportunitiesTest {
     final List<DestructifyReductionOpportunity> ops = DestructifyReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
           new ReducerContext(false,
-          ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+          true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as there is already a variable called 'dist' in scope,
     // and it is used.
     assertEquals(0, ops.size());
@@ -136,7 +136,7 @@ public class DestructifyReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<DestructifyReductionOpportunity> ops = DestructifyReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-          ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+          true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as there is already a variable called 'dist' in scope,
     // and it is used.
     assertEquals(1, ops.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ExprToConstantReductionOpportunitiesTest.java
@@ -36,7 +36,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(prog);
     List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(true, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(true, true, ShadingLanguageVersion.ESSL_100,
         new RandomWrapper(0), new IdGenerator()));
     for (SimplifyExprReductionOpportunity op : ops) {
       op.applyReduction();
@@ -51,7 +51,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(prog);
     List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(true, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(true, true, ShadingLanguageVersion.ESSL_100,
         new RandomWrapper(0), new IdGenerator()));
     for (SimplifyExprReductionOpportunity op : ops) {
       op.applyReduction();
@@ -67,7 +67,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(prog);
     List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(true, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(true, true, ShadingLanguageVersion.ESSL_100,
         new RandomWrapper(0), new IdGenerator()));
     for (SimplifyExprReductionOpportunity op : ops) {
       op.applyReduction();
@@ -82,7 +82,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0),
               new IdGenerator()));
     assertEquals(1, ops.size());
@@ -102,7 +102,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_310,
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(0, ops.size());
@@ -124,7 +124,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_310,
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(0, ops.size());
@@ -202,7 +202,7 @@ public class ExprToConstantReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_100,
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0),
             new IdGenerator()));
     for (SimplifyExprReductionOpportunity op : ops) {

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FlattenControlFlowReductionOpportunitiesTest.java
@@ -978,7 +978,7 @@ public class FlattenControlFlowReductionOpportunitiesTest {
                                                     boolean reduceEverywhere) {
     return FlattenControlFlowReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(reduceEverywhere,
+        new ReducerContext(reduceEverywhere, true,
             tu.getShadingLanguageVersion(), new RandomWrapper(0),
             new IdGenerator()));
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FoldConstantReductionOpportunitiesTest.java
@@ -629,7 +629,7 @@ public class FoldConstantReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(before);
     final List<SimplifyExprReductionOpportunity> ops = FoldConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     ops.forEach(item -> item.applyReduction());
     CompareAsts.assertEqualAsts(after, tu);
     assertEquals(numOps, ops.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FunctionReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/FunctionReductionOpportunitiesTest.java
@@ -34,7 +34,7 @@ public class FunctionReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(program);
     assertEquals(1, FunctionReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator())).size());
   }
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariableDeclToExprReductionOpportunitiesTest.java
@@ -37,7 +37,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_100,
+                true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as the preserve semantics is enabled.
     assertTrue(ops.isEmpty());
@@ -50,7 +50,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_100,
+                true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     // Since the new assignment statement must be only inserted as the first statement of
     // the main function, thus we have to ensure that main function exists.
@@ -65,7 +65,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_100,
+                true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     // Since the new assignment statement must be only inserted as the first statement of
     // the main function, thus we have to ensure that main function exists.
@@ -93,7 +93,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
@@ -119,7 +119,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     // Only variable declarations a and b have the initializer.
     // Thus, we expect the reducer to find only 2 opportunities.
@@ -135,7 +135,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-                ShadingLanguageVersion.ESSL_100,
+                true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as it is invalid to declare constant variable
     // without an initial value.
@@ -160,7 +160,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(3, ops.size());
     ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
@@ -189,7 +189,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, ops.size());
     ops.forEach(GlobalVariableDeclToExprReductionOpportunity::applyReductionImpl);
@@ -204,7 +204,7 @@ public class GlobalVariableDeclToExprReductionOpportunitiesTest {
     final List<GlobalVariableDeclToExprReductionOpportunity> ops =
         GlobalVariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_100,
+                true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     assertTrue(ops.isEmpty());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariablesDeclarationReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/GlobalVariablesDeclarationReductionOpportunitiesTest.java
@@ -46,7 +46,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<IReductionOpportunity> ops = ReductionOpportunities
           .getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()), fileOps);
     assertEquals(0, ops.size());
   }
@@ -60,7 +60,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops = GlobalVariablesDeclarationReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -75,7 +75,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final List<GlobalVariablesDeclarationReductionOpportunity> ops =
         GlobalVariablesDeclarationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -88,7 +88,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final List<GlobalVariablesDeclarationReductionOpportunity> ops =
         GlobalVariablesDeclarationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -105,7 +105,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final List<GlobalVariablesDeclarationReductionOpportunity> ops =
         GlobalVariablesDeclarationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -118,7 +118,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final List<GlobalVariablesDeclarationReductionOpportunity> ops =
         GlobalVariablesDeclarationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -134,7 +134,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     final List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -142,7 +142,7 @@ public class GlobalVariablesDeclarationReductionOpportunitiesTest {
     final List<GlobalVariablesDeclarationReductionOpportunity> moreOps =
         GlobalVariablesDeclarationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, moreOps.size());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/IdentityMutationReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/IdentityMutationReductionOpportunitiesTest.java
@@ -161,7 +161,7 @@ public class IdentityMutationReductionOpportunitiesTest {
 
   private ReducerContext getReducerContext() {
     return new ReducerContext(false,
-        ShadingLanguageVersion.ESSL_310,
+        true, ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0),
         new IdGenerator());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineFunctionReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineFunctionReductionOpportunitiesTest.java
@@ -53,7 +53,7 @@ public class InlineFunctionReductionOpportunitiesTest {
     final List<InlineFunctionReductionOpportunity> ops =
         InlineFunctionReductionOpportunities.findOpportunities(shaderJob,
         new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -77,7 +77,7 @@ public class InlineFunctionReductionOpportunitiesTest {
     final List<InlineFunctionReductionOpportunity> ops =
         InlineFunctionReductionOpportunities.findOpportunities(shaderJob,
             new ReducerContext(true,
-                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+                true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(0, ops.size());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineInitializerReductionOpportunitiesTest.java
@@ -38,7 +38,7 @@ public class InlineInitializerReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-          ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+          true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
     CompareAsts.assertEqualAsts(expected, tu);
@@ -46,7 +46,7 @@ public class InlineInitializerReductionOpportunitiesTest {
     // If we are preserving semantics, we do not want to apply this transformation.
     assertTrue(InlineInitializerReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-        ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator())).isEmpty());
+        true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator())).isEmpty());
   }
 
   @Test
@@ -62,13 +62,13 @@ public class InlineInitializerReductionOpportunitiesTest {
     List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(largeProgramTu),
                 new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
 
     ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(smallProgramTu),
                 new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(3, ops.size());
     ops.get(0).applyReduction();
     ops.get(1).applyReduction();
@@ -103,7 +103,7 @@ public class InlineInitializerReductionOpportunitiesTest {
 
     List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertTrue(ops.isEmpty());
   }
 
@@ -116,7 +116,7 @@ public class InlineInitializerReductionOpportunitiesTest {
 
     List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertTrue(ops.isEmpty());
   }
 
@@ -127,7 +127,7 @@ public class InlineInitializerReductionOpportunitiesTest {
 
     List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertTrue(ops.isEmpty());
   }
 
@@ -138,7 +138,7 @@ public class InlineInitializerReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
 
@@ -150,7 +150,7 @@ public class InlineInitializerReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
 
@@ -174,7 +174,7 @@ public class InlineInitializerReductionOpportunitiesTest {
     final List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
                 new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(2, ops.size());
     ops.get(0).applyReduction();
     ops.get(1).applyReduction();
@@ -201,7 +201,7 @@ public class InlineInitializerReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<SimplifyExprReductionOpportunity> ops = InlineInitializerReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+            true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
     assertEquals(2, ops.size());
     ops.get(0).applyReduction();
     ops.get(1).applyReduction();

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineStructifiedFieldReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineStructifiedFieldReductionOpportunitiesTest.java
@@ -80,11 +80,11 @@ public class InlineStructifiedFieldReductionOpportunitiesTest {
     assertEquals(1,
         InlineStructifiedFieldReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0), new IdGenerator())).size());
     InlineStructifiedFieldReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator())).get(0).applyReduction();
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(programAfter)),
         PrettyPrinterVisitor.prettyPrintAsString(tu));
@@ -123,7 +123,7 @@ public class InlineStructifiedFieldReductionOpportunitiesTest {
     List<InlineStructifiedFieldReductionOpportunity> ops =
         InlineStructifiedFieldReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0), new IdGenerator()));
     assertEquals(3, ops.size());
 
@@ -164,7 +164,7 @@ public class InlineStructifiedFieldReductionOpportunitiesTest {
     List<InlineStructifiedFieldReductionOpportunity> ops =
         InlineStructifiedFieldReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0),
               new IdGenerator()));
     assertEquals(1, ops.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineUniformReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InlineUniformReductionOpportunitiesTest.java
@@ -201,7 +201,7 @@ public class InlineUniformReductionOpportunitiesTest {
       final ShaderJob temp = shaderJob.clone();
       List<SimplifyExprReductionOpportunity> ops =
           InlineUniformReductionOpportunities.findOpportunities(temp,
-              new ReducerContext(true,
+              new ReducerContext(true, true,
                   ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), null));
       assertEquals(expectedSize, ops.size());
       ops.get(i).applyReduction();
@@ -225,7 +225,7 @@ public class InlineUniformReductionOpportunitiesTest {
     pipelineInfo.addUniform("u", BasicType.INT, Optional.empty(), Collections.singletonList(2));
     final List<SimplifyExprReductionOpportunity> opportunities =
         InlineUniformReductionOpportunities.findOpportunities(new GlslShaderJob(Optional.empty(),
-            pipelineInfo, tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
+            pipelineInfo, tu), new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310,
         new RandomWrapper(0), new IdGenerator()));
     assertTrue(opportunities.isEmpty());
   }
@@ -253,7 +253,7 @@ public class InlineUniformReductionOpportunitiesTest {
     pipelineInfo.addUniform("u", BasicType.INT, Optional.empty(), Collections.singletonList(2));
     final List<SimplifyExprReductionOpportunity> opportunities =
         InlineUniformReductionOpportunities.findOpportunities(new GlslShaderJob(Optional.empty(),
-            pipelineInfo, tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
+            pipelineInfo, tu), new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, opportunities.size());
     opportunities.get(0).applyReduction();
@@ -283,7 +283,7 @@ public class InlineUniformReductionOpportunitiesTest {
     pipelineInfo.addUniform("u", BasicType.INT, Optional.empty(), Collections.singletonList(2));
     final List<SimplifyExprReductionOpportunity> opportunities =
         InlineUniformReductionOpportunities.findOpportunities(new GlslShaderJob(Optional.empty(),
-            pipelineInfo, tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
+            pipelineInfo, tu), new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, opportunities.size());
     opportunities.get(0).applyReduction();
@@ -335,7 +335,7 @@ public class InlineUniformReductionOpportunitiesTest {
     pipelineInfo.addUniform("u", BasicType.INT, Optional.empty(), Collections.singletonList(2));
     final List<SimplifyExprReductionOpportunity> opportunities =
         InlineUniformReductionOpportunities.findOpportunities(new GlslShaderJob(Optional.empty(),
-            pipelineInfo, tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
+            pipelineInfo, tu), new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, opportunities.size());
     for (SimplifyExprReductionOpportunity op : opportunities) {
@@ -367,7 +367,7 @@ public class InlineUniformReductionOpportunitiesTest {
         Collections.singletonList(3));
     final List<SimplifyExprReductionOpportunity> opportunities =
         InlineUniformReductionOpportunities.findOpportunities(new GlslShaderJob(Optional.empty(),
-            pipelineInfo, tu), new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
+            pipelineInfo, tu), new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, opportunities.size());
     opportunities.get(0).applyReduction();

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/InterfaceBlockReductionOpportunitiesTest.java
@@ -41,7 +41,7 @@ public class InterfaceBlockReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     final List<InterfaceBlockReductionOpportunity> ops = InterfaceBlockReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -56,7 +56,7 @@ public class InterfaceBlockReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     final List<InterfaceBlockReductionOpportunity> ops = InterfaceBlockReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -64,7 +64,7 @@ public class InterfaceBlockReductionOpportunitiesTest {
     final List<InterfaceBlockReductionOpportunity> moreOps =
         InterfaceBlockReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, moreOps.size());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LiteralToUniformReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LiteralToUniformReductionOpportunitiesTest.java
@@ -71,7 +71,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
         .findOpportunities(shaderJob,
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                 new IdGenerator()));
 
     assertEquals("There should be two opportunities", 2, ops.size());
@@ -89,7 +90,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -130,7 +132,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be two opportunities", 2, ops.size());
@@ -148,7 +151,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -187,7 +191,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be two opportunities", 2, ops.size());
@@ -204,7 +209,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -243,7 +249,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be two opportunities", 2, ops.size());
@@ -260,7 +267,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -299,7 +307,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be two opportunities", 2, ops.size());
@@ -316,7 +325,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -384,7 +394,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be three opportunities", 3, ops.size());
@@ -409,7 +420,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -470,7 +482,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be 10 opportunities", 10, ops.size());
@@ -490,7 +503,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -527,7 +541,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be three opportunities", 3, ops.size());
@@ -539,7 +554,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());
@@ -578,7 +594,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be seven opportunities", 7, ops.size());
@@ -590,7 +607,8 @@ public class LiteralToUniformReductionOpportunitiesTest {
     final List<LiteralToUniformReductionOpportunity> ops2 =
         LiteralToUniformReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
 
     assertEquals("There should be no opportunities", 0, ops2.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LiveOutputVariableWriteReductionOpportunitiesTest.java
@@ -51,7 +51,8 @@ public class LiveOutputVariableWriteReductionOpportunitiesTest {
     List<LiveOutputVariableWriteReductionOpportunity> ops =
           LiveOutputVariableWriteReductionOpportunities
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                  new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                  new ReducerContext(false, true,
+                      ShadingLanguageVersion.ESSL_100,
                       new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -74,7 +75,7 @@ public class LiveOutputVariableWriteReductionOpportunitiesTest {
     List<LiveOutputVariableWriteReductionOpportunity> ops =
         LiveOutputVariableWriteReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(
-                    false, ShadingLanguageVersion.ESSL_100,
+                    false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -101,7 +102,8 @@ public class LiveOutputVariableWriteReductionOpportunitiesTest {
     final List<LiveOutputVariableWriteReductionOpportunity> ops =
         LiveOutputVariableWriteReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                 new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -124,7 +126,8 @@ public class LiveOutputVariableWriteReductionOpportunitiesTest {
     List<LiveOutputVariableWriteReductionOpportunity> ops =
           LiveOutputVariableWriteReductionOpportunities
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                     new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -148,8 +151,9 @@ public class LiveOutputVariableWriteReductionOpportunitiesTest {
     List<LiveOutputVariableWriteReductionOpportunity> ops =
           LiveOutputVariableWriteReductionOpportunities
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false,
-                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100,
+                    new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
     CompareAsts.assertEqualAsts(expected, tu);

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LoopMergeReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/LoopMergeReductionOpportunitiesTest.java
@@ -66,7 +66,7 @@ public class LoopMergeReductionOpportunitiesTest {
 
     List<LoopMergeReductionOpportunity> opportunities =
         LoopMergeReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(1, opportunities.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/OutlinedStatementReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/OutlinedStatementReductionOpportunitiesTest.java
@@ -41,7 +41,7 @@ public class OutlinedStatementReductionOpportunitiesTest {
 
     List<OutlinedStatementReductionOpportunity> ops = OutlinedStatementReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
 
@@ -64,7 +64,7 @@ public class OutlinedStatementReductionOpportunitiesTest {
 
     List<OutlinedStatementReductionOpportunity> ops = OutlinedStatementReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
 
@@ -89,7 +89,7 @@ public class OutlinedStatementReductionOpportunitiesTest {
 
     List<OutlinedStatementReductionOpportunity> ops = OutlinedStatementReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(1, ops.size());
@@ -111,7 +111,7 @@ public class OutlinedStatementReductionOpportunitiesTest {
 
     List<OutlinedStatementReductionOpportunity> ops = OutlinedStatementReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(0, ops.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/ReductionOpportunitiesTest.java
@@ -59,7 +59,7 @@ public class ReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(prog);
     List<IReductionOpportunity> opportunities =
         ReductionOpportunities.getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()), fileOps);
     // There should be no ExprToConstant reduction opportunity, because the expressions do not occur
     // under dead code, and the fuzzed expression is too simple to be reduced.
@@ -74,7 +74,7 @@ public class ReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(program);
     ReductionOpportunities.getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
           new ReducerContext(false,
-        ShadingLanguageVersion.ESSL_100,
+        true, ShadingLanguageVersion.ESSL_100,
         new RandomWrapper(0), new IdGenerator()), fileOps);
   }
 
@@ -86,7 +86,7 @@ public class ReductionOpportunitiesTest {
       List<InlineStructifiedFieldReductionOpportunity> ops =
           InlineStructifiedFieldReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
       if (ops.isEmpty()) {
         break;
@@ -97,7 +97,7 @@ public class ReductionOpportunitiesTest {
     while (true) {
       List<DestructifyReductionOpportunity> ops = DestructifyReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
       if (ops.isEmpty()) {
         break;
@@ -108,7 +108,7 @@ public class ReductionOpportunitiesTest {
     while (true) {
       List<IReductionOpportunity> ops = ReductionOpportunities
           .getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()), fileOps);
       if (ops.isEmpty()) {
         break;
@@ -346,7 +346,7 @@ public class ReductionOpportunitiesTest {
     final List<InlineStructifiedFieldReductionOpportunity> ops =
         InlineStructifiedFieldReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(1, ops.size());
@@ -393,7 +393,7 @@ public class ReductionOpportunitiesTest {
 
     List<DestructifyReductionOpportunity> ops = DestructifyReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(1, ops.size());
@@ -439,7 +439,8 @@ public class ReductionOpportunitiesTest {
     {
       List<IReductionOpportunity> ops = ReductionOpportunities
           .getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()), fileOps);
       for (int i = 0; i < ops.size(); i++) {
         if (ops.get(i) instanceof SimplifyExprReductionOpportunity) {
@@ -455,14 +456,16 @@ public class ReductionOpportunitiesTest {
       {
         final List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
               MakeShaderJobFromFragmentShader.make(tuClone),
-              new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()), fileOps);
+              new ReducerContext(false, true,
+                  ShadingLanguageVersion.ESSL_100,
+                  new RandomWrapper(0), new IdGenerator()), fileOps);
         ((SimplifyExprReductionOpportunity) ops.get(index)).applyReduction();
       }
       for (IReductionOpportunity op : ReductionOpportunities
               .getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tuClone),
-            new ReducerContext(false,
-          ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()), fileOps)) {
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100,
+                new RandomWrapper(0), new IdGenerator()), fileOps)) {
         if (op instanceof LoopMergeReductionOpportunity) {
           op.applyReduction();
         }
@@ -523,7 +526,7 @@ public class ReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(program);
     int numOps = ReductionOpportunities.getReductionOpportunities(MakeShaderJobFromFragmentShader
             .make(tu), new ReducerContext(false,
-        ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()), fileOps)
+        true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()), fileOps)
         .size();
 
     for (int i = 0; i < numOps; i++) {
@@ -535,7 +538,7 @@ public class ReductionOpportunitiesTest {
         final List<IReductionOpportunity> ops = ReductionOpportunities
                 .getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tuClone),
                   new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()),
+                true, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()),
                     fileOps);
 
         if (Compatibility.compatible(ops.get(i).getClass(), ops.get(j).getClass())) {
@@ -554,7 +557,7 @@ public class ReductionOpportunitiesTest {
     while (true) {
       List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
             MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-              ShadingLanguageVersion.GLSL_440,
+              true, ShadingLanguageVersion.GLSL_440,
             new RandomWrapper(0), new IdGenerator()), fileOps);
       if (ops.isEmpty()) {
         break;
@@ -574,7 +577,7 @@ public class ReductionOpportunitiesTest {
           + "}");
     List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, ops.size());
   }
@@ -590,7 +593,7 @@ public class ReductionOpportunitiesTest {
       final TranslationUnit tu = ParseHelper.parse(program);
       List<SimplifyExprReductionOpportunity> ops = ExprToConstantReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                  new ReducerContext(true, ShadingLanguageVersion.ESSL_100,
+                  new ReducerContext(true, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
       if (i >= ops.size()) {
         break;
@@ -628,7 +631,7 @@ public class ReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
           MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
           new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -657,8 +660,9 @@ public class ReductionOpportunitiesTest {
     while (true) {
       List<IReductionOpportunity> ops = ReductionOpportunities
           .getReductionOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false,
-              ShadingLanguageVersion.GLSL_440, new RandomWrapper(0), new IdGenerator()), fileOps);
+          new ReducerContext(false, true,
+              ShadingLanguageVersion.GLSL_440, new RandomWrapper(0),
+              new IdGenerator()), fileOps);
       if (ops.isEmpty()) {
         break;
       }
@@ -685,14 +689,14 @@ public class ReductionOpportunitiesTest {
     {
       List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator()));
       assertEquals(0, ops.size());
     }
     {
       List<IdentityMutationReductionOpportunity> ops = IdentityMutationReductionOpportunities
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator()));
       assertEquals(1, ops.size());
       ops.get(0).applyReduction();
@@ -707,7 +711,7 @@ public class ReductionOpportunitiesTest {
     {
       List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator()));
       assertEquals(2, ops.size());
       ops.get(0).applyReduction();
@@ -723,7 +727,7 @@ public class ReductionOpportunitiesTest {
     {
       List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
               .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator()));
       assertEquals(1, ops.size());
       ops.get(0).applyReduction();
@@ -738,7 +742,7 @@ public class ReductionOpportunitiesTest {
     {
       List<StmtReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
       assertEquals(1, ops.size());
       ops.get(0).applyReduction();
@@ -783,7 +787,7 @@ public class ReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+            new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(4, ops.size());
 
@@ -919,7 +923,7 @@ public class ReductionOpportunitiesTest {
     List<StmtReductionOpportunity> stmtOps = StmtReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
         new ReducerContext(false,
-        ShadingLanguageVersion.GLSL_440,
+        true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(7, stmtOps.size());
     for (StmtReductionOpportunity op : stmtOps) {
@@ -929,7 +933,7 @@ public class ReductionOpportunitiesTest {
 
     ops = VectorizationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+            new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(3, ops.size());
 
@@ -1004,7 +1008,7 @@ public class ReductionOpportunitiesTest {
             + "}\n";
     stmtOps = StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
         new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440,
+            true, ShadingLanguageVersion.GLSL_440,
             new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(3, stmtOps.size());
     for (StmtReductionOpportunity op : stmtOps) {
@@ -1027,7 +1031,7 @@ public class ReductionOpportunitiesTest {
     List<VariableDeclReductionOpportunity> varDeclOps = VariableDeclReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
             new ReducerContext(false,
-                ShadingLanguageVersion.GLSL_440,
+                true, ShadingLanguageVersion.GLSL_440,
                 new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(5, varDeclOps.size());
     for (VariableDeclReductionOpportunity op : varDeclOps) {
@@ -1045,7 +1049,7 @@ public class ReductionOpportunitiesTest {
     List<StmtReductionOpportunity> finalStmtOps =
         StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
         new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440,
+            true, ShadingLanguageVersion.GLSL_440,
             new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(5, finalStmtOps.size());
     for (StmtReductionOpportunity op : finalStmtOps) {
@@ -1068,7 +1072,7 @@ public class ReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, ops.size());
     for (VariableDeclReductionOpportunity op : ops) {
@@ -1076,7 +1080,7 @@ public class ReductionOpportunitiesTest {
     }
     final List<StmtReductionOpportunity> moreOps = StmtReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, moreOps.size());
   }
@@ -1124,7 +1128,7 @@ public class ReductionOpportunitiesTest {
 
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+        new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
             new RandomWrapper(0), new IdGenerator()), fileOps);
     assertEquals(1, ops.size());
     assertTrue(ops.get(0) instanceof VariableDeclReductionOpportunity);
@@ -1162,7 +1166,7 @@ public class ReductionOpportunitiesTest {
         + "}\n");
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.GLSL_440,
+            true, ShadingLanguageVersion.GLSL_440,
             new RandomWrapper(0), new IdGenerator()), fileOps);
     ops.forEach(IReductionOpportunity::applyReduction);
   }
@@ -1179,7 +1183,7 @@ public class ReductionOpportunitiesTest {
 
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_310,
+            true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()), fileOps);
     assertFalse(ops.isEmpty());
   }
@@ -1200,7 +1204,7 @@ public class ReductionOpportunitiesTest {
 
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_310,
+            true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()), fileOps);
 
     // We expect two less than the number of precision declarations above.
@@ -1222,7 +1226,7 @@ public class ReductionOpportunitiesTest {
 
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_310,
+            true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()), fileOps);
     // Neither precision statement can be removed since they each affect a declaration.
     assertTrue(ops.isEmpty());
@@ -1242,7 +1246,7 @@ public class ReductionOpportunitiesTest {
 
     List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_310,
+            true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()), fileOps);
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveRedundantUniformMetadataReductionOpportunitiesTest.java
@@ -52,7 +52,8 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
         RemoveRedundantUniformMetadataReductionOpportunities
         .findOpportunities(shaderJob,
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                 new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -82,7 +83,7 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
         RemoveRedundantUniformMetadataReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0),
                 new IdGenerator()));
     assertEquals(1, ops.size());
@@ -112,7 +113,8 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
         RemoveRedundantUniformMetadataReductionOpportunities
         .findOpportunities(shaderJob,
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                 new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -142,7 +144,8 @@ public class RemoveRedundantUniformMetadataReductionOpportunitiesTest {
     List<RemoveRedundantUniformMetadataReductionOpportunity> ops =
         RemoveRedundantUniformMetadataReductionOpportunities
             .findOpportunities(shaderJob,
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
+                new ReducerContext(false, true,
+                    ShadingLanguageVersion.ESSL_100, new RandomWrapper(0),
                 new IdGenerator()));
     assertEquals(0, ops.size());
   }

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveStructFieldReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveStructFieldReductionOpportunitiesTest.java
@@ -50,7 +50,7 @@ public class RemoveStructFieldReductionOpportunitiesTest {
 
     assertEquals(2, RemoveStructFieldReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator())).size());
 
   }
@@ -72,7 +72,7 @@ public class RemoveStructFieldReductionOpportunitiesTest {
 
     assertEquals(0, RemoveStructFieldReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
               new RandomWrapper(0), new IdGenerator())).size());
 
   }
@@ -105,7 +105,7 @@ public class RemoveStructFieldReductionOpportunitiesTest {
     TranslationUnit tu = ParseHelper.parse(shader);
     List<RemoveStructFieldReductionOpportunity> ops = RemoveStructFieldReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(true, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(true, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -142,7 +142,7 @@ public class RemoveStructFieldReductionOpportunitiesTest {
 
     final List<RemoveStructFieldReductionOpportunity> ops = RemoveStructFieldReductionOpportunities
           .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(2, ops
           .size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveUnusedParameterReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/RemoveUnusedParameterReductionOpportunitiesTest.java
@@ -141,7 +141,7 @@ public class RemoveUnusedParameterReductionOpportunitiesTest {
       boolean reduceEverywhere) {
     return RemoveUnusedParameterReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(reduceEverywhere,
+            new ReducerContext(reduceEverywhere, true,
                 ShadingLanguageVersion.ESSL_100, new RandomWrapper(0), new IdGenerator()));
   }
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/StmtReductionOpportunitiesTest.java
@@ -78,7 +78,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(prog);
     List<StmtReductionOpportunity> ops = StmtReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.GLSL_130,
+            new ReducerContext(false, true, ShadingLanguageVersion.GLSL_130,
         new RandomWrapper(0), new IdGenerator()));
 
     for (StmtReductionOpportunity op : ops) {
@@ -104,7 +104,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(prog);
     List<StmtReductionOpportunity> ops = StmtReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_310,
+            true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()));
 
     assertEquals(1, ops.size());
@@ -125,7 +125,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+                new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                     new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     assertTrue(ops.get(0) instanceof StmtReductionOpportunity);
@@ -141,7 +141,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     assertTrue(ops.get(0) instanceof StmtReductionOpportunity);
@@ -156,7 +156,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0),
                   new IdGenerator()));
     assertEquals(0, ops.size());
@@ -168,7 +168,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0),
                   new IdGenerator()));
     assertEquals(0, ops.size());
@@ -186,7 +186,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     assertTrue(ops.get(0) instanceof StmtReductionOpportunity);
@@ -210,7 +210,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, ops.size());
     for (int i = 0; i < ops.size(); i++) {
@@ -228,7 +228,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     assertTrue(ops.get(0) instanceof StmtReductionOpportunity);
@@ -243,7 +243,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<? extends IReductionOpportunity> ops =
           StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-              new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+              new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
                   new RandomWrapper(0), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -272,7 +272,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
           MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_300,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_300,
               new RandomWrapper(0),
               new IdGenerator()));
     assertEquals(4, ops.size());
@@ -294,7 +294,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
           MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, ShadingLanguageVersion.ESSL_300,
+          new ReducerContext(false, true, ShadingLanguageVersion.ESSL_300,
               new RandomWrapper(0), new IdGenerator()));
     assertEquals(3, ops.size());
   }
@@ -304,7 +304,7 @@ public class StmtReductionOpportunitiesTest {
     final String program = "int foo() { return 0; return 1; return 2; return 3; }";
     final String expected = "int foo() { return 1; }";
     final TranslationUnit tu = ParseHelper.parse(program);
-    final ReducerContext context = new ReducerContext(true, ShadingLanguageVersion.ESSL_300,
+    final ReducerContext context = new ReducerContext(true, true, ShadingLanguageVersion.ESSL_300,
         new RandomWrapper(0),
         new IdGenerator());
     final ShaderJob shaderJob = MakeShaderJobFromFragmentShader.make(tu);
@@ -341,7 +341,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_300, new RandomWrapper(0),
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_300, new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(6, ops.size());
     ops.get(0).applyReduction();
@@ -360,7 +360,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_300,
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_300,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(5, ops.size());
   }
@@ -372,7 +372,7 @@ public class StmtReductionOpportunitiesTest {
     final String program = "int foo() { return 1; return 0; }";
     final String expected = "int foo() { return 0; }";
     final TranslationUnit tu = ParseHelper.parse(program);
-    final ReducerContext context = new ReducerContext(true, ShadingLanguageVersion.ESSL_300,
+    final ReducerContext context = new ReducerContext(true, true, ShadingLanguageVersion.ESSL_300,
         new RandomWrapper(0), new IdGenerator());
     final ShaderJob shaderJob = MakeShaderJobFromFragmentShader.make(tu);
     List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
@@ -412,7 +412,7 @@ public class StmtReductionOpportunitiesTest {
         + "  }\n"
         + "}\n";
     final TranslationUnit tu = ParseHelper.parse(program);
-    final ReducerContext context = new ReducerContext(true, ShadingLanguageVersion.ESSL_300,
+    final ReducerContext context = new ReducerContext(true, true, ShadingLanguageVersion.ESSL_300,
         new RandomWrapper(0), new IdGenerator());
     final ShaderJob shaderJob = MakeShaderJobFromFragmentShader.make(tu);
     List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
@@ -439,7 +439,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_300, new RandomWrapper(0),
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_300, new RandomWrapper(0),
             new IdGenerator()));
     // We cannot remove the return, as this would make the write to 'color' reachable.
     // We could in principle remove the color write itself, since it is unreachable.  Right now we
@@ -461,7 +461,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(true, ShadingLanguageVersion.ESSL_300, new RandomWrapper(0),
+        new ReducerContext(true, true, ShadingLanguageVersion.ESSL_300, new RandomWrapper(0),
             new IdGenerator()));
     assertTrue(ops.size() > 0);
   }
@@ -585,7 +585,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops =
         StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_310,
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -609,7 +609,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -636,7 +636,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(2, ops.size());
     ops.get(0).applyReduction();
@@ -672,7 +672,7 @@ public class StmtReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     final List<StmtReductionOpportunity> ops = StmtReductionOpportunities.findOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
+        new ReducerContext(false, true, ShadingLanguageVersion.ESSL_310, new RandomWrapper(0),
             new IdGenerator()));
     assertEquals(2, ops.size());
     ops.get(0).applyReduction();

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/SwitchToLoopReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/SwitchToLoopReductionOpportunitiesTest.java
@@ -45,7 +45,7 @@ public class SwitchToLoopReductionOpportunitiesTest {
     final List<VariableDeclToExprReductionOpportunity> ops =
         VariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_320,
+                true, ShadingLanguageVersion.ESSL_320,
                 new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as the preserve semantics is enabled.
     assertTrue(ops.isEmpty());
@@ -73,7 +73,7 @@ public class SwitchToLoopReductionOpportunitiesTest {
     final List<SwitchToLoopReductionOpportunity> ops =
         SwitchToLoopReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-                ShadingLanguageVersion.ESSL_320,
+                true, ShadingLanguageVersion.ESSL_320,
                 new RandomWrapper(0), new IdGenerator()));
     // There should be an opportunity, as the switch statement is in a dead code block.
     assertEquals(1, ops.size());
@@ -116,7 +116,7 @@ public class SwitchToLoopReductionOpportunitiesTest {
     final List<SwitchToLoopReductionOpportunity> ops =
         SwitchToLoopReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-                ShadingLanguageVersion.ESSL_320,
+                true, ShadingLanguageVersion.ESSL_320,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -164,7 +164,7 @@ public class SwitchToLoopReductionOpportunitiesTest {
     final List<SwitchToLoopReductionOpportunity> ops =
         SwitchToLoopReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-                ShadingLanguageVersion.ESSL_320,
+                true, ShadingLanguageVersion.ESSL_320,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -199,7 +199,7 @@ public class SwitchToLoopReductionOpportunitiesTest {
     final List<SwitchToLoopReductionOpportunity> ops =
         SwitchToLoopReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-                ShadingLanguageVersion.ESSL_320,
+                true, ShadingLanguageVersion.ESSL_320,
                 new RandomWrapper(0), new IdGenerator()));
     assertEquals(2, ops.size());
     ops.get(0).applyReduction();

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/UnswitchifyReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/UnswitchifyReductionOpportunitiesTest.java
@@ -35,7 +35,7 @@ public class UnswitchifyReductionOpportunitiesTest {
     List<UnswitchifyReductionOpportunity> ops = UnswitchifyReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
               new ReducerContext(false,
-              ShadingLanguageVersion.GLSL_130,
+              true, ShadingLanguageVersion.GLSL_130,
                     new RandomWrapper(0),
                     new IdGenerator()));
     assertEquals(0, ops.size());

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/UnwrapReductionOpportunitiesTest.java
@@ -44,8 +44,9 @@ public class UnwrapReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false,
-        ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L), new IdGenerator()));
+          new ReducerContext(false, true,
+              ShadingLanguageVersion.GLSL_440,
+              new SameValueRandom(false, 0, 0L), new IdGenerator()));
     assertEquals(1, ops.size());
   }
 
@@ -56,7 +57,7 @@ public class UnwrapReductionOpportunitiesTest {
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
           new ReducerContext(false,
-          ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
+          true, ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
               new IdGenerator()));
     // No opportunities because the inner block is empty.  Another reduction pass may be able to
     // delete it, but it cannot be unwrapped.
@@ -69,8 +70,9 @@ public class UnwrapReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
+        new ReducerContext(false, true,
+            ShadingLanguageVersion.GLSL_440,
+            new SameValueRandom(false, 0, 0L),
             new IdGenerator()));
     assertEquals(1, ops.size());
   }
@@ -82,8 +84,9 @@ public class UnwrapReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L), new IdGenerator()));
+        new ReducerContext(false, true,
+            ShadingLanguageVersion.GLSL_440,
+            new SameValueRandom(false, 0, 0L), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
     CompareAsts.assertEqualAsts(expected, tu);
@@ -96,8 +99,9 @@ public class UnwrapReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
+        new ReducerContext(false, true,
+            ShadingLanguageVersion.GLSL_440,
+            new SameValueRandom(false, 0, 0L),
             new IdGenerator()));
     // The inner block cannot be unwrapped as it would change which variable 'x = 2' refers to.
     assertEquals(1, ops.size());
@@ -110,7 +114,7 @@ public class UnwrapReductionOpportunitiesTest {
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
         new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
+            true, ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
             new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -122,7 +126,7 @@ public class UnwrapReductionOpportunitiesTest {
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
         new ReducerContext(false,
-            ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
+            true, ShadingLanguageVersion.GLSL_440, new SameValueRandom(false, 0, 0L),
             new IdGenerator()));
     assertEquals(2, ops.size());
     assertTrue(ops.get(0).preconditionHolds());
@@ -157,7 +161,7 @@ public class UnwrapReductionOpportunitiesTest {
     IRandom generator = new RandomWrapper(1);
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, generator,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100, generator,
                 new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -172,11 +176,13 @@ public class UnwrapReductionOpportunitiesTest {
     final IRandom generator = new RandomWrapper(0);
     List<StmtReductionOpportunity> stmtOps = StmtReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, generator,
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100, generator,
                 new IdGenerator()));
     List<UnwrapReductionOpportunity> unwrapOps = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100, generator,
+            new ReducerContext(false, true,
+                ShadingLanguageVersion.ESSL_100, generator,
                 new IdGenerator()));
     assertFalse(stmtOps.isEmpty());
     assertFalse(unwrapOps.isEmpty());
@@ -211,13 +217,13 @@ public class UnwrapReductionOpportunitiesTest {
     final IdGenerator idGenerator = new IdGenerator();
     List<UnwrapReductionOpportunity> ops = UnwrapReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, version,
+            new ReducerContext(false, true, version,
           generator, idGenerator));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
     List<? extends IReductionOpportunity> remainingOps = VariableDeclReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, version, generator, idGenerator));
+            new ReducerContext(false, true, version, generator, idGenerator));
     assertEquals(PrettyPrinterVisitor.prettyPrintAsString(tu),
         PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected)));
     assertEquals(2, remainingOps.size());
@@ -233,7 +239,7 @@ public class UnwrapReductionOpportunitiesTest {
         PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected2)));
     remainingOps =
         StmtReductionOpportunities.findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, version, generator, idGenerator));
+            new ReducerContext(false, true, version, generator, idGenerator));
     assertEquals(3, remainingOps.size());
     remainingOps.get(0).applyReduction();
     remainingOps.get(1).applyReduction();
@@ -244,7 +250,7 @@ public class UnwrapReductionOpportunitiesTest {
         PrettyPrinterVisitor.prettyPrintAsString(ParseHelper.parse(expected3)));
     remainingOps = ReductionOpportunities.getReductionOpportunities(
         MakeShaderJobFromFragmentShader.make(tu),
-          new ReducerContext(false, version, generator, idGenerator), fileOps);
+          new ReducerContext(false, true, version, generator, idGenerator), fileOps);
     assertEquals(0, remainingOps.size());
   }
 

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclReductionOpportunitiesTest.java
@@ -40,7 +40,7 @@ public class VariableDeclReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -54,7 +54,7 @@ public class VariableDeclReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -68,7 +68,7 @@ public class VariableDeclReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<VariableDeclReductionOpportunity> ops = VariableDeclReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.ESSL_100,
+            new ReducerContext(false, true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -87,6 +87,7 @@ public class VariableDeclReductionOpportunitiesTest {
             MakeShaderJobFromFragmentShader.make(tu),
             new ReducerContext(
                 false,
+                true,
                 ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0),
                 new IdGenerator())
@@ -115,6 +116,7 @@ public class VariableDeclReductionOpportunitiesTest {
             MakeShaderJobFromFragmentShader.make(tu),
             new ReducerContext(
                 false,
+                true,
                 ShadingLanguageVersion.ESSL_310,
                 new RandomWrapper(0),
                 new IdGenerator())

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclToExprReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VariableDeclToExprReductionOpportunitiesTest.java
@@ -37,7 +37,7 @@ public class VariableDeclToExprReductionOpportunitiesTest {
     final List<VariableDeclToExprReductionOpportunity> ops =
         VariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(false,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as the preserve semantics is enabled.
     assertTrue(ops.isEmpty());
@@ -50,7 +50,7 @@ public class VariableDeclToExprReductionOpportunitiesTest {
     final List<VariableDeclToExprReductionOpportunity> ops =
         VariableDeclToExprReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-                ShadingLanguageVersion.ESSL_100,
+                true, ShadingLanguageVersion.ESSL_100,
                 new RandomWrapper(0), new IdGenerator()));
     // There should be no opportunities as it is invalid to declare constant variable
     // without an initial value.
@@ -74,7 +74,7 @@ public class VariableDeclToExprReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     // Only variable declarations a and b have the initializer.
     // Thus, we expect the reducer to find only 2 opportunities.
@@ -103,7 +103,7 @@ public class VariableDeclToExprReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(3, ops.size());
     ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);
@@ -132,7 +132,7 @@ public class VariableDeclToExprReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(program);
     List<VariableDeclToExprReductionOpportunity> ops = VariableDeclToExprReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu), new ReducerContext(true,
-            ShadingLanguageVersion.ESSL_100,
+            true, ShadingLanguageVersion.ESSL_100,
             new RandomWrapper(0), new IdGenerator()));
     assertEquals(4, ops.size());
     ops.forEach(VariableDeclToExprReductionOpportunity::applyReductionImpl);

--- a/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VectorizationReductionOpportunitiesTest.java
+++ b/reducer/src/test/java/com/graphicsfuzz/reducer/reductionopportunities/VectorizationReductionOpportunitiesTest.java
@@ -78,7 +78,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(2, ops.size());
     ops =
@@ -127,7 +127,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+        new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
             new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(2, ops.size());
     ops.stream().filter(item -> item.getVectorName().equals("GLF_merged2_0_1_1_1_1_1bc")
@@ -140,7 +140,7 @@ public class VectorizationReductionOpportunitiesTest {
         PrettyPrinterVisitor.prettyPrintAsString(tu));
     ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-        new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+        new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
             new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -185,7 +185,7 @@ public class VectorizationReductionOpportunitiesTest {
     final IRandom cannedRandom = new ZeroCannedRandom();
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
                     cannedRandom, new IdGenerator()));
     assertEquals(3, ops.size());
     ops.stream().filter(item -> item.getComponentName().equals("P")).findAny().get()
@@ -202,7 +202,7 @@ public class VectorizationReductionOpportunitiesTest {
         PrettyPrinterVisitor.prettyPrintAsString(tu));
     ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
                     cannedRandom, new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -247,7 +247,7 @@ public class VectorizationReductionOpportunitiesTest {
     final IRandom cannedRandom = new CannedRandom(2);
     final List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
                     cannedRandom, new IdGenerator()));
     ops.stream().filter(item -> item.getComponentName().equals("a")).findAny().get()
         .applyReduction();
@@ -302,7 +302,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(shader);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(3, ops.size());
     ops.stream().filter(item -> item.getComponentName().equals("GLF_merged2_0_1_1_1_1_1PQ"))
@@ -355,7 +355,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+            new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
                 new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(2, ops.size());
     ops.stream().filter(item -> item.getComponentName().equals("b")).findAny().get()
@@ -364,7 +364,7 @@ public class VectorizationReductionOpportunitiesTest {
         PrettyPrinterVisitor.prettyPrintAsString(tu));
     ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.stream().filter(item -> item.getComponentName().equals("c")).findAny().get()
@@ -403,7 +403,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(2, ops.size());
     ops.get(0).applyReduction();
@@ -411,7 +411,7 @@ public class VectorizationReductionOpportunitiesTest {
         PrettyPrinterVisitor.prettyPrintAsString(tu));
     ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -445,7 +445,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(shader);
     final List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.GLSL_440, new RandomWrapper(0),
+            new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440, new RandomWrapper(0),
                 new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -466,7 +466,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
         .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-            new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+            new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
                 new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(0, ops.size());
   }
@@ -501,7 +501,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(1, ops.size());
     ops.get(0).applyReduction();
@@ -525,7 +525,7 @@ public class VectorizationReductionOpportunitiesTest {
     final TranslationUnit tu = ParseHelper.parse(original);
     List<VectorizationReductionOpportunity> ops = VectorizationReductionOpportunities
             .findOpportunities(MakeShaderJobFromFragmentShader.make(tu),
-                new ReducerContext(false, ShadingLanguageVersion.GLSL_440,
+                new ReducerContext(false, true, ShadingLanguageVersion.GLSL_440,
         new ZeroCannedRandom(), new IdGenerator()));
     assertEquals(0, ops.size());
   }

--- a/tester/src/test/java/com/graphicsfuzz/tester/MiscellaneousGenerateThenReduceTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/MiscellaneousGenerateThenReduceTest.java
@@ -77,7 +77,7 @@ public class MiscellaneousGenerateThenReduceTest {
       List<IReductionOpportunity> ops = ReductionOpportunities
           .getReductionOpportunities(new GlslShaderJob(Optional.empty(),
                   new PipelineInfo(), tu),
-                new ReducerContext(false, shadingLanguageVersion,
+                new ReducerContext(false, true, shadingLanguageVersion,
               new SameValueRandom(false, 0, 0L), new IdGenerator()), fileOps);
       if (ops.isEmpty()) {
         break;

--- a/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/ReducerUnitTest.java
@@ -127,7 +127,7 @@ public class ReducerUnitTest {
       List<IReductionOpportunity> ops = ReductionOpportunities.getReductionOpportunities(
           new GlslShaderJob(Optional.empty(), pipelineInfo,
               fragmentShader),
-          new ReducerContext(false, fragmentShader.getShadingLanguageVersion(),
+          new ReducerContext(false, true, fragmentShader.getShadingLanguageVersion(),
               generator, idGenerator),
           fileOps);
       if (ops.isEmpty()) {
@@ -220,7 +220,7 @@ public class ReducerUnitTest {
       final String shaderJobShortName = FilenameUtils.removeExtension(shaderJobFile.getName());
 
       new ReductionDriver(new ReducerContext(false,
-          shadingLanguageVersion, generator,
+          true, shadingLanguageVersion, generator,
             new IdGenerator()), false, fileOps,
           new RandomFileJudge(generator, threshold, throwExceptionOnInvalid, fileOps),
           workDir)
@@ -393,7 +393,7 @@ public class ReducerUnitTest {
     final ShaderJob state = fileOps.readShaderJobFile(shaderJobFile);
     fileOps.copyShaderJobFileTo(shaderJobFile, new File(temporaryFolder.getRoot(),
         shaderJobFile.getName()), false);
-    return new ReductionDriver(new ReducerContext(false, version, generator,
+    return new ReductionDriver(new ReducerContext(false, true, version, generator,
         new IdGenerator()), false, fileOps,
         fileJudge, temporaryFolder.getRoot())
         .doReduction(state, shaderJobShortName, 0, -1);


### PR DESCRIPTION
For integration with GLSLsmith, we don't want glsl-reduce to add
undefined behaviour guards (because GLSLsmith will add them).