### PR TITLE
Apply floor() to gl_FragCoord

### DIFF
--- a/shaders/src/main/glsl/samples/100/colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/100/colorgrid_modulo.frag
@@ -38,8 +38,8 @@ void main()
     vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
     float ref = floor(resolution.x / 8.0);
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/100/mandelbrot_zoom.frag
+++ b/shaders/src/main/glsl/samples/100/mandelbrot_zoom.frag
@@ -55,7 +55,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/100/squares.frag
+++ b/shaders/src/main/glsl/samples/100/squares.frag
@@ -96,7 +96,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/100/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/100/stable_bubblesort_flag.frag
@@ -24,7 +24,7 @@ uniform vec2 resolution;
 
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 void main()
 {
@@ -62,7 +62,7 @@ void main()
                         }
                 }
         }
-    if(gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
         {
             gl_FragColor = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }

--- a/shaders/src/main/glsl/samples/300es/binarysearch_bw.frag
+++ b/shaders/src/main/glsl/samples/300es/binarysearch_bw.frag
@@ -55,7 +55,7 @@ vec2 brick(vec2 uv) {
     int b = 3;
     do {
         uv.y -= step(injectionSwitch.y, uv.x) + float(a);
-        uv.x *= (isnan(uv.y) ? cosh(gl_FragCoord.y) : tanh(gl_FragCoord.x));
+        uv.x *= (isnan(uv.y) ? cosh(floor(gl_FragCoord.y)) : tanh(floor(gl_FragCoord.x)));
         b--;
     } while (b > int(injectionSwitch.x));
     int c = 2;
@@ -75,7 +75,7 @@ vec2 brick(vec2 uv) {
 float patternize(vec2 uv) {
     vec2 size = vec2(0.45);
     vec2 st = smoothstep(size, size, uv);
-     switch (int(mod(gl_FragCoord.y, 5.0))) {
+     switch (int(mod(floor(gl_FragCoord.y), 5.0))) {
         case 0:
             return mix(pow(st.x, injectionSwitch.y), st.x, size.y);
         break;
@@ -139,11 +139,11 @@ void main() {
         }
     }
 
-    vec2 uv = (gl_FragCoord.xy / resolution.x) * vec2(resolution.x / resolution.y, 1.0);
+    vec2 uv = (floor(gl_FragCoord.xy) / resolution.x) * vec2(resolution.x / resolution.y, 1.0);
     vec2 b = brick(uv * 7.0);
     vec3 color = vec3(patternize(b));
 
-    if (gl_FragCoord.y < resolution.y / 1.1) {
+    if (floor(gl_FragCoord.y) < resolution.y / 1.1) {
         // We are going to search the item in array by giving the value of the item index 4 and 0 in an array.
         if (binarySearch(obj, obj.prime_numbers[4]) != -(int(resolution.y)) && binarySearch(obj, obj.prime_numbers[0]) >= -(int(resolution.x))) {
             color.yz -= dot(float(binarySearch(obj, obj.prime_numbers[4])), float(binarySearch(obj, obj.prime_numbers[0])));

--- a/shaders/src/main/glsl/samples/300es/binarysearch_tree.frag
+++ b/shaders/src/main/glsl/samples/300es/binarysearch_tree.frag
@@ -151,7 +151,7 @@ void main() {
     treeIndex++;
     insert(treeIndex, 13);
 
-    vec2 z = (gl_FragCoord.yx / resolution);
+    vec2 z = (floor(gl_FragCoord.yx) / resolution);
     float x = makeFrame(z.x);
     float y = makeFrame(z.y);
 

--- a/shaders/src/main/glsl/samples/300es/colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/300es/colorgrid_modulo.frag
@@ -40,8 +40,8 @@ void main()
     vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
     float ref = floor(resolution.x / 8.0);
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/300es/householder_lattice.frag
+++ b/shaders/src/main/glsl/samples/300es/householder_lattice.frag
@@ -28,7 +28,7 @@ void main()
 {
     // We need to modify A in place, so we have to copy the uniform
     mat4 matrix_a = mat4(matrix_a_uni);
-    vec4 matrix_b = gl_FragCoord.wxyz;
+    vec4 matrix_b = floor(gl_FragCoord.wxyz);
 
     vec4 matrix_u = vec4(0.0);
 

--- a/shaders/src/main/glsl/samples/300es/mandelbrot_fixed_point.frag
+++ b/shaders/src/main/glsl/samples/300es/mandelbrot_fixed_point.frag
@@ -63,7 +63,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/300es/mandelbrot_zoom.frag
+++ b/shaders/src/main/glsl/samples/300es/mandelbrot_zoom.frag
@@ -57,7 +57,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/300es/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/300es/mergesort_mosaic.frag
@@ -121,13 +121,13 @@ void main() {
         vec3(0, -5, int(injectionSwitch.y)) * LDEXP(0.2, 5.0),
         vec3(1, 8, int(injectionSwitch.y)) * LDEXP(injectionSwitch.y, 0.0)
     );
-    vec3 vecCoor = roundEven(pos * vec3(gl_FragCoord.xx / resolution.yx, 1));
+    vec3 vecCoor = roundEven(pos * vec3(floor(gl_FragCoord.xx) / resolution.yx, 1));
     vec2 color;
 
     do {
         if (int(gl_FragCoord[1]) < 30) {
             color = fract(sin(vecCoor.yx - trunc(float(data[0]))));
-            color[0] = dFdy(gl_FragCoord.y);
+            color[0] = dFdy(floor(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 60) {
             color = fract(sin(vecCoor.yx - trunc(float(data[1]))));
@@ -135,17 +135,17 @@ void main() {
             break;
         } else if (int(gl_FragCoord[1]) < 90) {
             color = fract(sin(vecCoor.yx - trunc(float(data[2]))));
-            color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
+            color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, floor(gl_FragCoord.yy)).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
             color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1.0, 1000.0)));
-            color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
+            color.x += (isnan(floor(gl_FragCoord.x)) ? log2(floor(gl_FragCoord.x)) : log2(floor(gl_FragCoord.y)));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {
             discard;
         } else if (int(gl_FragCoord[1]) < 180) {
             color = fract(sin(vecCoor.yx - trunc(float(data[4]))));
-            color[1] += asinh(gl_FragCoord.y * LDEXP(color.y, float(-i)));
+            color[1] += asinh(floor(gl_FragCoord.y) * LDEXP(color.y, float(-i)));
             break;
         } else if (int(gl_FragCoord[1]) < 210) {
             color = fract(sin(vecCoor.yx - trunc(float(data[5]))));
@@ -153,7 +153,7 @@ void main() {
             break;
         } else if (int(gl_FragCoord[1]) < 240) {
             color = fract(asinh(vecCoor.yx - trunc(float(data[6]))));
-            color.y -= isnan(float(i)) ? tanh(gl_FragCoord.x): atanh(gl_FragCoord.y);
+            color.y -= isnan(float(i)) ? tanh(floor(gl_FragCoord.x)): atanh(floor(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 270) {
             color = fract(sin(vecCoor.yx - trunc(float(data[7]))));

--- a/shaders/src/main/glsl/samples/300es/prefix_sum_checkers.frag
+++ b/shaders/src/main/glsl/samples/300es/prefix_sum_checkers.frag
@@ -46,7 +46,7 @@ vec2 pattern(in vec2 x) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / resolution.y;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.y;
   float A[50];
   for (int i = 0; i < 200; i++) {
     if (i >= int(resolution.x)) {

--- a/shaders/src/main/glsl/samples/300es/quicksort_palette.frag
+++ b/shaders/src/main/glsl/samples/300es/quicksort_palette.frag
@@ -97,7 +97,7 @@ void main() {
     }
     quicksort();
     vec2 grid = vec2(20, 20);
-    vec2 uv = gl_FragCoord.xy / resolution;
+    vec2 uv = floor(gl_FragCoord.xy) / resolution;
     vec3 color = palette(vec3(float(obj.numbers[4]) * 0.1), vec3(0.9, float(obj.numbers[8]) * 0.1, 0.8), trunc(vec3(injectionSwitch.y)), vec3(injectionSwitch.x, 0.3, 0.7));
     if (uv.x > (1.0 / 4.0)) {
         int count = int(injectionSwitch.x);
@@ -124,7 +124,7 @@ void main() {
         grid += vec2(count + obj.numbers[3], count + obj.numbers[3]);
     }
 
-    vec2 position = vec2(gl_FragCoord.x, resolution.x - gl_FragCoord.y);
+    vec2 position = vec2(floor(gl_FragCoord.x), resolution.x - floor(gl_FragCoord.y));
     position = floor(position / grid);
     _GLF_color = vec4(color, injectionSwitch.y) + vec4(!puzzlelize(position));
 

--- a/shaders/src/main/glsl/samples/300es/selection_sort_struct.frag
+++ b/shaders/src/main/glsl/samples/300es/selection_sort_struct.frag
@@ -60,11 +60,11 @@ void main() {
     obj.even_numbers[i] = smaller_number;
   }
 
-  vec2 uv = gl_FragCoord.xy/resolution.xy;
+  vec2 uv = floor(gl_FragCoord.xy)/resolution.xy;
   vec3 col =  tan(pow(uv.xxx, uv.yyy) +
   vec3(
-    obj.odd_numbers[int(floor(gl_FragCoord.x/1000.0))],
-    obj.even_numbers[int(floor(gl_FragCoord.y/1000.0))],
+    obj.odd_numbers[int(floor(floor(gl_FragCoord.x) / 1000.0))],
+    obj.even_numbers[int(floor(floor(gl_FragCoord.y) / 1000.0))],
     sinh(uv.x)
   ));
 

--- a/shaders/src/main/glsl/samples/300es/squares.frag
+++ b/shaders/src/main/glsl/samples/300es/squares.frag
@@ -98,7 +98,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/300es/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/300es/stable_bubblesort_flag.frag
@@ -26,7 +26,7 @@ uniform vec2 resolution;
 
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 void main()
 {
@@ -64,7 +64,7 @@ void main()
                         }
                 }
         }
-    if(gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
         {
             _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }

--- a/shaders/src/main/glsl/samples/300es/trigonometric_strip.frag
+++ b/shaders/src/main/glsl/samples/300es/trigonometric_strip.frag
@@ -37,7 +37,7 @@ float compute_stripe(float v) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / resolution.x;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.x;
   vec3 col = vec3(0, 0, 0);
 
   bool c1 = uv.y < 0.25;

--- a/shaders/src/main/glsl/samples/320es/binarysearch_bw.frag
+++ b/shaders/src/main/glsl/samples/320es/binarysearch_bw.frag
@@ -38,7 +38,7 @@ vec2 brick(vec2 uv) {
     int b = 3;
     do {
         uv.y -= step(injectionSwitch.y, uv.x) + float(a);
-        uv.x *= (isnan(uv.y) ? cosh(gl_FragCoord.y) : tanh(gl_FragCoord.x));
+        uv.x *= (isnan(uv.y) ? cosh(floor(gl_FragCoord.y)) : tanh(floor(gl_FragCoord.x)));
         b--;
     } while (b > int(injectionSwitch.x));
     int c = 2;
@@ -58,7 +58,7 @@ vec2 brick(vec2 uv) {
 float patternize(vec2 uv) {
     vec2 size = vec2(0.45);
     vec2 st = smoothstep(size, size, uv);
-     switch (int(mod(gl_FragCoord.y, 5.0))) {
+     switch (int(mod(floor(gl_FragCoord.y), 5.0))) {
         case 0:
             return mix(pow(st.x, injectionSwitch.y), st.x, size.y);
         break;
@@ -122,11 +122,11 @@ void main() {
         }
     }
 
-    vec2 uv = (gl_FragCoord.xy / resolution.x) * vec2(resolution.x / resolution.y, 1.0);
+    vec2 uv = (floor(gl_FragCoord.xy) / resolution.x) * vec2(resolution.x / resolution.y, 1.0);
     vec2 b = brick(uv * 7.0);
     vec3 color = vec3(patternize(b));
 
-    if (gl_FragCoord.y < resolution.y / 1.1) {
+    if (floor(gl_FragCoord.y) < resolution.y / 1.1) {
         // We are going to search the item in array by giving the value of the item index 4 and 0 in an array.
         if (binarySearch(obj, obj.prime_numbers[4]) != -(int(resolution.y)) && binarySearch(obj, obj.prime_numbers[0]) >= -(int(resolution.x))) {
             color.yz -= dot(float(binarySearch(obj, obj.prime_numbers[4])), float(binarySearch(obj, obj.prime_numbers[0])));

--- a/shaders/src/main/glsl/samples/320es/binarysearch_tree.frag
+++ b/shaders/src/main/glsl/samples/320es/binarysearch_tree.frag
@@ -149,7 +149,7 @@ void main() {
     treeIndex++;
     insert(treeIndex, 13);
 
-    vec2 z = (gl_FragCoord.yx / resolution);
+    vec2 z = (floor(gl_FragCoord.yx) / resolution);
     float x = makeFrame(z.x);
     float y = makeFrame(z.y);
 

--- a/shaders/src/main/glsl/samples/320es/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/320es/bubblesort_flag_intfunctions.frag
@@ -27,7 +27,7 @@ uniform vec2 resolution;
 
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 void main()
 {
@@ -58,7 +58,7 @@ void main()
         }
         i++;
     } while(i < findMSB(msb9));
-    if(gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
     {
         _GLF_color = vec4(data[findMSB(1)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(msb9)] / 10.0, 1.0);
     }

--- a/shaders/src/main/glsl/samples/320es/colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/320es/colorgrid_modulo.frag
@@ -40,8 +40,8 @@ void main()
     vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
     float ref = floor(resolution.x / 8.0);
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/320es/colorgrid_modulo_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/320es/colorgrid_modulo_intfunctions.frag
@@ -47,8 +47,8 @@ void main()
     vec4 c = vec4(bitfieldExtract(0, 0, 0), 0.0, 0.0, bitCount(msb8));
     float ref = floor(resolution.x / float(findLSB(msb8)));
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
     int i = bitfieldReverse(bitfieldExtract(0, 0, 0));
     do {

--- a/shaders/src/main/glsl/samples/320es/householder_lattice.frag
+++ b/shaders/src/main/glsl/samples/320es/householder_lattice.frag
@@ -28,7 +28,7 @@ void main()
 {
     // We need to modify A in place, so we have to copy the uniform
     mat4 matrix_a = mat4(matrix_a_uni);
-    vec4 matrix_b = gl_FragCoord.wxyz;
+    vec4 matrix_b = floor(gl_FragCoord.wxyz);
 
     vec4 matrix_u = vec4(0.0);
 

--- a/shaders/src/main/glsl/samples/320es/mandelbrot_fixed_point.frag
+++ b/shaders/src/main/glsl/samples/320es/mandelbrot_fixed_point.frag
@@ -63,7 +63,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/320es/mandelbrot_zoom.frag
+++ b/shaders/src/main/glsl/samples/320es/mandelbrot_zoom.frag
@@ -57,7 +57,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/320es/mandelbrot_zoom_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/320es/mandelbrot_zoom_intfunctions.frag
@@ -72,7 +72,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < findMSB(16); i++) {
     for (int j = 0; j < findLSB(16); j++) {
-      data[uaddCarry(uint(4*j), uint(i), uselessOutVariable)] = mand(gl_FragCoord.x + float(i - bitCount(1)), gl_FragCoord.y + float(j - bitCount(1)));
+      data[uaddCarry(uint(4*j), uint(i), uselessOutVariable)] = mand(floor(gl_FragCoord.x) + float(i - bitCount(1)), floor(gl_FragCoord.y) + float(j - bitCount(1)));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/320es/matrices_many_loops.frag
+++ b/shaders/src/main/glsl/samples/320es/matrices_many_loops.frag
@@ -87,8 +87,8 @@ void main()
   POPULATE_SUMS(m43, 4, 3, 7);
   POPULATE_SUMS(m44, 4, 4, 8);
 
-  int region_x = int(gl_FragCoord.x / (resolution.x / 3.0));
-  int region_y = int(gl_FragCoord.y / (resolution.x / 3.0));
+  int region_x = int(floor(gl_FragCoord.x) / (resolution.x / 3.0));
+  int region_y = int(floor(gl_FragCoord.y) / (resolution.x / 3.0));
   int overall_region = region_y * 3 + region_x;
 
   if (overall_region > 0 && overall_region < 9) {

--- a/shaders/src/main/glsl/samples/320es/matrices_smart_loops.frag
+++ b/shaders/src/main/glsl/samples/320es/matrices_smart_loops.frag
@@ -138,8 +138,8 @@ void main()
     }
   }
 
-  int region_x = int(gl_FragCoord.x / (resolution.x / 3.0));
-  int region_y = int(gl_FragCoord.y / (resolution.x / 3.0));
+  int region_x = int(floor(gl_FragCoord.x) / (resolution.x / 3.0));
+  int region_y = int(floor(gl_FragCoord.y) / (resolution.x / 3.0));
   int overall_region = region_y * 3 + region_x;
 
   if (overall_region > 0 && overall_region < 9) {

--- a/shaders/src/main/glsl/samples/320es/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/320es/mergesort_mosaic.frag
@@ -119,13 +119,13 @@ void main() {
         vec3(0, -5, int(injectionSwitch.y)) * ldexp(0.2, 5),
         vec3(1, 8, int(injectionSwitch.y)) * ldexp(injectionSwitch.y, 0)
     );
-    vec3 vecCoor = roundEven(pos * vec3(gl_FragCoord.xx / resolution.yx, 1));
+    vec3 vecCoor = roundEven(pos * vec3(floor(gl_FragCoord.xx) / resolution.yx, 1));
     vec2 color;
 
     do {
         if (int(gl_FragCoord[1]) < 30) {
             color = fract(sin(vecCoor.yx - trunc(float(data[0]))));
-            color[0] = dFdy(gl_FragCoord.y);
+            color[0] = dFdy(floor(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 60) {
             color = fract(sin(vecCoor.yx - trunc(float(data[1]))));
@@ -133,17 +133,17 @@ void main() {
             break;
         } else if (int(gl_FragCoord[1]) < 90) {
             color = fract(sin(vecCoor.yx - trunc(float(data[2]))));
-            color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
+            color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, floor(gl_FragCoord.yy)).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
             color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1.0, 1000.0)));
-            color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
+            color.x += (isnan(floor(gl_FragCoord.x)) ? log2(floor(gl_FragCoord.x)) : log2(floor(gl_FragCoord.y)));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {
             discard;
         } else if (int(gl_FragCoord[1]) < 180) {
             color = fract(sin(vecCoor.yx - trunc(float(data[4]))));
-            color[1] += asinh(gl_FragCoord.y * ldexp(color.y, -i));
+            color[1] += asinh(floor(gl_FragCoord.y) * ldexp(color.y, -i));
             break;
         } else if (int(gl_FragCoord[1]) < 210) {
             color = fract(sin(vecCoor.yx - trunc(float(data[5]))));
@@ -151,7 +151,7 @@ void main() {
             break;
         } else if (int(gl_FragCoord[1]) < 240) {
             color = fract(asinh(vecCoor.yx - trunc(float(data[6]))));
-            color.y -= isnan(float(i)) ? tanh(gl_FragCoord.x): atanh(gl_FragCoord.y);
+            color.y -= isnan(float(i)) ? tanh(floor(gl_FragCoord.x)): atanh(floor(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 270) {
             color = fract(sin(vecCoor.yx - trunc(float(data[7]))));

--- a/shaders/src/main/glsl/samples/320es/prefix_sum_checkers.frag
+++ b/shaders/src/main/glsl/samples/320es/prefix_sum_checkers.frag
@@ -46,7 +46,7 @@ vec2 pattern(in vec2 x) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / resolution.y;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.y;
   float A[50];
   for (int i = 0; i < 200; i++) {
     if (i >= int(resolution.x)) {

--- a/shaders/src/main/glsl/samples/320es/quicksort_palette.frag
+++ b/shaders/src/main/glsl/samples/320es/quicksort_palette.frag
@@ -97,7 +97,7 @@ void main() {
     }
     quicksort();
     vec2 grid = vec2(20, 20);
-    vec2 uv = gl_FragCoord.xy / resolution;
+    vec2 uv = floor(gl_FragCoord.xy) / resolution;
     vec3 color = palette(vec3(float(obj.numbers[4]) * 0.1), vec3(0.9, float(obj.numbers[8]) * 0.1, 0.8), trunc(vec3(injectionSwitch.y)), vec3(injectionSwitch.x, 0.3, 0.7));
     if (uv.x > (1.0 / 4.0)) {
         int count = int(injectionSwitch.x);
@@ -124,7 +124,7 @@ void main() {
         grid += vec2(count + obj.numbers[3], count + obj.numbers[3]);
     }
 
-    vec2 position = vec2(gl_FragCoord.x, resolution.x - gl_FragCoord.y);
+    vec2 position = vec2(floor(gl_FragCoord.x), resolution.x - floor(gl_FragCoord.y));
     position = floor(position / grid);
     _GLF_color = vec4(color, injectionSwitch.y) + vec4(!puzzlelize(position));
 

--- a/shaders/src/main/glsl/samples/320es/selection_sort_struct.frag
+++ b/shaders/src/main/glsl/samples/320es/selection_sort_struct.frag
@@ -60,11 +60,11 @@ void main() {
     obj.even_numbers[i] = smaller_number;
   }
 
-  vec2 uv = gl_FragCoord.xy/resolution.xy;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.xy;
   vec3 col =  tan(pow(uv.xxx, uv.yyy) +
   vec3(
-    obj.odd_numbers[int(floor(gl_FragCoord.x/1000.0))],
-    obj.even_numbers[int(floor(gl_FragCoord.y/1000.0))],
+    obj.odd_numbers[int(floor(floor(gl_FragCoord.x) / 1000.0))],
+    obj.even_numbers[int(floor(floor(gl_FragCoord.y) / 1000.0))],
     sinh(uv.x)
   ));
 

--- a/shaders/src/main/glsl/samples/320es/squares.frag
+++ b/shaders/src/main/glsl/samples/320es/squares.frag
@@ -98,7 +98,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/320es/squares_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/320es/squares_intfunctions.frag
@@ -102,7 +102,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/320es/stable_bifurcation.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_bifurcation.frag
@@ -61,7 +61,7 @@ to pick a color from the table of 16 colors.
 
 void main() {
   // pos is screen coordinates in 0..1 range
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // lin is screen coordinates in 0..9 range, integer steps;
   // this creates a grid pattern.
   ivec2 lin = ivec2(int(pos.x * 10.0), int(pos.y * 10.0));

--- a/shaders/src/main/glsl/samples/320es/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_bubblesort_flag.frag
@@ -47,7 +47,7 @@ are numerically stable.
 // vertically sort in one order, and for the other half the other.
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 
 void main()
@@ -86,7 +86,7 @@ void main()
     // Draw image based on the sorted values.
     // For half the screen horizontally use one order,
     // and for the other the inverse order of values.
-    if (gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
         {
             _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }

--- a/shaders/src/main/glsl/samples/320es/stable_collatz.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_collatz.frag
@@ -80,7 +80,7 @@ int collatz(int v) {
 
 void main() {
   // lin is screen coordinates in 0..1
-  vec2 lin = gl_FragCoord.xy / resolution;
+  vec2 lin = floor(gl_FragCoord.xy) / resolution;
   // now lin is screen coordinates in 0..7 in integer steps
   // this creates a tile pattern of 8x8 pixel tiles
   lin = floor(lin * 8.0);

--- a/shaders/src/main/glsl/samples/320es/stable_colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_colorgrid_modulo.frag
@@ -74,8 +74,8 @@ void main()
     // Use of uniform avoids compiler optimizations.
     float thirty_two = round(resolution.x / 8.0);
 
-    c.x = compute_value(gl_FragCoord.x, thirty_two);
-    c.y = compute_value(gl_FragCoord.y, thirty_two);
+    c.x = compute_value(floor(gl_FragCoord.x), thirty_two);
+    c.y = compute_value(floor(gl_FragCoord.y), thirty_two);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/320es/stable_logicops.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_logicops.frag
@@ -34,7 +34,7 @@ making this a stable shader.
 
 void main()
 {
-    vec2 coord = vec2(gl_FragCoord.xy) * (1.0 / 256.0);
+    vec2 coord = vec2(floor(gl_FragCoord.xy)) * (1.0 / 256.0);
     
     if (coord.x > 0.4)
     {

--- a/shaders/src/main/glsl/samples/320es/stable_maze.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_maze.frag
@@ -49,7 +49,7 @@ int map[16 * 16];
 
 void main() {
   // pos is screen position in 0..1 range
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // ipos is screen position in 0..15 range, in integer steps.
   // This creates a tile pattern.
   ivec2 ipos = ivec2(int(pos.x * 16.0), int(pos.y * 16.0));

--- a/shaders/src/main/glsl/samples/320es/stable_orbit.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_orbit.frag
@@ -69,7 +69,7 @@ ivec2 iter(ivec2 p) {
 
 void main() {
   // pos is screen coordinates in 0..1 range
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // ipos is screen coordinates in 0..7 range in integer steps.
   // This creates a tile pattern.
   ivec2 ipos = ivec2(int(pos.x * 8.0), int(pos.y * 8.0));

--- a/shaders/src/main/glsl/samples/320es/stable_pillars.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_pillars.frag
@@ -82,7 +82,7 @@ vec4 trace(ivec2 pos) {
 
 void main() {
   // pos is screen coodrdinates in 0..1
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // ipos is screen coordinates in 0..255 in integer steps.
   ivec2 ipos = ivec2(int(pos.x * 256.0), int(pos.y * 256.0));
 

--- a/shaders/src/main/glsl/samples/320es/stable_quicksort.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_quicksort.frag
@@ -123,7 +123,7 @@ void main() {
     quicksort();
 
     // uv gets screen coordinates in 0..1 range
-    vec2 uv = gl_FragCoord.xy / resolution;
+    vec2 uv = floor(gl_FragCoord.xy) / resolution;
 
     // start color from an arbituary vector
     vec3 color = vec3(1.0, 2.0, 3.0);

--- a/shaders/src/main/glsl/samples/320es/stable_rects.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_rects.frag
@@ -105,7 +105,7 @@ vec4 match(vec2 pos) {
 
 void main() {
   // Lin is screen position in 0..1 range
-  vec2 lin = gl_FragCoord.xy / resolution;
+  vec2 lin = floor(gl_FragCoord.xy) / resolution;
   // Lin is screen position in 0..31 range in integer steps.
   // This creates a tile pattern.
   lin = floor(lin * 32.0);

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_boxfilter.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_boxfilter.frag
@@ -44,7 +44,7 @@ const float weights[9] = float[9](
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     float uvstep = 1.0 / 256.0;
 
     vec4 res = vec4(0);

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_loop.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_loop.frag
@@ -42,7 +42,7 @@ uniform sampler2D tex;
 void main()
 {
     int i = 0;
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     vec4 texel = texture(tex, coord);
     while (texel.x + texel.y + texel.z > 1.0 && i < 16)
     {

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_minimal.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_minimal.frag
@@ -33,6 +33,6 @@ uniform sampler2D tex;
 
 void main()
 {
-    _GLF_color = texture(tex, gl_FragCoord.xy * (1.0 / 256.0));
+    _GLF_color = texture(tex, floor(gl_FragCoord.xy) * (1.0 / 256.0));
 }
 

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_mip.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_mip.frag
@@ -37,7 +37,7 @@ uniform sampler2D tex;
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     vec4 res = vec4(0.25);
     coord *= 2.0;
     int i = 0;

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_polar_simple.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_polar_simple.frag
@@ -92,7 +92,7 @@ vec2 polarize(vec2 coord)
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     coord = polarize(coord);
     coord = floor(coord * 256.0) / 256.0;
     _GLF_color = vec4(texture(tex, coord).xyz, 1.0);

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_polar_warp.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_polar_warp.frag
@@ -93,7 +93,7 @@ vec2 polarize(vec2 coord)
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
 
     vec2 coord1 = polarize(coord + vec2(20.0 / 256.0, -80.0 / 256.0));
     vec2 coord2 = polarize(coord + vec2(-60.0 / 256.0, 40.0 / 256.0));

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_reuse.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_reuse.frag
@@ -39,7 +39,7 @@ uniform sampler2D tex;
 
 void main()
 {
-    vec3 texel = texture(tex, gl_FragCoord.xy * (1.0 / 256.0)).xyz;
+    vec3 texel = texture(tex, floor(gl_FragCoord.xy) * (1.0 / 256.0)).xyz;
     vec2 reuse = (texel.xz + texel.yy) * 0.5 + vec2(0.25, 0.25);
     reuse = floor(reuse * 256.0) / 256.0;
     _GLF_color = texture(tex, reuse);

--- a/shaders/src/main/glsl/samples/320es/stable_sampler_trace.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_sampler_trace.frag
@@ -42,7 +42,7 @@ void main()
     int i = 0;
     vec2 uvstep = vec2(1.0) * (1.0 / 256.0);
     float slope = 2.0 / 256.0;
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     float refh = texture(tex, coord).y;
     coord -= uvstep;
     refh += slope;

--- a/shaders/src/main/glsl/samples/320es/stable_triangle.frag
+++ b/shaders/src/main/glsl/samples/320es/stable_triangle.frag
@@ -56,7 +56,7 @@ int pointInTriangle(vec2 p, vec2 a, vec2 b, vec2 c) {
 }
 
 void main() {
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   if (pointInTriangle(pos, vec2(0.7, 0.3), vec2(0.5, 0.9), vec2(0.1, 0.4)) == 1) {
     _GLF_color = vec4(1.0, 0.0, 0.0, 1.0);
   }

--- a/shaders/src/main/glsl/samples/320es/trigonometric_strip.frag
+++ b/shaders/src/main/glsl/samples/320es/trigonometric_strip.frag
@@ -37,7 +37,7 @@ float compute_stripe(float v) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / resolution.x;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.x;
   vec3 col = vec3(0, 0, 0);
 
   bool c1 = uv.y < 0.25;

--- a/shaders/src/main/glsl/samples/450/binarysearch_bw.frag
+++ b/shaders/src/main/glsl/samples/450/binarysearch_bw.frag
@@ -38,7 +38,7 @@ vec2 brick(vec2 uv) {
     int b = 3;
     do {
         uv.y -= step(injectionSwitch.y, uv.x) + float(a);
-        uv.x *= (isnan(uv.y) ? cosh(gl_FragCoord.y) : tanh(gl_FragCoord.x));
+        uv.x *= (isnan(uv.y) ? cosh(floor(gl_FragCoord.y)) : tanh(floor(gl_FragCoord.x)));
         b--;
     } while (b > int(injectionSwitch.x));
     int c = 2;
@@ -58,7 +58,7 @@ vec2 brick(vec2 uv) {
 float patternize(vec2 uv) {
     vec2 size = vec2(0.45);
     vec2 st = smoothstep(size, size, uv);
-     switch (int(mod(gl_FragCoord.y, 5.0))) {
+     switch (int(mod(floor(gl_FragCoord.y), 5.0))) {
         case 0:
             return mix(pow(st.x, injectionSwitch.y), st.x, size.y);
         break;
@@ -122,11 +122,11 @@ void main() {
         }
     }
 
-    vec2 uv = (gl_FragCoord.xy / resolution.x) * vec2(resolution.x / resolution.y, 1.0);
+    vec2 uv = (floor(gl_FragCoord.xy) / resolution.x) * vec2(resolution.x / resolution.y, 1.0);
     vec2 b = brick(uv * 7.0);
     vec3 color = vec3(patternize(b));
 
-    if (gl_FragCoord.y < resolution.y / 1.1) {
+    if (floor(gl_FragCoord.y) < resolution.y / 1.1) {
         // We are going to search the item in array by giving the value of the item index 4 and 0 in an array.
         if (binarySearch(obj, obj.prime_numbers[4]) != -(int(resolution.y)) && binarySearch(obj, obj.prime_numbers[0]) >= -(int(resolution.x))) {
             color.yz -= dot(float(binarySearch(obj, obj.prime_numbers[4])), float(binarySearch(obj, obj.prime_numbers[0])));

--- a/shaders/src/main/glsl/samples/450/binarysearch_tree.frag
+++ b/shaders/src/main/glsl/samples/450/binarysearch_tree.frag
@@ -149,7 +149,7 @@ void main() {
     treeIndex++;
     insert(treeIndex, 13);
 
-    vec2 z = (gl_FragCoord.yx / resolution);
+    vec2 z = (floor(gl_FragCoord.yx) / resolution);
     float x = makeFrame(z.x);
     float y = makeFrame(z.y);
 

--- a/shaders/src/main/glsl/samples/450/bubblesort_flag_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/450/bubblesort_flag_intfunctions.frag
@@ -27,7 +27,7 @@ uniform vec2 resolution;
 
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 void main()
 {
@@ -58,7 +58,7 @@ void main()
         }
         i++;
     } while(i < findMSB(msb9));
-    if(gl_FragCoord.x < resolution.x / 2.0)
+    if(floor(gl_FragCoord.x) < resolution.x / 2.0)
     {
         _GLF_color = vec4(data[findMSB(1)] / 10.0, data[findLSB(32)] / 10.0, data[findMSB(msb9)] / 10.0, 1.0);
     }

--- a/shaders/src/main/glsl/samples/450/colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/450/colorgrid_modulo.frag
@@ -40,8 +40,8 @@ void main()
     vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
     float ref = floor(resolution.x / 8.0);
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/450/colorgrid_modulo_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/450/colorgrid_modulo_intfunctions.frag
@@ -47,8 +47,8 @@ void main()
     vec4 c = vec4(bitfieldExtract(0, 0, 0), 0.0, 0.0, bitCount(msb8));
     float ref = floor(resolution.x / float(findLSB(msb8)));
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
     int i = bitfieldReverse(bitfieldExtract(0, 0, 0));
     do {

--- a/shaders/src/main/glsl/samples/450/householder_lattice.frag
+++ b/shaders/src/main/glsl/samples/450/householder_lattice.frag
@@ -28,7 +28,7 @@ void main()
 {
     // We need to modify A in place, so we have to copy the uniform
     mat4 matrix_a = mat4(matrix_a_uni);
-    vec4 matrix_b = gl_FragCoord.wxyz;
+    vec4 matrix_b = floor(gl_FragCoord.wxyz);
 
     vec4 matrix_u = vec4(0.0);
 

--- a/shaders/src/main/glsl/samples/450/mandelbrot_fixed_point.frag
+++ b/shaders/src/main/glsl/samples/450/mandelbrot_fixed_point.frag
@@ -63,7 +63,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/450/mandelbrot_zoom.frag
+++ b/shaders/src/main/glsl/samples/450/mandelbrot_zoom.frag
@@ -57,7 +57,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/450/mandelbrot_zoom_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/450/mandelbrot_zoom_intfunctions.frag
@@ -72,7 +72,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < findMSB(16); i++) {
     for (int j = 0; j < findLSB(16); j++) {
-      data[uaddCarry(uint(4*j), uint(i), uselessOutVariable)] = mand(gl_FragCoord.x + float(i - bitCount(1)), gl_FragCoord.y + float(j - bitCount(1)));
+      data[uaddCarry(uint(4*j), uint(i), uselessOutVariable)] = mand(floor(gl_FragCoord.x) + float(i - bitCount(1)), floor(gl_FragCoord.y) + float(j - bitCount(1)));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/450/matrices_many_loops.frag
+++ b/shaders/src/main/glsl/samples/450/matrices_many_loops.frag
@@ -87,8 +87,8 @@ void main()
   POPULATE_SUMS(m43, 4, 3, 7);
   POPULATE_SUMS(m44, 4, 4, 8);
 
-  int region_x = int(gl_FragCoord.x / (resolution.x / 3.0));
-  int region_y = int(gl_FragCoord.y / (resolution.x / 3.0));
+  int region_x = int(floor(gl_FragCoord.x) / (resolution.x / 3.0));
+  int region_y = int(floor(gl_FragCoord.y) / (resolution.x / 3.0));
   int overall_region = region_y * 3 + region_x;
 
   if (overall_region > 0 && overall_region < 9) {

--- a/shaders/src/main/glsl/samples/450/matrices_smart_loops.frag
+++ b/shaders/src/main/glsl/samples/450/matrices_smart_loops.frag
@@ -138,8 +138,8 @@ void main()
     }
   }
 
-  int region_x = int(gl_FragCoord.x / (resolution.x / 3.0));
-  int region_y = int(gl_FragCoord.y / (resolution.x / 3.0));
+  int region_x = int(floor(gl_FragCoord.x) / (resolution.x / 3.0));
+  int region_y = int(floor(gl_FragCoord.y) / (resolution.x / 3.0));
   int overall_region = region_y * 3 + region_x;
 
   if (overall_region > 0 && overall_region < 9) {

--- a/shaders/src/main/glsl/samples/450/mergesort_mosaic.frag
+++ b/shaders/src/main/glsl/samples/450/mergesort_mosaic.frag
@@ -119,13 +119,13 @@ void main() {
         vec3(0, -5, int(injectionSwitch.y)) * ldexp(0.2, 5),
         vec3(1, 8, int(injectionSwitch.y)) * ldexp(injectionSwitch.y, 0)
     );
-    vec3 vecCoor = roundEven(pos * vec3(gl_FragCoord.xx / resolution.yx, 1));
+    vec3 vecCoor = roundEven(pos * vec3(floor(gl_FragCoord.xx) / resolution.yx, 1));
     vec2 color;
 
     do {
         if (int(gl_FragCoord[1]) < 30) {
             color = fract(sin(vecCoor.yx - trunc(float(data[0]))));
-            color[0] = dFdy(gl_FragCoord.y);
+            color[0] = dFdy(floor(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 60) {
             color = fract(sin(vecCoor.yx - trunc(float(data[1]))));
@@ -133,17 +133,17 @@ void main() {
             break;
         } else if (int(gl_FragCoord[1]) < 90) {
             color = fract(sin(vecCoor.yx - trunc(float(data[2]))));
-            color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, gl_FragCoord.yy).x;
+            color.x += atanh(color.x) * cosh(injectionSwitch.y) * smoothstep(color, injectionSwitch, floor(gl_FragCoord.yy)).x;
             break;
         } else if (int(gl_FragCoord[1]) < 120) {
             color = fract(acosh(clamp(vecCoor.yx - trunc(float(data[3])), 1.0, 1000.0)));
-            color.x += (isnan(gl_FragCoord.x) ? log2(gl_FragCoord.x) : log2(gl_FragCoord.y));
+            color.x += (isnan(floor(gl_FragCoord.x)) ? log2(floor(gl_FragCoord.x)) : log2(floor(gl_FragCoord.y)));
             break;
         } else if (int(gl_FragCoord[1]) < 150) {
             discard;
         } else if (int(gl_FragCoord[1]) < 180) {
             color = fract(sin(vecCoor.yx - trunc(float(data[4]))));
-            color[1] += asinh(gl_FragCoord.y * ldexp(color.y, -i));
+            color[1] += asinh(floor(gl_FragCoord.y) * ldexp(color.y, -i));
             break;
         } else if (int(gl_FragCoord[1]) < 210) {
             color = fract(sin(vecCoor.yx - trunc(float(data[5]))));
@@ -151,7 +151,7 @@ void main() {
             break;
         } else if (int(gl_FragCoord[1]) < 240) {
             color = fract(asinh(vecCoor.yx - trunc(float(data[6]))));
-            color.y -= isnan(float(i)) ? tanh(gl_FragCoord.x): atanh(gl_FragCoord.y);
+            color.y -= isnan(float(i)) ? tanh(floor(gl_FragCoord.x)): atanh(floor(gl_FragCoord.y));
             break;
         } else if (int(gl_FragCoord[1]) < 270) {
             color = fract(sin(vecCoor.yx - trunc(float(data[7]))));

--- a/shaders/src/main/glsl/samples/450/prefix_sum_checkers.frag
+++ b/shaders/src/main/glsl/samples/450/prefix_sum_checkers.frag
@@ -46,7 +46,7 @@ vec2 pattern(in vec2 x) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / resolution.y;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.y;
   float A[50];
   for (int i = 0; i < 200; i++) {
     if (i >= int(resolution.x)) {

--- a/shaders/src/main/glsl/samples/450/quicksort_palette.frag
+++ b/shaders/src/main/glsl/samples/450/quicksort_palette.frag
@@ -97,7 +97,7 @@ void main() {
     }
     quicksort();
     vec2 grid = vec2(20, 20);
-    vec2 uv = gl_FragCoord.xy / resolution;
+    vec2 uv = floor(gl_FragCoord.xy) / resolution;
     vec3 color = palette(vec3(float(obj.numbers[4]) * 0.1), vec3(0.9, float(obj.numbers[8]) * 0.1, 0.8), trunc(vec3(injectionSwitch.y)), vec3(injectionSwitch.x, 0.3, 0.7));
     if (uv.x > (1.0 / 4.0)) {
         int count = int(injectionSwitch.x);
@@ -124,7 +124,7 @@ void main() {
         grid += vec2(count + obj.numbers[3], count + obj.numbers[3]);
     }
 
-    vec2 position = vec2(gl_FragCoord.x, resolution.x - gl_FragCoord.y);
+    vec2 position = vec2(floor(gl_FragCoord.x), resolution.x - floor(gl_FragCoord.y));
     position = floor(position / grid);
     _GLF_color = vec4(color, injectionSwitch.y) + vec4(!puzzlelize(position));
 

--- a/shaders/src/main/glsl/samples/450/selection_sort_struct.frag
+++ b/shaders/src/main/glsl/samples/450/selection_sort_struct.frag
@@ -60,11 +60,11 @@ void main() {
     obj.even_numbers[i] = smaller_number;
   }
 
-  vec2 uv = gl_FragCoord.xy/resolution.xy;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.xy;
   vec3 col =  tan(pow(uv.xxx, uv.yyy) +
   vec3(
-    obj.odd_numbers[int(floor(gl_FragCoord.x/1000.0))],
-    obj.even_numbers[int(floor(gl_FragCoord.y/1000.0))],
+    obj.odd_numbers[int(floor(floor(gl_FragCoord.x)/1000.0))],
+    obj.even_numbers[int(floor(floor(gl_FragCoord.y)/1000.0))],
     sinh(uv.x)
   ));
 

--- a/shaders/src/main/glsl/samples/450/squares.frag
+++ b/shaders/src/main/glsl/samples/450/squares.frag
@@ -98,7 +98,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/450/squares_intfunctions.frag
+++ b/shaders/src/main/glsl/samples/450/squares_intfunctions.frag
@@ -102,7 +102,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/450/stable_bifurcation.frag
+++ b/shaders/src/main/glsl/samples/450/stable_bifurcation.frag
@@ -61,7 +61,7 @@ to pick a color from the table of 16 colors.
 
 void main() {
   // pos is screen coordinates in 0..1 range
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // lin is screen coordinates in 0..9 range, integer steps;
   // this creates a grid pattern.
   ivec2 lin = ivec2(int(pos.x * 10.0), int(pos.y * 10.0));

--- a/shaders/src/main/glsl/samples/450/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/450/stable_bubblesort_flag.frag
@@ -47,7 +47,7 @@ are numerically stable.
 // vertically sort in one order, and for the other half the other.
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 
 void main()
@@ -86,7 +86,7 @@ void main()
     // Draw image based on the sorted values.
     // For half the screen horizontally use one order,
     // and for the other the inverse order of values.
-    if (gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
         {
             _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }

--- a/shaders/src/main/glsl/samples/450/stable_collatz.frag
+++ b/shaders/src/main/glsl/samples/450/stable_collatz.frag
@@ -80,7 +80,7 @@ int collatz(int v) {
 
 void main() {
   // lin is screen coordinates in 0..1
-  vec2 lin = gl_FragCoord.xy / resolution;
+  vec2 lin = floor(gl_FragCoord.xy) / resolution;
   // now lin is screen coordinates in 0..7 in integer steps
   // this creates a tile pattern of 8x8 pixel tiles
   lin = floor(lin * 8.0);

--- a/shaders/src/main/glsl/samples/450/stable_colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/450/stable_colorgrid_modulo.frag
@@ -74,8 +74,8 @@ void main()
     // Use of uniform avoids compiler optimizations.
     float thirty_two = round(resolution.x / 8.0);
 
-    c.x = compute_value(gl_FragCoord.x, thirty_two);
-    c.y = compute_value(gl_FragCoord.y, thirty_two);
+    c.x = compute_value(floor(gl_FragCoord.x), thirty_two);
+    c.y = compute_value(floor(gl_FragCoord.y), thirty_two);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/450/stable_logicops.frag
+++ b/shaders/src/main/glsl/samples/450/stable_logicops.frag
@@ -34,7 +34,7 @@ making this a stable shader.
 
 void main()
 {
-    vec2 coord = vec2(gl_FragCoord.xy) * (1.0 / 256.0);
+    vec2 coord = vec2(floor(gl_FragCoord.xy)) * (1.0 / 256.0);
     
     if (coord.x > 0.4)
     {

--- a/shaders/src/main/glsl/samples/450/stable_maze.frag
+++ b/shaders/src/main/glsl/samples/450/stable_maze.frag
@@ -49,7 +49,7 @@ int map[16 * 16];
 
 void main() {
   // pos is screen position in 0..1 range
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // ipos is screen position in 0..15 range, in integer steps.
   // This creates a tile pattern.
   ivec2 ipos = ivec2(int(pos.x * 16.0), int(pos.y * 16.0));

--- a/shaders/src/main/glsl/samples/450/stable_orbit.frag
+++ b/shaders/src/main/glsl/samples/450/stable_orbit.frag
@@ -69,7 +69,7 @@ ivec2 iter(ivec2 p) {
 
 void main() {
   // pos is screen coordinates in 0..1 range
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // ipos is screen coordinates in 0..7 range in integer steps.
   // This creates a tile pattern.
   ivec2 ipos = ivec2(int(pos.x * 8.0), int(pos.y * 8.0));

--- a/shaders/src/main/glsl/samples/450/stable_pillars.frag
+++ b/shaders/src/main/glsl/samples/450/stable_pillars.frag
@@ -82,7 +82,7 @@ vec4 trace(ivec2 pos) {
 
 void main() {
   // pos is screen coodrdinates in 0..1
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   // ipos is screen coordinates in 0..255 in integer steps.
   ivec2 ipos = ivec2(int(pos.x * 256.0), int(pos.y * 256.0));
 

--- a/shaders/src/main/glsl/samples/450/stable_quicksort.frag
+++ b/shaders/src/main/glsl/samples/450/stable_quicksort.frag
@@ -123,7 +123,7 @@ void main() {
     quicksort();
 
     // uv gets screen coordinates in 0..1 range
-    vec2 uv = gl_FragCoord.xy / resolution;
+    vec2 uv = floor(gl_FragCoord.xy) / resolution;
 
     // start color from an arbituary vector
     vec3 color = vec3(1.0, 2.0, 3.0);

--- a/shaders/src/main/glsl/samples/450/stable_rects.frag
+++ b/shaders/src/main/glsl/samples/450/stable_rects.frag
@@ -105,7 +105,7 @@ vec4 match(vec2 pos) {
 
 void main() {
   // Lin is screen position in 0..1 range
-  vec2 lin = gl_FragCoord.xy / resolution;
+  vec2 lin = floor(gl_FragCoord.xy) / resolution;
   // Lin is screen position in 0..31 range in integer steps.
   // This creates a tile pattern.
   lin = floor(lin * 32.0);

--- a/shaders/src/main/glsl/samples/450/stable_sampler_boxfilter.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_boxfilter.frag
@@ -44,7 +44,7 @@ const float weights[9] = float[9](
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     float uvstep = 1.0 / 256.0;
 
     vec4 res = vec4(0);

--- a/shaders/src/main/glsl/samples/450/stable_sampler_loop.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_loop.frag
@@ -42,7 +42,7 @@ uniform sampler2D tex;
 void main()
 {
     int i = 0;
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     vec4 texel = texture(tex, coord);
     while (texel.x + texel.y + texel.z > 1.0 && i < 16)
     {

--- a/shaders/src/main/glsl/samples/450/stable_sampler_minimal.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_minimal.frag
@@ -33,6 +33,6 @@ uniform sampler2D tex;
 
 void main()
 {
-    _GLF_color = texture(tex, gl_FragCoord.xy * (1.0 / 256.0));
+    _GLF_color = texture(tex, floor(gl_FragCoord.xy) * (1.0 / 256.0));
 }
 

--- a/shaders/src/main/glsl/samples/450/stable_sampler_mip.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_mip.frag
@@ -37,7 +37,7 @@ uniform sampler2D tex;
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     vec4 res = vec4(0.25);
     coord *= 2.0;
     int i = 0;

--- a/shaders/src/main/glsl/samples/450/stable_sampler_polar_simple.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_polar_simple.frag
@@ -92,7 +92,7 @@ vec2 polarize(vec2 coord)
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     coord = polarize(coord);
     coord = floor(coord * 256.0) / 256.0;
     _GLF_color = vec4(texture(tex, coord).xyz, 1.0);

--- a/shaders/src/main/glsl/samples/450/stable_sampler_polar_warp.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_polar_warp.frag
@@ -93,7 +93,7 @@ vec2 polarize(vec2 coord)
 
 void main()
 {
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
 
     vec2 coord1 = polarize(coord + vec2(20.0 / 256.0, -80.0 / 256.0));
     vec2 coord2 = polarize(coord + vec2(-60.0 / 256.0, 40.0 / 256.0));

--- a/shaders/src/main/glsl/samples/450/stable_sampler_reuse.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_reuse.frag
@@ -39,7 +39,7 @@ uniform sampler2D tex;
 
 void main()
 {
-    vec3 texel = texture(tex, gl_FragCoord.xy * (1.0 / 256.0)).xyz;
+    vec3 texel = texture(tex, floor(gl_FragCoord.xy) * (1.0 / 256.0)).xyz;
     vec2 reuse = (texel.xz + texel.yy) * 0.5 + vec2(0.25, 0.25);
     reuse = floor(reuse * 256.0) / 256.0;
     _GLF_color = texture(tex, reuse);

--- a/shaders/src/main/glsl/samples/450/stable_sampler_trace.frag
+++ b/shaders/src/main/glsl/samples/450/stable_sampler_trace.frag
@@ -42,7 +42,7 @@ void main()
     int i = 0;
     vec2 uvstep = vec2(1.0) * (1.0 / 256.0);
     float slope = 2.0 / 256.0;
-    vec2 coord = gl_FragCoord.xy * (1.0 / 256.0);
+    vec2 coord = floor(gl_FragCoord.xy) * (1.0 / 256.0);
     float refh = texture(tex, coord).y;
     coord -= uvstep;
     refh += slope;

--- a/shaders/src/main/glsl/samples/450/stable_triangle.frag
+++ b/shaders/src/main/glsl/samples/450/stable_triangle.frag
@@ -56,7 +56,7 @@ int pointInTriangle(vec2 p, vec2 a, vec2 b, vec2 c) {
 }
 
 void main() {
-  vec2 pos = gl_FragCoord.xy / resolution;
+  vec2 pos = floor(gl_FragCoord.xy) / resolution;
   if (pointInTriangle(pos, vec2(0.7, 0.3), vec2(0.5, 0.9), vec2(0.1, 0.4)) == 1) {
     _GLF_color = vec4(1.0, 0.0, 0.0, 1.0);
   }

--- a/shaders/src/main/glsl/samples/450/trigonometric_strip.frag
+++ b/shaders/src/main/glsl/samples/450/trigonometric_strip.frag
@@ -37,7 +37,7 @@ float compute_stripe(float v) {
 }
 
 void main() {
-  vec2 uv = gl_FragCoord.xy / resolution.x;
+  vec2 uv = floor(gl_FragCoord.xy) / resolution.x;
   vec3 col = vec3(0, 0, 0);
 
   bool c1 = uv.y < 0.25;

--- a/shaders/src/main/glsl/samples/webgl1/colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/webgl1/colorgrid_modulo.frag
@@ -39,8 +39,8 @@ void main()
     vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
     float ref = floor(resolution.x / 8.0);
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/webgl1/mandelbrot_zoom.frag
+++ b/shaders/src/main/glsl/samples/webgl1/mandelbrot_zoom.frag
@@ -56,7 +56,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/webgl1/squares.frag
+++ b/shaders/src/main/glsl/samples/webgl1/squares.frag
@@ -97,7 +97,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/webgl1/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/webgl1/stable_bubblesort_flag.frag
@@ -25,7 +25,7 @@ uniform vec2 resolution;
 
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 void main()
 {
@@ -63,7 +63,7 @@ void main()
                         }
                 }
         }
-    if(gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
         {
             gl_FragColor = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }

--- a/shaders/src/main/glsl/samples/webgl2/colorgrid_modulo.frag
+++ b/shaders/src/main/glsl/samples/webgl2/colorgrid_modulo.frag
@@ -41,8 +41,8 @@ void main()
     vec4 c = vec4(0.0, 0.0, 0.0, 1.0);
     float ref = floor(resolution.x / 8.0);
 
-    c.x = nb_mod(gl_FragCoord.x, ref);
-    c.y = nb_mod(gl_FragCoord.y, ref);
+    c.x = nb_mod(floor(gl_FragCoord.x), ref);
+    c.y = nb_mod(floor(gl_FragCoord.y), ref);
     c.z = c.x + c.y;
 
     for (int i = 0; i < 3; i++) {

--- a/shaders/src/main/glsl/samples/webgl2/mandelbrot_zoom.frag
+++ b/shaders/src/main/glsl/samples/webgl2/mandelbrot_zoom.frag
@@ -58,7 +58,7 @@ void main() {
   vec3 data[16];
   for (int i = 0; i < 4; i++) {
     for (int j = 0; j < 4; j++) {
-      data[4*j + i] = mand(gl_FragCoord.x + float(i - 1), gl_FragCoord.y + float(j - 1));
+      data[4*j + i] = mand(floor(gl_FragCoord.x) + float(i - 1), floor(gl_FragCoord.y) + float(j - 1));
     }
   }
   vec3 sum = vec3(0.0);

--- a/shaders/src/main/glsl/samples/webgl2/squares.frag
+++ b/shaders/src/main/glsl/samples/webgl2/squares.frag
@@ -99,7 +99,7 @@ vec3 computePoint(mat2 rotationMatrix)
     vec2 aspect;
     aspect = resolution.xy / min(resolution.x, resolution.y);
     vec2 position;
-    position = (gl_FragCoord.xy / resolution.xy) * aspect;
+    position = (floor(gl_FragCoord.xy) / resolution.xy) * aspect;
     vec2 center;
     center = vec2(0.5) * aspect;
     position *= rotationMatrix;

--- a/shaders/src/main/glsl/samples/webgl2/stable_bubblesort_flag.frag
+++ b/shaders/src/main/glsl/samples/webgl2/stable_bubblesort_flag.frag
@@ -27,7 +27,7 @@ uniform vec2 resolution;
 
 bool checkSwap(float a, float b)
 {
-    return gl_FragCoord.y < resolution.y / 2.0 ? a > b : a < b;
+    return floor(gl_FragCoord.y) < resolution.y / 2.0 ? a > b : a < b;
 }
 void main()
 {
@@ -65,7 +65,7 @@ void main()
                         }
                 }
         }
-    if(gl_FragCoord.x < resolution.x / 2.0)
+    if (floor(gl_FragCoord.x) < resolution.x / 2.0)
         {
             _GLF_color = vec4(data[0] / 10.0, data[5] / 10.0, data[9] / 10.0, 1.0);
         }


### PR DESCRIPTION
This change applies floor() to the uses of gl_FragCoord in order to
eliminate the potential ambiguity of having 0.5 in the source values.
This should improve the stability of the shaders in fuzzing.