### PR TITLE
Remove duplicate line from GeneratorUnitTest

### DIFF
--- a/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
+++ b/tester/src/test/java/com/graphicsfuzz/tester/GeneratorUnitTest.java
@@ -295,8 +295,6 @@ public class GeneratorUnitTest {
                                                List<String> exclusionList100,
                                                List<String> exclusionList300es)
       throws IOException, ParseTimeoutException, InterruptedException, GlslParserException {
-    testTransformationMultiVersions(Arrays.asList(transformation), probabilities,
-        suffix, exclusionList100, exclusionList300es);
     testTransformationMultiVersions(Collections.singletonList(transformation), probabilities,
         suffix, exclusionList100, exclusionList300es);
   }


### PR DESCRIPTION
This caused tests to be run twice.