### PR TITLE
gfauto: Update add_amber_tests_to_cts.py

### DIFF
--- a/gfauto/gfauto/add_amber_tests_to_cts.py
+++ b/gfauto/gfauto/add_amber_tests_to_cts.py
@@ -32,9 +32,7 @@ SHORT_DESCRIPTION_LINE_PREFIX = "# Short description: "
 
 MUST_PASS_PATHS = [
     os.path.join("android", "cts", "main", "vk-master", "graphicsfuzz.txt"),
-    os.path.join(
-        "android", "cts", "main", "vk-master-2021-03-01", "graphicsfuzz.txt"
-    ),
+    os.path.join("android", "cts", "main", "vk-master-2021-03-01", "graphicsfuzz.txt"),
     os.path.join(
         "external", "vulkancts", "mustpass", "main", "vk-default", "graphicsfuzz.txt"
     ),

--- a/gfauto/gfauto/add_amber_tests_to_cts.py
+++ b/gfauto/gfauto/add_amber_tests_to_cts.py
@@ -31,12 +31,12 @@ from typing import Pattern, TextIO, cast
 SHORT_DESCRIPTION_LINE_PREFIX = "# Short description: "
 
 MUST_PASS_PATHS = [
-    os.path.join("android", "cts", "master", "vk-master", "graphicsfuzz.txt"),
+    os.path.join("android", "cts", "main", "vk-master", "graphicsfuzz.txt"),
     os.path.join(
-        "android", "cts", "master", "vk-master-2021-03-01", "graphicsfuzz.txt"
+        "android", "cts", "main", "vk-master-2021-03-01", "graphicsfuzz.txt"
     ),
     os.path.join(
-        "external", "vulkancts", "mustpass", "master", "vk-default", "graphicsfuzz.txt"
+        "external", "vulkancts", "mustpass", "main", "vk-default", "graphicsfuzz.txt"
     ),
 ]
 


### PR DESCRIPTION
The directories containing mustpass files in CTS were renamed from
"master" to "main". This commit changes add_amber_tests_to_cts.py
to look up the mustpass files in the proper directories.